### PR TITLE
Add account request text filer

### DIFF
--- a/app/controllers/admin/registration_filters_controller.rb
+++ b/app/controllers/admin/registration_filters_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Admin
+  class RegistrationFiltersController < BaseController
+    before_action :set_registration_filter, only: [:edit, :update, :destroy]
+
+    def index
+      authorize :registration_filter, :index?
+      @registration_filters = RegistrationFilter.order(id: :desc).page(params[:page])
+    end
+
+    def new
+      authorize :registration_filter, :create?
+      @registration_filter = RegistrationFilter.new
+    end
+
+    def create
+      authorize :registration_filter, :create?
+
+      @registration_filter = RegistrationFilter.new(resource_params)
+
+      if @registration_filter.save
+        log_action :create, @registration_filter
+
+        redirect_to admin_registration_filters_path, notice: I18n.t('admin.registration_filters.created_msg')
+      else
+        render :new
+      end
+    end
+
+    def edit
+      authorize @registration_filter, :update?
+    end
+
+    def update
+      authorize @registration_filter, :update?
+      if @registration_filter.update(resource_params)
+        log_action :update, @registration_filter
+
+        redirect_to admin_registration_filters_path, notice: I18n.t('admin.registration_filters.updated_msg')
+      else
+        render action: :edit
+      end
+    end
+
+    def destroy
+      authorize @registration_filter, :destroy?
+      @registration_filter.destroy!
+      log_action :destroy, @registration_filter
+      redirect_to admin_registration_filters_path, notice: I18n.t('admin.registration_filters.destroyed_msg')
+    end
+
+    private
+
+    def set_registration_filter
+      @registration_filter = RegistrationFilter.find(params[:id])
+    end
+
+    def resource_params
+      params.require(:registration_filter).permit(:phrase, :type, :whole_word)
+    end
+  end
+end

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -33,6 +33,8 @@ module Admin::ActionLogsHelper
       else
         I18n.t('admin.action_logs.deleted_account')
       end
+    when 'RegistrationFilter'
+      link_to log.human_identifier, admin_registration_filters_path(log.target_id)
     end
   end
 end

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -26,6 +26,7 @@ class Admin::ActionLogFilter
     create_unavailable_domain: { target_type: 'UnavailableDomain', action: 'create' }.freeze,
     create_user_role: { target_type: 'UserRole', action: 'create' }.freeze,
     create_canonical_email_block: { target_type: 'CanonicalEmailBlock', action: 'create' }.freeze,
+    create_registration_filter: { target_type: 'RegistrationFilter', action: 'create' }.freeze,
     demote_user: { target_type: 'User', action: 'demote' }.freeze,
     destroy_announcement: { target_type: 'Announcement', action: 'destroy' }.freeze,
     destroy_custom_emoji: { target_type: 'CustomEmoji', action: 'destroy' }.freeze,
@@ -35,6 +36,7 @@ class Admin::ActionLogFilter
     destroy_email_domain_block: { target_type: 'EmailDomainBlock', action: 'destroy' }.freeze,
     destroy_instance: { target_type: 'Instance', action: 'destroy' }.freeze,
     destroy_unavailable_domain: { target_type: 'UnavailableDomain', action: 'destroy' }.freeze,
+    destroy_registration_filter: { target_type: 'RegistrationFilter', action: 'destroy' }.freeze,
     destroy_status: { target_type: 'Status', action: 'destroy' }.freeze,
     destroy_user_role: { target_type: 'UserRole', action: 'destroy' }.freeze,
     destroy_canonical_email_block: { target_type: 'CanonicalEmailBlock', action: 'destroy' }.freeze,
@@ -63,6 +65,7 @@ class Admin::ActionLogFilter
     update_user_role: { target_type: 'UserRole', action: 'update' }.freeze,
     update_ip_block: { target_type: 'IpBlock', action: 'update' }.freeze,
     unblock_email_account: { target_type: 'Account', action: 'unblock_email' }.freeze,
+    update_registration_filter: { target_type: 'RegistrationFilter', action: 'update' }.freeze,
   }.freeze
 
   attr_reader :params

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -47,6 +47,7 @@ class Form::AdminSettings
     media_cache_retention_period
     content_cache_retention_period
     backups_retention_period
