### PR TITLE
Add visual indicator that image has alt-text

### DIFF
--- a/app/javascript/flavours/glitch/components/media_gallery.js
+++ b/app/javascript/flavours/glitch/components/media_gallery.js
@@ -198,6 +198,7 @@ class Item extends React.PureComponent {
             style={{ objectPosition: letterbox ? null : `${x}% ${y}%` }}
             onLoad={this.handleImageLoad}
           />
+          {attachment.get('description') ? (<span className='media-gallery__gifv__label'>ALT</span>) : null}
         </a>
       );
     } else if (attachment.get('type') === 'gifv') {

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -177,6 +177,7 @@ class Item extends React.PureComponent {
             style={{ objectPosition: `${x}% ${y}%` }}
             onLoad={this.handleImageLoad}
           />
+          {attachment.get('description') ? (<span className='media-gallery__gifv__label'>ALT</span>) : null}
         </a>
       );
     } else if (attachment.get('type') === 'gifv') {


### PR DESCRIPTION
This just adds a little indicator to the left bottom of images when alt-text is available.

Glitch:
![Screenshot_2022-12-05_07-06-41](https://user-images.githubusercontent.com/117664621/205561470-0ff95c6c-0faf-4498-ac15-fde6b5b729cf.png)

Vanilla:
![Screenshot_2022-12-05_07-07-27](https://user-images.githubusercontent.com/117664621/205561498-898b55f7-5cf0-41bb-b00b-4cf9772a01d8.png)

