### PR TITLE
Move localisations to glitch

### DIFF
--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -16,7 +16,7 @@
     = f.input :trends, as: :boolean, wrapper: :with_label
 
   .fields-group
-    = f.input :trends_as_landing_page, as: :boolean, wrapper: :with_label
+    = f.input :trends_as_landing_page, as: :boolean, wrapper: :with_label, glitch_only: true
 
   .fields-group
     = f.input :trendable_by_default, as: :boolean, wrapper: :with_label, recommended: :not_recommended

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -32,7 +32,7 @@
   %h4= t('admin.settings.discovery.search')
 
   .fields-group
-    = f.input :search_preview, as: :boolean, wrapper: :with_label
+    = f.input :search_preview, as: :boolean, wrapper: :with_label, glitch_only: true
 
   .fields-group
     = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -36,6 +36,10 @@ en:
         text: Simple text
         text_hint: Use this for simple recurring keywords and if you do not know regular expressions.
       updated_msg: Registration text filter successfully updated!
+    roles:
+      privileges:
+        change_max_use: Change Max Use
+        change_max_use_description: Allows users to change max uses of invites
     settings:
       captcha_enabled:
         desc_html: This relies on external scripts from hCaptcha, which may be a security and privacy concern. In addition, <strong>this can make the registration process significantly less accessible to some (especially disabled) people</strong>. For these reasons, please consider alternative measures such as approval-based or invite-based registration.<br>Users that have been invited through a limited-use invite will not need to solve a CAPTCHA

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -52,6 +52,7 @@ en:
         title: Disclose application used to send posts
       discovery:
         rss: RSS
+        search: Search
       enable_keybase:
         desc_html: Allow your users to prove their identity via keybase
         title: Enable keybase integration

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -7,9 +7,9 @@ en:
         destroy_registration_filter: Destroy Registration Text Filter
         update_registration_filter: Update Registration Text Filter
       actions:
-        create_registration_filter_html: "%{name} blocked registrations with request text matching %{target}"
-        destroy_registration_filter_html: "%{name} unblocked registrations with request text matching %{target}"
-        update_registration_filter_html: "%{name} updated registration filter blocking request text matching %{target}"
+        create_registration_filter_html: '%{name} blocked registrations with request text matching %{target}'
+        destroy_registration_filter_html: '%{name} unblocked registrations with request text matching %{target}'
+        update_registration_filter_html: '%{name} updated registration filter blocking request text matching %{target}'
     custom_emojis:
       batch_copy_error: 'An error occurred while copying some of the selected emoji: %{message}'
       batch_error: 'An error occurred: %{message}'

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -12,6 +12,8 @@ en:
         setting_hide_followers_count: Hide your followers count from everybody, including you. Some applications may display a negative followers count.
         setting_norss: Mastodon offers an RSS feed of all public posts by default.
         setting_skin: Reskins the selected Mastodon flavour
+      form_admin_settings:
+        trends_as_landing_page: Show trending content to logged-out users and visitors instead of a description of this server. Requires trends to be enabled.
     labels:
       defaults:
         setting_default_content_type: Default format for toots
@@ -24,6 +26,8 @@ en:
         setting_notification_sound: Notification Sound
         setting_skin: Skin
         setting_system_emoji_font: Use system's default font for emojis (applies to Glitch flavour only)
+      form_admin_settings:
+        trends_as_landing_page: Use trends as the landing page
       notification_emails:
         trending_tag: New trending tag requires review
         trending_link: New trending link requires review

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -13,6 +13,7 @@ en:
         setting_norss: Mastodon offers an RSS feed of all public posts by default.
         setting_skin: Reskins the selected Mastodon flavour
       form_admin_settings:
+        search_preview: Logged out visitors will be able to use the search bar.
         trends_as_landing_page: Show trending content to logged-out users and visitors instead of a description of this server. Requires trends to be enabled.
       invite:
         comment: Optional. You can enter for whom the invite is for, or reason for creating it
