### PR TITLE
Experimental: Add setting to customise favicon

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,6 +95,18 @@ module ApplicationHelper
     end
   end
 
+  def favicon_path
+    instance_presenter.favicon ? instance_presenter.favicon&.file&.url : '/favicon.ico'
+  end
+
+  def favicon_type
+    instance_presenter.favicon ? instance_presenter.favicon.file.content_type : 'image/x-icon'
+  end
+
+  def favicon?
+    instance_presenter.favicon.present?
+  end
+
   def title
     Rails.env.production? ? site_title : "#{site_title} (Dev)"
   end

--- a/app/javascript/flavours/glitch/styles/forms.scss
+++ b/app/javascript/flavours/glitch/styles/forms.scss
@@ -297,6 +297,19 @@ code {
         margin-bottom: 0;
       }
     }
+
+    &__favicon {
+      display: block;
+      margin: 0;
+      margin-bottom: 10px;
+      max-width: 64px;
+      height: auto;
+      border-radius: 4px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
   }
 
   .fields-row {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -305,6 +305,19 @@ code {
         margin-bottom: 0;
       }
     }
+
+    &__favicon {
+      display: block;
+      margin: 0;
+      margin-bottom: 10px;
+      max-width: 64px;
+      height: auto;
+      border-radius: 4px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
   }
 
   .fields-row {

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -23,6 +23,7 @@ class Form::AdminSettings
     profile_directory
     hide_followers_count
     flavour_and_skin
+    favicon
     thumbnail
     mascot
     show_reblogs_in_public_timelines
@@ -70,6 +71,7 @@ class Form::AdminSettings
   ).freeze
 
   UPLOAD_KEYS = %i(
+    favicon
     thumbnail
     mascot
   ).freeze

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -38,7 +38,19 @@ class SiteUpload < ApplicationRecord
     }.freeze,
 
     mascot: {}.freeze,
+    favicon: {},
   }.freeze
+
+  # Feels a bit hacky, but adds required sizes to favicon and then freezes it.
+  %w(16 32 48 57 60 72 76 114 120 144 152 167 180 1024).each do |size|
+    STYLES[:favicon][:"#{size}"] = {
+      format: 'png',
+      geometry: "#{size}x#{size}#",
+      file_geometry_parser: FastGeometryParser,
+    }.freeze
+  end
+
+  STYLES[:favicon].freeze
 
   has_attached_file :file, styles: ->(file) { STYLES[file.instance.var.to_sym] }, convert_options: { all: '-coalesce +profile "!icc,*" +set modify-date +set create-date' }, processors: [:lazy_thumbnail, :blurhash_transcoder, :type_corrector]
 

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -89,4 +89,8 @@ class InstancePresenter < ActiveModelSerializers::Model
   def mascot
     @mascot ||= Rails.cache.fetch('site_uploads/mascot') { SiteUpload.find_by(var: 'mascot') }
   end
+
+  def favicon
+    @favicon ||= Rails.cache.fetch('site_uploads/favicon') { SiteUpload.find_by(var: 'favicon') }
+  end
 end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -39,6 +39,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       version: instance_presenter.version,
       limited_federation_mode: Rails.configuration.x.whitelist_mode,
       mascot: instance_presenter.mascot&.file&.url,
+      favicon: instance_presenter.favicon&.file&.url,
       profile_directory: Setting.profile_directory,
       trends: Setting.trends,
       registrations_open: Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode,

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -32,5 +32,15 @@
           = fa_icon 'trash fw'
           = t('admin.site_uploads.delete')
 
+  .fields-row
+    .fields-row__column.fields-row__column-6.fields-group
+      = f.input :favicon, as: :file, wrapper: :with_block_label
+    .fields-row__column.fields-row__column-6.fields-group 
+      - if @admin_settings.favicon.persisted?
+        = image_tag @admin_settings.favicon.file.url(:'original'), class: 'fields-group__favicon'
+        = link_to admin_site_upload_path(@admin_settings.favicon), data: { method: :delete }, class: 'link-button link-button--destructive' do
+          = fa_icon 'trash fw'
+          = t('admin.site_uploads.delete') 
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,4 +1,5 @@
 !!! 5
+- # Uses: application_helper.rb
 %html{ lang: I18n.locale }
   %head
     %meta{ charset: 'utf-8' }/
@@ -11,13 +12,19 @@
     - if storage_host?
       %link{ rel: 'dns-prefetch', href: storage_host }/
 
-    %link{ rel: 'icon', href: '/favicon.ico', type: 'image/x-icon' }/
+    %link{ rel: 'icon', href: favicon_path, type: favicon_type }/
 
     - %w(16 32 48).each do |size|
-      %link{ rel: 'icon', sizes: "#{size}x#{size}", href: asset_pack_path("media/icons/favicon-#{size}x#{size}.png"), type: 'image/png' }/
+      - if favicon?
+        %link{ rel: 'icon', sizes: "#{size}x#{size}", href: instance_presenter.favicon&.file&.url(:"#{size}"), type: 'image/png' }/
+      - else
+        %link{ rel: 'icon', sizes: "#{size}x#{size}", href: asset_pack_path("media/icons/favicon-#{size}x#{size}.png"), type: 'image/png' }/
 
     - %w(57 60 72 76 114 120 144 152 167 180 1024).each do |size|
-      %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: asset_pack_path("media/icons/apple-touch-icon-#{size}x#{size}.png") }/
+      - if favicon?
+        %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: instance_presenter.favicon&.file&.url(:"#{size}") }/
+      - else
+        %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: asset_pack_path("media/icons/apple-touch-icon-#{size}x#{size}.png") }/
 
     %link{ rel: 'mask-icon', href: asset_pack_path('media/images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -81,6 +81,7 @@ en:
         closed_registrations_message: Displayed when sign-ups are closed
         content_cache_retention_period: Posts from other servers will be deleted after the specified number of days when set to a positive value. This may be irreversible.
         custom_css: You can apply custom styles on the web version of Mastodon.
+        favicon: An image to use as favicon.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         profile_directory: The profile directory lists all users who have opted-in to be discoverable.
@@ -239,6 +240,7 @@ en:
         closed_registrations_message: Custom message when sign-ups are not available
         content_cache_retention_period: Content cache retention period
         custom_css: Custom CSS
+        favicon: Server favicon
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
         profile_directory: Enable profile directory


### PR DESCRIPTION
I just want to spite top guy.

This feature adds a new setting to the branding settings, which allows upload of a custom favicon[^1].
![Screenshot_2022-12-09_14-23-03](https://user-images.githubusercontent.com/117664621/206713301-f0648c6b-b858-47d0-b7ba-4d40264322df.png)
![Screenshot_2022-12-09_14-36-12](https://user-images.githubusercontent.com/117664621/206714306-9e3e0b56-1777-44b2-bd6d-51c2be6bcd77.png)


The custom favicon replaces all default favicons[^2].
![Screenshot_2022-12-09_14-38-21](https://user-images.githubusercontent.com/117664621/206714681-aeda3188-02f9-4ad0-8f73-422290380ca3.png)


Used chaos.social favicon for testing.

[^1]: png, ico or svg recommended
[^2]: custom favicons are resized to the appropriate resolution, but this doesn't always work.
Images don't scale up and resizing the test svg failed for 1024x1024.