### PR TITLE
Add setting to customize publish button text

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/publisher.js
+++ b/app/javascript/flavours/glitch/features/compose/components/publisher.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { length } from 'stringz';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import { publishButtonText as customPublishButtonText } from 'flavours/glitch/initial_state';
 
 //  Components.
 import Button from 'flavours/glitch/components/button';
@@ -56,17 +57,18 @@ class Publisher extends ImmutablePureComponent {
     const privacyIcons = { direct: 'envelope', private: 'lock', public: 'globe', unlisted: 'unlock' };
 
     let publishText;
+    let publishButtonText = customPublishButtonText || intl.formatMessage(messages.publish);
     if (isEditing) {
       publishText = intl.formatMessage(messages.saveChanges);
     } else if (privacy === 'private' || privacy === 'direct') {
       const iconId = privacyIcons[privacy];
       publishText = (
         <span>
-          <Icon id={iconId} /> {intl.formatMessage(messages.publish)}
+          <Icon id={iconId} /> {publishButtonText}
         </span>
       );
     } else {
-      publishText = privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
+      publishText = privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: publishButtonText }) : publishButtonText;
     }
 
     return (
@@ -79,7 +81,7 @@ class Publisher extends ImmutablePureComponent {
               onClick={onSecondarySubmit}
               style={{ padding: null }}
               text={<Icon id={privacyIcons[sideArm]} />}
-              title={`${intl.formatMessage(messages.publish)}: ${intl.formatMessage({ id: `privacy.${sideArm}.short` })}`}
+              title={`${publishButtonText}: ${intl.formatMessage({ id: `privacy.${sideArm}.short` })}`}
             />
           </div>
         ) : null}
@@ -87,7 +89,7 @@ class Publisher extends ImmutablePureComponent {
           <Button
             className='primary'
             text={publishText}
-            title={`${intl.formatMessage(messages.publish)}: ${intl.formatMessage({ id: `privacy.${privacy}.short` })}`}
+            title={`${publishButtonText}: ${intl.formatMessage({ id: `privacy.${privacy}.short` })}`}
             onClick={this.handleSubmit}
             disabled={disabled}
           />

--- a/app/javascript/flavours/glitch/initial_state.js
+++ b/app/javascript/flavours/glitch/initial_state.js
@@ -86,6 +86,7 @@
  * @property {number} visible_reactions
  * @property {boolean} translation_enabled
  * @property {object} local_settings
+ * @property {string} publish_button_text
  */
 
 /**
@@ -150,6 +151,7 @@ export const version = getMeta('version');
 export const visibleReactions = getMeta('visible_reactions');
 export const translationEnabled = getMeta('translation_enabled');
 export const languages = initialState?.languages;
+export const publishButtonText = getMeta('publish_button_text');
 
 // Glitch-soc-specific settings
 export const maxChars = (initialState && initialState.max_toot_chars) || 500;

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -21,6 +21,7 @@ import { length } from 'stringz';
 import { countableText } from '../util/counter';
 import Icon from 'mastodon/components/icon';
 import { maxChars } from '../../../initial_state';
+import { publishButtonText as customPublishButtonText } from 'mastodon/initial_state';
 
 const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
 
@@ -211,13 +212,14 @@ class ComposeForm extends ImmutablePureComponent {
     const disabled = this.props.isSubmitting;
 
     let publishText = '';
+    let publishButtonText = customPublishButtonText || intl.formatMessage(messages.publish);
 
     if (this.props.isEditing) {
       publishText = intl.formatMessage(messages.saveChanges);
     } else if (this.props.privacy === 'private' || this.props.privacy === 'direct') {
-      publishText = <span className='compose-form__publish-private'><Icon id='lock' /> {intl.formatMessage(messages.publish)}</span>;
+      publishText = <span className='compose-form__publish-private'><Icon id='lock' /> {publishButtonText}</span>;
     } else {
-      publishText = this.props.privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
+      publishText = this.props.privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: publishButtonText }) : publishButtonText;
     }
 
     return (

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -85,6 +85,7 @@
  * @property {string} version
  * @property {number} visible_reactions
  * @property {boolean} translation_enabled
+ * @property {string} publish_button_text
  */
 
 /**
@@ -142,6 +143,7 @@ export const version = getMeta('version');
 export const visibleReactions = getMeta('visible_reactions');
 export const translationEnabled = getMeta('translation_enabled');
 export const languages = initialState?.languages;
+export const publishButtonText = getMeta('publish_button_text');
 
 // Glitch-soc-specific settings
 export const maxChars = (initialState && initialState.max_toot_chars) || 500;

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -44,6 +44,7 @@ class Form::AdminSettings
     content_cache_retention_period
     backups_retention_period
     search_preview
+    publish_button_text
   ).freeze
 
   INTEGER_KEYS = %i(

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -53,6 +53,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       translation_enabled: TranslationService.configured?,
       trends_as_landing_page: Setting.trends_as_landing_page,
       search_preview: Setting.search_preview,
+      publish_button_text: Setting.publish_button_text,
     }
 
     if object.current_account

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -27,5 +27,8 @@
           = fa_icon 'trash fw'
           = t('admin.site_uploads.delete')
 
+  .fields-group
+    = f.input :publish_button_text, wrapper: :with_block_label
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -13,6 +13,7 @@ en:
         setting_norss: Mastodon offers an RSS feed of all public toots by default.
         setting_skin: Reskins the selected Mastodon flavour
       form_admin_settings:
+        publish_button_text: Overrides the text of the publish button.
         search_preview: Logged out visitors will be able to use the search bar.
         trends_as_landing_page: Show trending content to logged-out users and visitors instead of a description of this server. Requires trends to be enabled.
       invite:
@@ -31,6 +32,7 @@ en:
         setting_system_emoji_font: Use system's default font for emojis (applies to Glitch flavour only)
         setting_visible_reactions: Number of visible emoji reactions
       form_admin_settings:
+        publish_button_text: Publish button text
         search_preview: Allow unauthenticated access to search
         trends_as_landing_page: Use trends as the landing page
       notification_emails:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,6 +87,7 @@ defaults: &defaults
   backups_retention_period: 7
   search_preview: false
   invite_text_filter: ''
+  publish_button_text: ''
 
 development:
   <<: *defaults


### PR DESCRIPTION
Port of upstream/#1945

Adds an admin setting to customise the text of the publish button.
This setting will apply to all languages.