@@ -29,6 +30,7 @@ en:
         setting_skin: Skin
         setting_system_emoji_font: Use system's default font for emojis (applies to Glitch flavour only)
       form_admin_settings:
+        search_preview: Allow unauthenticated access to search
         trends_as_landing_page: Use trends as the landing page
       notification_emails:
         trending_tag: New trending tag requires review

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -14,6 +14,8 @@ en:
         setting_skin: Reskins the selected Mastodon flavour
       form_admin_settings:
         trends_as_landing_page: Show trending content to logged-out users and visitors instead of a description of this server. Requires trends to be enabled.
+      invite:
+        comment: Optional. You can enter for whom the invite is for, or reason for creating it
     labels:
       defaults:
         setting_default_content_type: Default format for toots

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -712,7 +712,6 @@ en:
         preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.
         profile_directory: Profile directory
         public_timelines: Public timelines
-        search: Search
         title: Discovery
         trends: Trends
       domain_blocks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -643,8 +643,6 @@ en:
       privileges:
         administrator: Administrator
         administrator_description: Users with this permission will bypass every permission
-        change_max_use: Change Max Use
-        change_max_use_description: Allows users to change max uses of invites
         delete_user_data: Delete User Data
         delete_user_data_description: Allows users to delete other users' data without delay
         invite_users: Invite Users

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -95,7 +95,6 @@ en:
         timeline_preview: Logged out visitors will be able to browse the most recent public posts available on the server.
         trendable_by_default: Skip manual review of trending content. Individual items can still be removed from trends after the fact.
         trends: Trends show which posts, hashtags and news stories are gaining traction on your server.
-        search_preview: Logged out visitors will be able to use the search bar.
       form_challenge:
         current_password: You are entering a secure area
       imports:
@@ -255,7 +254,6 @@ en:
         timeline_preview: Allow unauthenticated access to public timelines
         trendable_by_default: Allow trends without prior review
         trends: Enable trends
-        search_preview: Allow unauthenticated access to search
       interactions:
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -97,7 +97,6 @@ en:
         timeline_preview: Logged out visitors will be able to browse the most recent public posts available on the server.
         trendable_by_default: Skip manual review of trending content. Individual items can still be removed from trends after the fact.
         trends: Trends show which posts, hashtags and news stories are gaining traction on your server.
-        trends_as_landing_page: Show trending content to logged-out users and visitors instead of a description of this server. Requires trends to be enabled.
         search_preview: Logged out visitors will be able to use the search bar.
       form_challenge:
         current_password: You are entering a secure area
@@ -258,7 +257,6 @@ en:
         timeline_preview: Allow unauthenticated access to public timelines
         trendable_by_default: Allow trends without prior review
         trends: Enable trends
-        trends_as_landing_page: Use trends as the landing page
         search_preview: Allow unauthenticated access to search
       interactions:
         must_be_follower: Block notifications from non-followers

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -29,8 +29,6 @@ en:
         text: You can use post syntax. Please be mindful of the space the announcement will take up on the user's screen
       appeal:
         text: You can only appeal a strike once
-      invite:
-        comment: Optional. You can enter for whom the invite is for, or reason for creating it
       defaults:
         autofollow: People who sign up through the invite will automatically follow you
         avatar: PNG, GIF or JPG. At most %{size}. Will be downscaled to %{dimensions}px


### PR DESCRIPTION
I made the mistake of editing vanilla locale files in various earlier commits.
While it's not that much of an issue with backend files, I want to avoid merge conflicts when pulling updates.
Glitch locales don't update that often, so merge conflicts will be rare.
Also in interest of best practices, I added the glitch-soc label to these settings, to make it clear these are not offered by vanilla.
Ideally I would have my own label, to also make it clear these settings are specific to this fork, but I'm still thinking about that.

localisation for de and nl will be added in a future PR.
(I could need help with nl, as mijn Nederlands is niet zo goed)

Contributions of other languages are welcome.