+    invite_text_filter
   ).freeze
 
   BOOLEAN_KEYS = %i(

--- a/app/models/registration_filter.rb
+++ b/app/models/registration_filter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: registration_filters
+#
+#  id         :bigint(8)        not null, primary key
+#  phrase     :text             default(""), not null
+#  type       :integer          default("text"), not null
+#  whole_word :boolean          default(TRUE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class RegistrationFilter < ApplicationRecord
+  self.inheritance_column = nil
+
+  enum type: { text: 0, regexp: 1 }, _suffix: :type
+
+  validates :phrase, presence: true
+  validates :phrase, regex: true, if: :regexp_type?
+
+  def to_log_human_identifier
+    "#{phrase} (#{I18n.t("admin.registration_filters.types.#{type}")})"
+  end
+end

--- a/app/models/user_invite_request.rb
+++ b/app/models/user_invite_request.rb
@@ -14,4 +14,5 @@
 class UserInviteRequest < ApplicationRecord
   belongs_to :user, inverse_of: :invite_request
   validates :text, presence: true, length: { maximum: 420 }
+  validates_with InviteRequestValidator
 end

--- a/app/policies/registration_filter_policy.rb
+++ b/app/policies/registration_filter_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RegistrationFilterPolicy < ApplicationPolicy
+  def index?
+    role.can?(:manage_settings)
+  end
+
+  def create?
+    role.can?(:manage_settings)
+  end
+
+  def destroy?
+    role.can?(:manage_settings)
+  end
+
+  def update?
+    role.can?(:manage_settings)
+  end
+end

--- a/app/validators/invite_request_validator.rb
+++ b/app/validators/invite_request_validator.rb
@@ -8,8 +8,23 @@ class InviteRequestValidator < ActiveModel::Validator
   private
 
   def invalid_text?(invite_request)
-    return if Setting.invite_text_filter.blank?
+    filters = RegistrationFilter.all.to_a
+    filters.map! do |filter|
+      if filter.regexp_type?
+        /#{filter.phrase}/i
+      elsif filter.whole_word
+        sb = /\A[[:word:]]/.match?(filter.phrase) ? '\b' : ''
+        eb = /[[:word:]]\z/.match?(filter.phrase) ? '\b' : ''
 
-    invite_request.text =~ Regexp.new(Setting.invite_text_filter, Regexp::IGNORECASE)
+        /(?mix:#{sb}#{Regexp.escape(filter.phrase)}#{eb})/
+      else
+        /#{Regexp.escape(filter.phrase)}/i
+      end
+    end
+
+    return false if filters.empty?
+
+    combined_regex = filters.reduce { |memo, obj| Regexp.union(memo, obj) }
+    combined_regex.match?(invite_request.text)
   end
 end

--- a/app/validators/invite_request_validator.rb
+++ b/app/validators/invite_request_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class InviteRequestValidator < ActiveModel::Validator
+  def validate(invite_request)
+    invite_request.errors.add(:text, I18n.t('users.invalid_invite_request_text')) if invalid_text?(invite_request)
+  end
+
+  private
+
+  def invalid_text?(invite_request)
+    return if Setting.invite_text_filter.blank?
+
+    invite_request.text =~ Regexp.new(Setting.invite_text_filter, Regexp::IGNORECASE)
+  end
+end

--- a/app/validators/regex_validator.rb
+++ b/app/validators/regex_validator.rb
@@ -6,6 +6,6 @@ class RegexValidator < ActiveModel::EachValidator
 
     _ = Regexp.new(value)
   rescue RegexpError => e
-    record.errors.add(attribute, I18n.t('regex_validator.invalid_regexp', error: e.to_s)) unless errors.empty?
+    record.errors.add(attribute, I18n.t('regex_validator.invalid_regexp', error: e.to_s))
   end
 end

--- a/app/validators/regex_validator.rb
+++ b/app/validators/regex_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RegexValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    _ = Regexp.new(value)
+  rescue RegexpError => e
+    record.errors.add(attribute, I18n.t('regex_validator.invalid_regexp', error: e.to_s)) unless errors.empty?
+  end
+end

--- a/app/views/admin/registration_filters/_fields.html.haml
+++ b/app/views/admin/registration_filters/_fields.html.haml
@@ -1,0 +1,8 @@
+.fields-group
+  = f.input :phrase, as: :string, wrapper: :with_block_label, label: t('admin.registration_filters.phrase'), hint: t('admin.registration_filters.phrase_hint')
+
+.fields-group
+  = f.input :type, as: :radio_buttons, collection: %i(text regexp), label: t('admin.registration_filters.type.title'), label_method: ->(type) { safe_join([t("admin.registration_filters.types.#{type}"), content_tag(:span, I18n.t("admin.registration_filters.types.#{type}_hint"), class: 'hint')]) }
+
+.fields-group
+  = f.input :whole_word, wrapper: :with_label

--- a/app/views/admin/registration_filters/_registration_filter.html.haml
+++ b/app/views/admin/registration_filters/_registration_filter.html.haml
@@ -1,0 +1,10 @@
+%tr
+  %td
+    %samp= registration_filter.phrase
+  %td
+    = t("admin.registration_filters.types.#{registration_filter.type}")
+  %td
+    - if can?(:update, registration_filter)
+      = table_link_to 'pencil', t('filters.edit.title'), edit_admin_registration_filter_path(registration_filter)
+    - if can?(:update, registration_filter)
+      = table_link_to 'trash', t('admin.registration_filters.delete'), admin_registration_filter_path(registration_filter), method: :delete

--- a/app/views/admin/registration_filters/edit.html.haml
+++ b/app/views/admin/registration_filters/edit.html.haml
@@ -1,0 +1,10 @@
+- content_for :page_title do
+  = t('admin.registration_filters.edit.title')
+
+= simple_form_for @registration_filter, url: admin_registration_filter_path(@registration_filter), method: :put do |f|
+  = render 'shared/error_messages', object: @registration_filter
+
+  = render 'fields', f: f
+
+  .actions
+    = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/registration_filters/index.html.haml
+++ b/app/views/admin/registration_filters/index.html.haml
@@ -1,0 +1,23 @@
+- content_for :page_title do
+  = t('admin.registration_filters.title')
+
+- if can?(:create, :registration_filter)
+  - content_for :heading_actions do
+    = link_to t('admin.registration_filters.add_new'), new_admin_registration_filter_path, class: 'button'
+
+%p= t('admin.registration_filters.description_html')
+
+- if @registration_filters.empty?
+  %div.muted-hint.center-text=t 'admin.registration_filters.empty'
+- else
+  .table-wrapper
+    %table.table
+      %thead
+        %tr
+          %th= t('admin.registration_filters.text')
+          %th= t('admin.registration_filters.type.title')
+          %th
+      %tbody
+        = render partial: 'registration_filter', collection: @registration_filters
+
+= paginate @registration_filters

--- a/app/views/admin/registration_filters/new.html.haml
+++ b/app/views/admin/registration_filters/new.html.haml
@@ -1,0 +1,10 @@
+- content_for :page_title do
+  = t('admin.registration_filters.new.title')
+
+= simple_form_for @registration_filter, url: admin_registration_filters_path do |f|
+  = render 'shared/error_messages', object: @registration_filter
+
+  = render 'fields', f: f
+
+  .actions
+    = f.button :button, t('.create'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,7 @@ en:
         create_domain_block: Create Domain Block
         create_email_domain_block: Create E-mail Domain Block
         create_ip_block: Create IP rule
+        create_registration_filter: Create Registration Text Filter
         create_unavailable_domain: Create Unavailable Domain
         create_user_role: Create Role
         demote_user: Demote User
@@ -191,6 +192,7 @@ en:
         destroy_email_domain_block: Delete E-mail Domain Block
         destroy_instance: Purge Domain
         destroy_ip_block: Delete IP rule
+        destroy_registration_filter: Destroy Registration Text Filter
         destroy_status: Delete Post
         destroy_unavailable_domain: Delete Unavailable Domain
         destroy_user_role: Destroy Role
@@ -222,6 +224,7 @@ en:
         update_custom_emoji: Update Custom Emoji
         update_domain_block: Update Domain Block
         update_ip_block: Update IP rule
+        update_registration_filter: Update Registration Text Filter
         update_status: Update Post
         update_user_role: Update Role
       actions:
@@ -239,6 +242,7 @@ en:
         create_domain_block_html: "%{name} blocked domain %{target}"
         create_email_domain_block_html: "%{name} blocked e-mail domain %{target}"
         create_ip_block_html: "%{name} created rule for IP %{target}"
+        create_registration_filter_html: "%{name} blocked registrations with request text matching %{target}"
         create_unavailable_domain_html: "%{name} stopped delivery to domain %{target}"
         create_user_role_html: "%{name} created %{target} role"
         demote_user_html: "%{name} demoted user %{target}"
@@ -250,6 +254,7 @@ en:
         destroy_email_domain_block_html: "%{name} unblocked e-mail domain %{target}"
         destroy_instance_html: "%{name} purged domain %{target}"
         destroy_ip_block_html: "%{name} deleted rule for IP %{target}"
+        destroy_registration_filter_html: "%{name} unblocked registrations with request text matching %{target}"
         destroy_status_html: "%{name} removed post by %{target}"
         destroy_unavailable_domain_html: "%{name} resumed delivery to domain %{target}"
         destroy_user_role_html: "%{name} deleted %{target} role"
@@ -281,6 +286,7 @@ en:
         update_custom_emoji_html: "%{name} updated emoji %{target}"
         update_domain_block_html: "%{name} updated domain block for %{target}"
         update_ip_block_html: "%{name} changed rule for IP %{target}"
+        update_registration_filter_html: "%{name} updated registration filter blocking request text matching %{target}"
         update_status_html: "%{name} updated post by %{target}"
         update_user_role_html: "%{name} changed %{target} role"
       deleted_account: deleted account
@@ -540,6 +546,29 @@ en:
         title: Create new IP rule
       no_ip_block_selected: No IP rules were changed as none were selected
       title: IP rules
+    registration_filters:
+      add_new: Add new filter
+      created_msg: Registration text filter successfully created!
+      delete: Delete
+      description_html: Registration text filters allow you to automatically reject new user registrations based on their invite request text, that is their response to the “Why do you want to join?” prompt. This can be used to cut down on registration spam.
+      destroyed_msg: Registration text filter successfully destroyed!
+      edit:
+        title: Edit registration text filter
+      empty: No registration text filter found.
+      new:
+        create: Create registration text filter
+        title: New registration text filter
+      phrase: Keyword, phrase or regular expression
+      phrase_hint: Forbid registration of new users whose answer to the “Why do you want to join?” prompt contains text that matches this keyword, phrase or regular expression.
+      title: Registration text filters
+      type:
+        title: Filter type
+      types:
+        regexp: Regular Expression
+        regexp_hint: Use regular expressions if you want to filter registrations featuring more advanced patterns.
+        text: Simple text
+        text_hint: Use this for simple recurring keywords and if you do not know regular expressions.
+      updated_msg: Registration text filter successfully updated!
     relationships:
       title: "%{acct}'s relationships"
     relays:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -721,6 +721,18 @@ en:
       registrations:
         preamble: Control who can create an account on your server.
         title: Registrations
+        closed_message:
+          desc_html: Displayed on frontpage when registrations are closed. You can use HTML tags
+          title: Closed registration message
+        deletion:
+          desc_html: Allow anyone to delete their account
+          title: Open account deletion
+        invite_text_filter:
+          desc_html: 'Regular expression used to automatically reject users based on their invite request text. This can be used to cut down on registration spam. For instance, to reject registrations refering to blockchains or featuring links, you can use the following filter: <code>blockchain|https://</code>'
+          title: Registration text filter
+        require_invite_text:
+          desc_html: When registrations require manual approval, make the “Why do you want to join?” text input mandatory rather than optional
+          title: Require new users to enter a reason to join
       registrations_mode:
         modes:
           approved: Approval required for sign up
@@ -1365,6 +1377,8 @@ en:
     errors:
       limit_reached: Limit of different reactions reached
       unrecognized_emoji: is not a recognized emoji
+  regex_validator:
+    invalid_regexp: 'error parsing regular expression: %{error}'
   relationships:
     activity: Account activity
     dormant: Dormant
@@ -1643,6 +1657,7 @@ en:
       title: Welcome aboard, %{name}!
   users:
     follow_limit_reached: You cannot follow more than %{limit} people
+    invalid_invite_request_text: This text includes forbidden words or expressions
     invalid_otp_token: Invalid two-factor code
     otp_lost_help_html: If you lost access to both, you may get in touch with %{email}
     seamless_external_login: You are logged in via an external service, so password and e-mail settings are not available.

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -54,6 +54,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_path, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :ip_blocks, safe_join([fa_icon('ban fw'), t('admin.ip_blocks.title')]), admin_ip_blocks_path, highlights_on: %r{/admin/ip_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_path, if: -> { current_user.can?(:view_audit_log) }
+      s.item :registration_filters, safe_join([fa_icon('filter fw'), t('admin.registration_filters.title')]), admin_registration_filters_path, highlights_on: %r{/admin/registration_filters}, if: -> { current_user.can?(:manage_settings) }
     end
 
     n.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), nil, if: -> { current_user.can?(:view_dashboard, :manage_settings, :manage_rules, :manage_announcements, :manage_custom_emojis, :manage_webhooks, :manage_federation) } do |s|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,7 @@ Rails.application.routes.draw do
 
     resources :action_logs, only: [:index]
     resources :warning_presets, except: [:new]
+    resources :registration_filters, except: [:show]
 
     resources :announcements, except: [:show] do
       member do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -84,6 +84,7 @@ defaults: &defaults
   captcha_enabled: false
   backups_retention_period: 7
   search_preview: false
+  invite_text_filter: ''
 
 development:
   <<: *defaults

--- a/db/migrate/20221127215222_create_registration_filters.rb
+++ b/db/migrate/20221127215222_create_registration_filters.rb
@@ -1,0 +1,11 @@
+class CreateRegistrationFilters < ActiveRecord::Migration[6.1]
+  def change
+    create_table :registration_filters do |t|
+      t.text :phrase, null: false, default: ''
+      t.integer :type, null: false, default: 0
+      t.boolean :whole_word, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_25_104951) do
+ActiveRecord::Schema.define(version: 2022_11_27_215222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -780,6 +780,14 @@ ActiveRecord::Schema.define(version: 2022_11_25_104951) do
     t.bigint "preview_card_id", null: false
     t.bigint "status_id", null: false
     t.index ["status_id", "preview_card_id"], name: "index_preview_cards_statuses_on_status_id_and_preview_card_id"
+  end
+
+  create_table "registration_filters", force: :cascade do |t|
+    t.text "phrase", default: "", null: false
+    t.integer "type", default: 0, null: false
+    t.boolean "whole_word", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "relays", force: :cascade do |t|

--- a/spec/controllers/admin/registration_filters_controller_spec.rb
+++ b/spec/controllers/admin/registration_filters_controller_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::RegistrationFiltersController, type: :controller do
+  render_views
+
+  before do
+    sign_in Fabricate(:user, admin: true), scope: :user
+  end
+
+  describe 'GET #index' do
+    around do |example|
+      default_per_page = RegistrationFilter.default_per_page
+      RegistrationFilter.paginates_per 1
+      example.run
+      RegistrationFilter.paginates_per default_per_page
+    end
+
+    it 'renders registration filters' do
+      2.times { Fabricate(:registration_filter) }
+
+      get :index, params: { page: 2 }
+
+      assigned = assigns(:registration_filters)
+      expect(assigned.count).to eq 1
+      expect(assigned.klass).to be RegistrationFilter
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET #new' do
+    it 'assigns a new registration filter' do
+      get :new
+
+      expect(assigns(:registration_filter)).to be_instance_of(RegistrationFilter)
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'POST #create' do
+    it 'returns to registration filters page when succeeded to save' do
+      post :create, params: { registration_filter: { phrase: 'bitcoin' } }
+
+      expect(flash[:notice]).to eq I18n.t('admin.registration_filters.created_msg')
+      expect(response).to redirect_to(admin_registration_filters_path)
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'returns to registration filters page when succeeded destroying' do
+      registration_filter = Fabricate(:registration_filter)
+      delete :destroy, params: { id: registration_filter.id }
+
+      expect(flash[:notice]).to eq I18n.t('admin.registration_filters.destroyed_msg')
+      expect(response).to redirect_to(admin_registration_filters_path)
+    end
+  end
+end

--- a/spec/fabricators/registration_filter_fabricator.rb
+++ b/spec/fabricators/registration_filter_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:registration_filter) do
+  phrase     "MyText"
+  type       0
+  whole_word true
+end

--- a/spec/models/registration_filter_spec.rb
+++ b/spec/models/registration_filter_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RegistrationFilter, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/policies/registration_filter_policy_spec.rb
+++ b/spec/policies/registration_filter_policy_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe RegistrationFilterPolicy do
+  let(:subject) { described_class }
+  let(:admin)   { Fabricate(:user, admin: true).account }
+  let(:mod)     { Fabricate(:user, moderator: true).account }
+  let(:john)    { Fabricate(:user).account }
+
+  permissions :index? do
+    context 'admin' do
+      it 'permits' do
+        expect(subject).to permit(admin, RegistrationFilter)
+      end
+    end
+
+    context 'moderator' do
+      it 'permits' do
+        expect(subject).to permit(mod, RegistrationFilter)
+      end
+    end
+
+    context 'not staff' do
+      it 'denies' do
+        expect(subject).to_not permit(john, RegistrationFilter)
+      end
+    end
+  end
+
+  permissions :create?, :destroy?, :update? do
+    context 'admin' do
+      it 'permits' do
+        expect(subject).to permit(admin, RegistrationFilter)
+      end
+    end
+
+    context 'moderator' do
+      it 'denies' do
+        expect(subject).to_not permit(mod, RegistrationFilter)
+      end
+    end
+
+    context 'not admin' do
+      it 'denies' do
+        expect(subject).to_not permit(john, RegistrationFilter)
+      end
+    end
+  end
+end

--- a/spec/validators/invite_request_validator_spec.rb
+++ b/spec/validators/invite_request_validator_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe InviteRequestValidator do
+  let!(:whole_word_filter) { Fabricate(:registration_filter, phrase: 'whole-word', type: :text, whole_word: true) }
+  let!(:not_whole_word)    { Fabricate(:registration_filter, phrase: 'find-it-anywhere', type: :text, whole_word: false) }
+  let!(:regexp_filter)     { Fabricate(:registration_filter, phrase: 'https://.*/.*\.exe', type: :regexp) }
+  let(:invite_request)     { double(text: request_text, persisted?: false, errors: double(add: nil)) }
+
+  describe '#validate' do
+    context 'when invite request text does not match any filter' do
+      let(:request_text)    { 'I am just a prospective new user wanting to try out Mastodon. My website is https://allaboutbitcoin.org/' }
+
+      it 'does not add any error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to_not have_received(:add)
+      end
+    end
+
+    context 'when middle of invite request text matches whole-word filter' do
+      let(:request_text) { 'I like Whole-word so much!' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when start of invite request text matches whole-word filter' do
+      let(:request_text) { 'Whole-word is great!' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when end of invite request text matches whole-word filter' do
+      let(:request_text) { 'I will tell you all about Whole-word' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when middle of invite request text matches non-whole-word filter' do
+      let(:request_text) { 'dontthinkyoucanfind-it-anywherehere' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when start of invite request text matches non-whole-word filter' do
+      let(:request_text) { 'find-it-anywhereifyouwish' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when end of invite request text matches non-whole-word filter' do
+      let(:request_text) { 'cantfind-it-anywhere' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when middle of invite request text matches regexp filter' do
+      let(:request_text) { 'check out my website at https://foo.bar/pwned.exe it is dank' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when start of invite request text matches regexp filter' do
+      let(:request_text) { 'https://foo.bar/pwned.exe is so dank check it out' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+
+    context 'when end of invite request text matches regexp filter' do
+      let(:request_text) { 'check out my website at https://foo.bar/pwned.exe' }
+
+      it 'adds an error' do
+        subject.validate(invite_request)
+        expect(invite_request.errors).to have_received(:add)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on [7dd4502](https://github.com/mastodon/mastodon/pull/15275/commits/7dd4502df7ea66de4c5b7d8e418230d5dd97bcee), [e499cc8](https://github.com/mastodon/mastodon/pull/15275/commits/e499cc8301ee1d10053d131ab6a4814388874446)

Updated for 4.0.x
Enabled editing of filters without enabled approval mode.

Automatically deny creation of account request when invite text includes filtered keyword(s). Supports RegEx. 

Important:
This feature creates a new table and requires db migration.