### PR TITLE
Experimental: Add exclusive lists feature

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -42,6 +42,6 @@ class Api::V1::ListsController < Api::BaseController
   end
 
   def list_params
-    params.permit(:title, :replies_policy)
+    params.permit(:title, :replies_policy, :is_exclusive)
   end
 end

--- a/app/javascript/flavours/glitch/actions/lists.js
+++ b/app/javascript/flavours/glitch/actions/lists.js
@@ -160,7 +160,7 @@ export const createListFail = error => ({
 export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: !!isExclusive }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/flavours/glitch/actions/lists.js
+++ b/app/javascript/flavours/glitch/actions/lists.js
@@ -11,6 +11,7 @@ export const LISTS_FETCH_SUCCESS = 'LISTS_FETCH_SUCCESS';
 export const LISTS_FETCH_FAIL    = 'LISTS_FETCH_FAIL';
 
 export const LIST_EDITOR_TITLE_CHANGE = 'LIST_EDITOR_TITLE_CHANGE';
+export const LIST_EDITOR_IS_EXCLUSIVE_CHANGE = 'LIST_EDITOR_IS_EXCLUSIVE_CHANGE';
 export const LIST_EDITOR_RESET        = 'LIST_EDITOR_RESET';
 export const LIST_EDITOR_SETUP        = 'LIST_EDITOR_SETUP';
 
@@ -102,11 +103,12 @@ export const fetchListsFail = error => ({
 export const submitListEditor = shouldReset => (dispatch, getState) => {
   const listId = getState().getIn(['listEditor', 'listId']);
   const title  = getState().getIn(['listEditor', 'title']);
+  const isExclusive = getState().getIn(['listEditor', 'isExclusive']);
 
   if (listId === null) {
     dispatch(createList(title, shouldReset));
   } else {
-    dispatch(updateList(listId, title, shouldReset));
+    dispatch(updateList(listId, title, shouldReset, isExclusive));
   }
 };
 
@@ -121,6 +123,11 @@ export const setupListEditor = listId => (dispatch, getState) => {
 
 export const changeListEditorTitle = value => ({
   type: LIST_EDITOR_TITLE_CHANGE,
+  value,
+});
+
+export const changeListEditorIsExclusive = value => ({
+  type: LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   value,
 });
 
@@ -150,10 +157,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset, replies_policy) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/flavours/glitch/features/list_editor/components/edit_list_form.js
+++ b/app/javascript/flavours/glitch/features/list_editor/components/edit_list_form.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { changeListEditorTitle, submitListEditor } from 'flavours/glitch/actions/lists';
+import { changeListEditorTitle, changeListEditorIsExclusive, submitListEditor } from 'flavours/glitch/actions/lists';
 import IconButton from 'flavours/glitch/components/icon_button';
 import { defineMessages, injectIntl } from 'react-intl';
+import Toggle from 'react-toggle';
 
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },
+  exclusive: { id: 'lists.is-exclusive', defaultMessage: 'Exclusive?' },
 });
 
 const mapStateToProps = state => ({
@@ -17,6 +19,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   onChange: value => dispatch(changeListEditorTitle(value)),
   onSubmit: () => dispatch(submitListEditor(false)),
+  onToggle: value => dispatch(changeListEditorIsExclusive(value)),
 });
 
 export default @connect(mapStateToProps, mapDispatchToProps)
