### PR TITLE
Remove limit of featured tags shown on profile

### DIFF
--- a/app/javascript/flavours/glitch/features/account/components/featured_tags.js
+++ b/app/javascript/flavours/glitch/features/account/components/featured_tags.js
@@ -35,7 +35,7 @@ class FeaturedTags extends ImmutablePureComponent {
       <div className='getting-started__trends'>
         <h4><FormattedMessage id='account.featured_tags.title' defaultMessage="{name}'s featured hashtags" values={{ name: <bdi dangerouslySetInnerHTML={{ __html: account.get('display_name_html') }} /> }} /></h4>
 
-        {featuredTags.take(3).map(featuredTag => (
+        {featuredTags.map(featuredTag => (
           <Hashtag
             key={featuredTag.get('name')}
             name={featuredTag.get('name')}

--- a/app/javascript/mastodon/features/account/components/featured_tags.js
+++ b/app/javascript/mastodon/features/account/components/featured_tags.js
@@ -35,7 +35,7 @@ class FeaturedTags extends ImmutablePureComponent {
       <div className='getting-started__trends'>
         <h4><FormattedMessage id='account.featured_tags.title' defaultMessage="{name}'s featured hashtags" values={{ name: <bdi dangerouslySetInnerHTML={{ __html: account.get('display_name_html') }} /> }} /></h4>
 
-        {featuredTags.take(3).map(featuredTag => (
+        {featuredTags.map(featuredTag => (
           <Hashtag
             key={featuredTag.get('name')}
             name={featuredTag.get('name')}


### PR DESCRIPTION
Basically reverts c9d3c7d63a3218e3e113435213b7f9e63feb68a1 and 23d367f544485eaeed888c707012a8282bbb5806

Featured tags on profiles are limited to 3 out of 10 which can be set.
The limit of 3 was imposed because it causes the nav panel to scroll, which is a non-issue since it also scrolls when adding multiple lists.