### PR TITLE
Add setting to disable RSS feed

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -24,6 +24,11 @@ class AccountsController < ApplicationController
       format.rss do
         expires_in 1.minute, public: true
 
+        if @account&.user&.setting_norss
+          @statuses = []
+          next
+        end
+
         limit     = params[:limit].present? ? [params[:limit].to_i, PAGE_SIZE_MAX].min : PAGE_SIZE
         @statuses = filtered_statuses.without_reblogs.limit(limit)
         @statuses = cache_collection(@statuses, Status)

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -48,6 +48,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_system_font_ui,
       :setting_system_emoji_font,
       :setting_noindex,
+      :setting_norss,
       :setting_hide_followers_count,
       :setting_aggregate_reblogs,
       :setting_show_application,

--- a/app/lib/settings/scoped_settings.rb
+++ b/app/lib/settings/scoped_settings.rb
@@ -7,6 +7,7 @@ module Settings
       skin
       noindex
       show_application
+      norss
     ).freeze
 
     def initialize(object)

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -35,6 +35,7 @@ class UserSettingsDecorator
     user.settings['hide_followers_count'] = hide_followers_count_preference if change?('setting_hide_followers_count')
     user.settings['flavour']             = flavour_preference if change?('setting_flavour')
     user.settings['skin']                = skin_preference if change?('setting_skin')
+    user.settings['norss']               = norss_preference if change?('setting_norss')
     user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
     user.settings['show_application']    = show_application_preference if change?('setting_show_application')
     user.settings['advanced_layout']     = advanced_layout_preference if change?('setting_advanced_layout')
@@ -113,6 +114,10 @@ class UserSettingsDecorator
 
   def flavour_preference
     settings['setting_flavour']
+  end
+
+  def norss_preference
+    boolean_cast_setting 'setting_norss'
   end
 
   def skin_preference

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -36,6 +36,7 @@ class Form::AdminSettings
     show_domain_blocks
     show_domain_blocks_rationale
     noindex
+    norss
     outgoing_spoilers
     require_invite_text
     captcha_enabled
@@ -67,6 +68,7 @@ class Form::AdminSettings
     trendable_by_default
     trending_status_cw
     noindex
+    norss
     require_invite_text
     captcha_enabled
     search_preview

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,7 +132,7 @@ class User < ApplicationRecord
   has_many :session_activations, dependent: :destroy
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :favourite_modal, :delete_modal,
-           :reduce_motion, :system_font_ui, :noindex, :flavour, :skin, :display_media, :hide_followers_count,
+           :reduce_motion, :system_font_ui, :noindex, :norss, :flavour, :skin, :display_media, :hide_followers_count,
            :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
            :advanced_layout, :use_blurhash, :use_pending_items, :trends, :crop_images,
            :disable_swiping, :notification_sound, :always_send_emails, :default_content_type, :system_emoji_font,

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -5,7 +5,9 @@
   - if @account.user_prefers_noindex?
     %meta{ name: 'robots', content: 'noindex, noarchive' }/
 
-  %link{ rel: 'alternate', type: 'application/rss+xml', href: @rss_url }/
+  - if !@account.user&.setting_norss
+    %link{ rel: 'alternate', type: 'application/rss+xml', href: @rss_url }/
+
   %link{ rel: 'alternate', type: 'application/activity+json', href: ActivityPub::TagManager.instance.uri_for(@account) }/
 
   - @account.fields.select(&:verifiable?).each do |field|

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -34,6 +34,11 @@
   .fields-group
     = f.input :search_preview, as: :boolean, wrapper: :with_label
 
+  %h4= t('admin.settings.discovery.rss')
+
+  .fields-group
+    = f.input :norss, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_norss.title'), hint: t('admin.settings.default_norss.desc_html'), glitch_only: true
+
   %h4= t('admin.settings.discovery.follow_recommendations')
 
   .fields-group

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -11,6 +11,9 @@
     = f.input :setting_noindex, as: :boolean, wrapper: :with_label
 
   .fields-group
+    = f.input :setting_norss, as: :boolean, wrapper: :with_label, glitch_only: true
+
+  .fields-group
     = f.input :setting_aggregate_reblogs, as: :boolean, wrapper: :with_label, recommended: true
 
   - unless Setting.hide_followers_count

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -11,9 +11,14 @@ en:
       default_noindex:
         desc_html: Affects all users who have not changed this setting themselves
         title: Opt users out of search engine indexing by default
+      default_norss:
+        desc_html: Affects all users who have not changed this setting themselves
+        title: Opt users out of having an RSS feed of their public posts by default
       default_show_application:
         desc_html: Affects all users who have not changed this setting themselves
         title: Disclose application used to send posts
+      discovery:
+        rss: RSS
       enable_keybase:
         desc_html: Allow your users to prove their identity via keybase
         title: Enable keybase integration

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -10,6 +10,7 @@ en:
         setting_default_content_type_plain: When writing toots, assume they are plain text with no special formatting, unless specified otherwise (default Mastodon behavior)
         setting_default_language: The language of your toots can be detected automatically, but it's not always accurate
         setting_hide_followers_count: Hide your followers count from everybody, including you. Some applications may display a negative followers count.
+        setting_norss: Mastodon offers an RSS feed of all public posts by default.
         setting_skin: Reskins the selected Mastodon flavour
     labels:
       defaults:
@@ -18,6 +19,7 @@ en:
         setting_default_content_type_markdown: Markdown
         setting_default_content_type_plain: Plain text
         setting_favourite_modal: Show confirmation dialog before favouriting (applies to Glitch flavour only)
+        setting_norss: Disable RSS feed for your public posts
         setting_hide_followers_count: Hide your followers count
         setting_skin: Skin
         setting_system_emoji_font: Use system's default font for emojis (applies to Glitch flavour only)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,7 @@ defaults: &defaults
   system_font_ui: false
   system_emoji_font: false
   noindex: false
+  norss: false
   hide_followers_count: false
   flavour: 'glitch'
   skin: 'default'


### PR DESCRIPTION
Port of upstream/#2002

Adds a user option to disable RSS feed for public posts.
Lets admins set a default for users.

Converted to glitch-only setting.
Added a hint to the user setting.

The `discovery.rss` locale string is unnecessary, as it defaults to the locale string name, but included for good measure.