@@ -26,6 +29,7 @@ class ListForm extends React.PureComponent {
   static propTypes = {
     value: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
+    isExclusive: PropTypes.bool,
     intl: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
@@ -44,8 +48,12 @@ class ListForm extends React.PureComponent {
     this.props.onSubmit();
   }
 
+  handleToggle = e => {
+    this.props.onToggle(e.target.checked);
+  }
+
   render () {
-    const { value, disabled, intl } = this.props;
+    const { value, disabled, intl, isExclusive } = this.props;
 
     const title = intl.formatMessage(messages.title);
 
@@ -56,6 +64,11 @@ class ListForm extends React.PureComponent {
           value={value}
           onChange={this.handleChange}
         />
+
+        <label htmlFor='is-exclusive-checkbox'>
+          <Toggle className='is-exclusive-checkbox' defaultChecked={isExclusive} onChange={this.handleToggle} />
+          {intl.formatMessage(messages.exclusive)}
+        </label>
 
         <IconButton
           disabled={disabled}

--- a/app/javascript/flavours/glitch/features/list_editor/index.js
+++ b/app/javascript/flavours/glitch/features/list_editor/index.js
@@ -30,6 +30,7 @@ class ListEditor extends ImmutablePureComponent {
     listId: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
+    isExclusive: PropTypes.bool.isRequired,
     onInitialize: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
     onReset: PropTypes.func.isRequired,
@@ -53,7 +54,7 @@ class ListEditor extends ImmutablePureComponent {
 
     return (
       <div className='modal-root__modal list-editor'>
-        <EditListForm />
+        <EditListForm isExclusive={this.props.isExclusive} />
 
         <SearchContainer />
 

--- a/app/javascript/flavours/glitch/features/list_timeline/index.js
+++ b/app/javascript/flavours/glitch/features/list_timeline/index.js
@@ -113,7 +113,7 @@ class ListTimeline extends React.PureComponent {
   }
 
   handleEditClick = () => {
-    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id }));
+    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id, isExclusive: this.props.list.get('is_exclusive') }));
   }
 
   handleDeleteClick = () => {

--- a/app/javascript/flavours/glitch/features/list_timeline/index.js
+++ b/app/javascript/flavours/glitch/features/list_timeline/index.js
@@ -138,7 +138,7 @@ class ListTimeline extends React.PureComponent {
   handleRepliesPolicyChange = ({ target }) => {
     const { dispatch, list } = this.props;
     const { id } = this.props.params;
-    this.props.dispatch(updateList(id, undefined, false, target.value));
+    this.props.dispatch(updateList(id, undefined, false, undefined, target.value));
   }
 
   render () {

--- a/app/javascript/flavours/glitch/reducers/list_editor.js
+++ b/app/javascript/flavours/glitch/reducers/list_editor.js
@@ -9,6 +9,7 @@ import {
   LIST_EDITOR_RESET,
   LIST_EDITOR_SETUP,
   LIST_EDITOR_TITLE_CHANGE,
+  LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   LIST_ACCOUNTS_FETCH_REQUEST,
   LIST_ACCOUNTS_FETCH_SUCCESS,
   LIST_ACCOUNTS_FETCH_FAIL,
@@ -21,6 +22,7 @@ import {
 
 const initialState = ImmutableMap({
   listId: null,
+  isExclusive: false,
   isSubmitting: false,
   isChanged: false,
   title: '',
@@ -45,11 +47,17 @@ export default function listEditorReducer(state = initialState, action) {
     return state.withMutations(map => {
       map.set('listId', action.list.get('id'));
       map.set('title', action.list.get('title'));
+      map.set('isExclusive', action.list.get('is_exclusive'));
       map.set('isSubmitting', false);
     });
   case LIST_EDITOR_TITLE_CHANGE:
     return state.withMutations(map => {
       map.set('title', action.value);
+      map.set('isChanged', true);
+    });
+  case LIST_EDITOR_IS_EXCLUSIVE_CHANGE:
+    return state.withMutations(map => {
+      map.set('isExclusive', action.value);
       map.set('isChanged', true);
     });
   case LIST_CREATE_REQUEST:

--- a/app/javascript/flavours/glitch/styles/components/index.scss
+++ b/app/javascript/flavours/glitch/styles/components/index.scss
@@ -1017,6 +1017,15 @@
   border-color: $ui-highlight-color;
 }
 
+label[for="is-exclusive-checkbox"] {
+  margin-left: 20px;
+}
+
+.is-exclusive-checkbox {
+  transform: scale(0.7);
+  transform-origin: bottom;
+}
+
 .getting-started__wrapper,
 .getting_started,
 .flex-spacer {

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -160,7 +160,7 @@ export const createListFail = error => ({
 export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: !!isExclusive }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -11,6 +11,7 @@ export const LISTS_FETCH_SUCCESS = 'LISTS_FETCH_SUCCESS';
 export const LISTS_FETCH_FAIL    = 'LISTS_FETCH_FAIL';
 
 export const LIST_EDITOR_TITLE_CHANGE = 'LIST_EDITOR_TITLE_CHANGE';
+export const LIST_EDITOR_IS_EXCLUSIVE_CHANGE = 'LIST_EDITOR_IS_EXCLUSIVE_CHANGE';
 export const LIST_EDITOR_RESET        = 'LIST_EDITOR_RESET';
 export const LIST_EDITOR_SETUP        = 'LIST_EDITOR_SETUP';
 
@@ -102,11 +103,12 @@ export const fetchListsFail = error => ({
 export const submitListEditor = shouldReset => (dispatch, getState) => {
   const listId = getState().getIn(['listEditor', 'listId']);
   const title  = getState().getIn(['listEditor', 'title']);
+  const isExclusive = getState().getIn(['listEditor', 'isExclusive']);
 
   if (listId === null) {
     dispatch(createList(title, shouldReset));
   } else {
-    dispatch(updateList(listId, title, shouldReset));
+    dispatch(updateList(listId, title, shouldReset, isExclusive));
   }
 };
 
@@ -121,6 +123,11 @@ export const setupListEditor = listId => (dispatch, getState) => {
 
 export const changeListEditorTitle = value => ({
   type: LIST_EDITOR_TITLE_CHANGE,
+  value,
+});
+
+export const changeListEditorIsExclusive = value => ({
+  type: LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   value,
 });
 
@@ -150,10 +157,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset, replies_policy) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/mastodon/features/list_editor/components/edit_list_form.js
+++ b/app/javascript/mastodon/features/list_editor/components/edit_list_form.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { changeListEditorTitle, submitListEditor } from '../../../actions/lists';
+import { changeListEditorTitle, changeListEditorIsExclusive, submitListEditor } from '../../../actions/lists';
 import IconButton from '../../../components/icon_button';
 import { defineMessages, injectIntl } from 'react-intl';
+import Toggle from 'react-toggle';
 
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },
+  exclusive: { id: 'lists.is-exclusive', defaultMessage: 'Exclusive?' },
 });
 
 const mapStateToProps = state => ({
@@ -17,6 +19,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   onChange: value => dispatch(changeListEditorTitle(value)),
   onSubmit: () => dispatch(submitListEditor(false)),
+  onToggle: value => dispatch(changeListEditorIsExclusive(value)),
 });
 
 export default @connect(mapStateToProps, mapDispatchToProps)
@@ -26,6 +29,7 @@ class ListForm extends React.PureComponent {
   static propTypes = {
     value: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
+    isExclusive: PropTypes.bool,
     intl: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
@@ -44,8 +48,12 @@ class ListForm extends React.PureComponent {
     this.props.onSubmit();
   }
 
+  handleToggle = e => {
+    this.props.onToggle(e.target.checked);
+  }
+
   render () {
-    const { value, disabled, intl } = this.props;
+    const { value, disabled, intl, isExclusive } = this.props;
 
     const title = intl.formatMessage(messages.title);
 
@@ -56,6 +64,11 @@ class ListForm extends React.PureComponent {
           value={value}
           onChange={this.handleChange}
         />
+
+        <label htmlFor='is-exclusive-checkbox'>
+          <Toggle className='is-exclusive-checkbox' defaultChecked={isExclusive} onChange={this.handleToggle} />
+          {intl.formatMessage(messages.exclusive)}
+        </label>
 
         <IconButton
           disabled={disabled}

--- a/app/javascript/mastodon/features/list_editor/index.js
+++ b/app/javascript/mastodon/features/list_editor/index.js
@@ -30,6 +30,7 @@ class ListEditor extends ImmutablePureComponent {
     listId: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
+    isExclusive: PropTypes.bool.isRequired,
     onInitialize: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
     onReset: PropTypes.func.isRequired,
@@ -53,7 +54,7 @@ class ListEditor extends ImmutablePureComponent {
 
     return (
       <div className='modal-root__modal list-editor'>
-        <EditListForm />
+        <EditListForm isExclusive={this.props.isExclusive} />
 
         <Search />
 

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -113,7 +113,7 @@ class ListTimeline extends React.PureComponent {
   }
 
   handleEditClick = () => {
-    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id }));
+    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id, isExclusive: this.props.list.get('is_exclusive') }));
   }
 
   handleDeleteClick = () => {

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -138,7 +138,7 @@ class ListTimeline extends React.PureComponent {
   handleRepliesPolicyChange = ({ target }) => {
     const { dispatch } = this.props;
     const { id } = this.props.params;
-    dispatch(updateList(id, undefined, false, target.value));
+    dispatch(updateList(id, undefined, false, undefined, target.value));
   }
 
   render () {

--- a/app/javascript/mastodon/reducers/list_editor.js
+++ b/app/javascript/mastodon/reducers/list_editor.js
@@ -9,6 +9,7 @@ import {
   LIST_EDITOR_RESET,
   LIST_EDITOR_SETUP,
   LIST_EDITOR_TITLE_CHANGE,
+  LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   LIST_ACCOUNTS_FETCH_REQUEST,
   LIST_ACCOUNTS_FETCH_SUCCESS,
   LIST_ACCOUNTS_FETCH_FAIL,
@@ -21,6 +22,7 @@ import {
 
 const initialState = ImmutableMap({
   listId: null,
+  isExclusive: false,
   isSubmitting: false,
   isChanged: false,
   title: '',
@@ -45,11 +47,17 @@ export default function listEditorReducer(state = initialState, action) {
     return state.withMutations(map => {
       map.set('listId', action.list.get('id'));
       map.set('title', action.list.get('title'));
+      map.set('isExclusive', action.list.get('is_exclusive'));
       map.set('isSubmitting', false);
     });
   case LIST_EDITOR_TITLE_CHANGE:
     return state.withMutations(map => {
       map.set('title', action.value);
+      map.set('isChanged', true);
+    });
+  case LIST_EDITOR_IS_EXCLUSIVE_CHANGE:
+    return state.withMutations(map => {
+      map.set('isExclusive', action.value);
       map.set('isChanged', true);
     });
   case LIST_CREATE_REQUEST:

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3040,6 +3040,15 @@ $ui-header-height: 55px;
   border-color: $ui-highlight-color;
 }
 
+label[for="is-exclusive-checkbox"] {
+  margin-left: 20px;
+}
+
+.is-exclusive-checkbox {
+  transform: scale(0.7);
+  transform-origin: bottom;
+}
+
 .column-link {
   background: lighten($ui-base-color, 8%);
   color: $primary-text-color;

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -43,6 +43,7 @@ class FeedManager
       filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]))
     when :list
       filter_from_list?(status, receiver) || filter_from_home?(status, receiver.account_id, build_crutches(receiver.account_id, [status]))
+      filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]), :list)
     when :mentions
       filter_from_mentions?(status, receiver.id)
     when :direct
@@ -399,11 +400,19 @@ class FeedManager
   # @param [Status] status
   # @param [Integer] receiver_id
   # @param [Hash] crutches
+  # @param [Symbol] timeline_type
   # @return [Boolean]
-  def filter_from_home?(status, receiver_id, crutches)
+  def filter_from_home?(status, receiver_id, crutches, timeline_type=:home)
     return false if receiver_id == status.account_id
     return true  if status.reply? && (status.in_reply_to_id.nil? || status.in_reply_to_account_id.nil?)
     return true  if crutches[:languages][status.account_id].present? && status.language.present? && !crutches[:languages][status.account_id].include?(status.language)
+    # exclusive list feature
+    unless timeline_type == :list
+      # find all exclusive lists
+      lists = List.where(account: Account.find(receiver_id), is_exclusive: true)
+      # is account on an exclusive list, filter from home
+      return true if ListAccount.where(list: lists, account_id: status.account_id).exists?
+    end
 
     check_for_blocks = crutches[:active_mentions][status.id] || []
     check_for_blocks.concat([status.account_id])

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -9,6 +9,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  replies_policy :integer          default("list"), not null
+#  is_exclusive   :boolean          default(FALSE)
 #
 
 class List < ApplicationRecord

--- a/app/serializers/rest/list_serializer.rb
+++ b/app/serializers/rest/list_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ListSerializer < ActiveModel::Serializer
-  attributes :id, :title, :replies_policy
+  attributes :id, :title, :replies_policy, :is_exclusive
 
   def id
     object.id.to_s

--- a/db/migrate/20221125104951_add_is_exclusive_to_list.rb
+++ b/db/migrate/20221125104951_add_is_exclusive_to_list.rb
@@ -1,0 +1,6 @@
+class AddIsExclusiveToList < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lists, :is_exclusive, :boolean
+    change_column_default :lists, :is_exclusive, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_133904) do
+ActiveRecord::Schema.define(version: 2022_11_25_104951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -540,6 +540,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "replies_policy", default: 0, null: false
+    t.boolean "is_exclusive", default: false
     t.index ["account_id"], name: "index_lists_on_account_id"
   end
 


### PR DESCRIPTION
Port of hometown [exclusive list feature](https://github.com/hometown-fork/hometown/wiki/Exclusive-lists)
TL;DR: Toots from accounts on exclusive lists won't show up on home tl.
You can change any list to an exclusive list by enabling the "Exclusive?" toggle in the edit list setting.

Based on 
- [Adding exlusive lists feature](https://github.com/hometown-fork/hometown/commit/bfc0fbab2c94dc134715f555edf793991da172a2)
- [Fix for exclusive lists not working](https://github.com/hometown-fork/hometown/commit/b2270fd37)
- [Fix isExclusive being reset when renaming list](https://github.com/hometown-fork/hometown/commit/de227c8b1a4c37ec03b1def064a5cc454cb867c7)
- [Support changing list replies policies from web UI](https://github.com/hometown-fork/hometown/commit/4f7fa085cb3ae373e3e30139f32088c461efb728)

Split into several commits for easier cherry-picking.
If you run only vanilla Mastodon, you need backend and mastodon commits.
If you use glitch, you additionally need the glitch specific commits.

Important:
This feature updates the database and needs db migration.