### PR TITLE
Add admin user setting override

### DIFF
--- a/app/lib/settings/scoped_settings.rb
+++ b/app/lib/settings/scoped_settings.rb
@@ -6,6 +6,7 @@ module Settings
       flavour
       skin
       noindex
+      show_application
     ).freeze
 
     def initialize(object)

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -31,6 +31,7 @@ class Form::AdminSettings
     trends_as_landing_page
     trendable_by_default
     trending_status_cw
+    show_application
     show_domain_blocks
     show_domain_blocks_rationale
     noindex
@@ -57,6 +58,7 @@ class Form::AdminSettings
     preview_sensitive_media
     profile_directory
     hide_followers_count
+    show_application
     show_reblogs_in_public_timelines
     show_replies_in_public_timelines
     trends

--- a/app/views/admin/settings/other/show.html.haml
+++ b/app/views/admin/settings/other/show.html.haml
@@ -20,6 +20,9 @@
     = f.input :show_replies_in_public_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_replies_in_public_timelines.title'), hint: t('admin.settings.show_replies_in_public_timelines.desc_html'), glitch_only: true
 
   .fields-group
+    = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html'), glitch_only: true
+
+  .fields-group
     = f.input :outgoing_spoilers, wrapper: :with_label, label: t('admin.settings.outgoing_spoilers.title'), hint: t('admin.settings.outgoing_spoilers.desc_html'), glitch_only: true
 
   .actions

--- a/app/views/admin/settings/other/show.html.haml
+++ b/app/views/admin/settings/other/show.html.haml
@@ -23,6 +23,9 @@
     = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html'), glitch_only: true
 
   .fields-group
+    = f.input :show_application, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_show_application.title'), hint: t('admin.settings.default_show_application.desc_html'), glitch_only: true
+
+  .fields-group
     = f.input :outgoing_spoilers, wrapper: :with_label, label: t('admin.settings.outgoing_spoilers.title'), hint: t('admin.settings.outgoing_spoilers.desc_html'), glitch_only: true
 
   .actions

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -2,12 +2,15 @@
 en:
   admin:
     custom_emojis:
-      batch_copy_error: 'An error occurred when copying some of the selected emoji: %{message}'
+      batch_copy_error: 'An error occurred while copying some of the selected emoji: %{message}'
       batch_error: 'An error occurred: %{message}'
     settings:
       captcha_enabled:
         desc_html: This relies on external scripts from hCaptcha, which may be a security and privacy concern. In addition, <strong>this can make the registration process significantly less accessible to some (especially disabled) people</strong>. For these reasons, please consider alternative measures such as approval-based or invite-based registration.<br>Users that have been invited through a limited-use invite will not need to solve a CAPTCHA
         title: Require new users to solve a CAPTCHA to confirm their account
+      default_noindex:
+        desc_html: Affects all users who have not changed this setting themselves
+        title: Opt users out of search engine indexing by default
       enable_keybase:
         desc_html: Allow your users to prove their identity via keybase
         title: Enable keybase integration

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -11,6 +11,9 @@ en:
       default_noindex:
         desc_html: Affects all users who have not changed this setting themselves
         title: Opt users out of search engine indexing by default
+      default_show_application:
+        desc_html: Affects all users who have not changed this setting themselves
+        title: Disclose application used to send posts
       enable_keybase:
         desc_html: Allow your users to prove their identity via keybase
         title: Enable keybase integration


### PR DESCRIPTION
Adds back the noindex admin setting to opt out users of search indexing by default.
Adds new admin setting to disclose application by default.

These setting are added as glitch specific settings and available in the `other` tab.

If you're running vanilla, you have to port the settings to a different tab and copy the translation strings to vanilla language files.