### PR TITLE
Add alt-text modal

### DIFF
--- a/app/javascript/flavours/glitch/components/media_gallery.js
+++ b/app/javascript/flavours/glitch/components/media_gallery.js
@@ -44,6 +44,7 @@ class Item extends React.PureComponent {
     displayWidth: PropTypes.number,
     visible: PropTypes.bool.isRequired,
     autoplay: PropTypes.bool,
+    onAltClick: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -90,6 +91,15 @@ class Item extends React.PureComponent {
       onClick(index);
     }
 
+    e.stopPropagation();
+  }
+
+  handleAltClick = (e) => {
+    const { index, onAltClick } = this.props;
+
+    onAltClick(index);
+
+    // Prevents opening of media modal
     e.stopPropagation();
   }
 
@@ -150,6 +160,7 @@ class Item extends React.PureComponent {
     }
 
     let thumbnail = '';
+    let altButton = (<button type='button' className='media-gallery__alt__button' onClick={this.handleAltClick}><span>ALT</span></button>);
 
     if (attachment.get('type') === 'unknown') {
       return (
@@ -198,7 +209,10 @@ class Item extends React.PureComponent {
             style={{ objectPosition: letterbox ? null : `${x}% ${y}%` }}
             onLoad={this.handleImageLoad}
           />
-          {attachment.get('description') ? (<span className='media-gallery__gifv__label'>ALT</span>) : null}
+          {attachment.get('description') ? (
+            <div className='media-gallery__label-container'>
+              {altButton}
+            </div>) : null}
         </a>
       );
     } else if (attachment.get('type') === 'gifv') {
@@ -221,7 +235,10 @@ class Item extends React.PureComponent {
             muted
           />
 
-          <span className='media-gallery__gifv__label'>GIF</span>
+          <div className='media-gallery__label-container'>
+            <span className='media-gallery__gifv__label'>GIF</span>
+            {attachment.get('description') ? altButton : null}
+          </div>
         </div>
       );
     }
@@ -260,6 +277,7 @@ class MediaGallery extends React.PureComponent {
     visible: PropTypes.bool,
     autoplay: PropTypes.bool,
     onToggleVisibility: PropTypes.func,
+    onOpenAltText: PropTypes.func,
   };
 
   static defaultProps = {
@@ -314,6 +332,10 @@ class MediaGallery extends React.PureComponent {
     this.props.onOpenMedia(this.props.media, index);
   }
 
+  handleAltClick = (index) => {
+    this.props.onOpenAltText(index);
+  }
+
   handleRef = (node) => {
     this.node = node;
 
@@ -365,9 +387,9 @@ class MediaGallery extends React.PureComponent {
     }
 
     if (this.isStandaloneEligible()) {
-      children = <Item standalone autoplay={autoplay} onClick={this.handleClick} attachment={media.get(0)} displayWidth={width} visible={visible} />;
+      children = <Item standalone autoplay={autoplay} onClick={this.handleClick} onAltClick={this.handleAltClick} attachment={media.get(0)} displayWidth={width} visible={visible} />;
     } else {
-      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} size={size} letterbox={letterbox} displayWidth={width} visible={visible || uncached} />);
+      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} onAltClick={this.handleAltClick} attachment={attachment} index={i} size={size} letterbox={letterbox} displayWidth={width} visible={visible || uncached} />);
     }
 
     if (uncached) {

--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -110,6 +110,7 @@ class Status extends ImmutablePureComponent {
       inUse: PropTypes.bool,
       available: PropTypes.bool,
     }),
+    onOpenAltText: PropTypes.func,
   };
 
   state = {
@@ -391,6 +392,12 @@ class Status extends ImmutablePureComponent {
     this.props.onOpenMedia(this.props.status.get('id'), media, index);
   }
 
+  handleAltClick = (index) => {
+    const { status } = this.props;
+
+    this.props.onOpenAltText(status.get('id'), status.getIn(['media_attachments', index ? index : 0]));
+  }
+
   handleHotkeyOpenMedia = e => {
     const { status, onOpenMedia, onOpenVideo } = this.props;
     const statusId = status.get('id');
@@ -518,6 +525,7 @@ class Status extends ImmutablePureComponent {
       unread,
       featured,
       pictureInPicture,
+      onOpenAltText,
       ...other
     } = this.props;
     const { isCollapsed, forceFilter } = this.state;
@@ -642,6 +650,7 @@ class Status extends ImmutablePureComponent {
                 blurhash={attachment.get('blurhash')}
                 visible={this.state.showMedia}
                 onToggleVisibility={this.handleToggleMediaVisibility}
+                onOpenAltText={this.handleAltClick}
               />
             )}
           </Bundle>,
@@ -669,6 +678,7 @@ class Status extends ImmutablePureComponent {
               deployPictureInPicture={pictureInPicture.get('available') ? this.handleDeployPictureInPicture : undefined}
               visible={this.state.showMedia}
               onToggleVisibility={this.handleToggleMediaVisibility}
+              onOpenAltText={this.handleAltClick}
             />)}
           </Bundle>,
         );
@@ -688,6 +698,7 @@ class Status extends ImmutablePureComponent {
                 defaultWidth={this.props.cachedMediaWidth}
                 visible={this.state.showMedia}
                 onToggleVisibility={this.handleToggleMediaVisibility}
+                onOpenAltText={this.handleAltClick}
               />
             )}
           </Bundle>,

--- a/app/javascript/flavours/glitch/containers/status_container.js
+++ b/app/javascript/flavours/glitch/containers/status_container.js
@@ -219,6 +219,10 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     dispatch(openModal('VIDEO', { statusId, media, options }));
   },
 
+  onOpenAltText (statusId, media) {
+    dispatch(openModal('ALTTEXT', { statusId, media }));
+  },
+
   onBlock (status) {
     const account = status.get('account');
     dispatch(initBlockModal(account));

--- a/app/javascript/flavours/glitch/features/audio/index.js
+++ b/app/javascript/flavours/glitch/features/audio/index.js
@@ -19,6 +19,7 @@ const messages = defineMessages({
   unmute: { id: 'video.unmute', defaultMessage: 'Unmute sound' },
   download: { id: 'video.download', defaultMessage: 'Download file' },
   hide: { id: 'audio.hide', defaultMessage: 'Hide audio' },
+  alt: { id: 'video.alt', defaultMessage: 'Show alt-text' },
 });
 
 const TICK_SIZE = 10;
@@ -50,6 +51,7 @@ class Audio extends React.PureComponent {
     volume: PropTypes.number,
     muted: PropTypes.bool,
     deployPictureInPicture: PropTypes.func,
+    onOpenAltText: PropTypes.func,
   };
 
   state = {
@@ -463,6 +465,11 @@ class Audio extends React.PureComponent {
     }
   }
 
+  handleAltClick = () => {
+    this.audio.pause();
+    this.props.onOpenAltText();
+  }
+
   render () {
     const { src, intl, alt, editable, autoPlay, sensitive, blurhash } = this.props;
     const { paused, muted, volume, currentTime, duration, buffer, dragging, revealed } = this.state;
@@ -561,6 +568,7 @@ class Audio extends React.PureComponent {
             </div>
 
             <div className='video-player__buttons right'>
+              {alt && <button type='button' title={intl.formatMessage(messages.alt)} aria-label={intl.formatMessage(messages.alt)} className='player-button alt-button' onClick={this.handleAltClick}><span>ALT</span></button>}
               {!editable && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
               <a title={intl.formatMessage(messages.download)} aria-label={intl.formatMessage(messages.download)} className='video-player__download__icon player-button' href={this.props.src} download>
                 <Icon id={'download'} fixedWidth />

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.js
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.js
@@ -51,6 +51,7 @@ class DetailedStatus extends ImmutablePureComponent {
     onReactionAdd: PropTypes.func.isRequired,
     onReactionRemove: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
+    onOpenAltText: PropTypes.func.isRequired,
   };
 
   state = {
@@ -81,6 +82,12 @@ class DetailedStatus extends ImmutablePureComponent {
 
   handleOpenVideo = (options) => {
     this.props.onOpenVideo(this.props.status.getIn(['media_attachments', 0]), options);
+  }
+
+  handleAltClick = (index) => {
+    const { status } = this.props;
+
+    this.props.onOpenAltText(status.get('id'), status.getIn(['media_attachments', index ? index : 0]));
   }
 
   _measureHeight (heightJustChanged) {
@@ -183,6 +190,7 @@ class DetailedStatus extends ImmutablePureComponent {
             blurhash={attachment.get('blurhash')}
             height={150}
             onToggleVisibility={this.props.onToggleMediaVisibility}
+            onOpenAltText={this.props.onOpenAltText}
           />,
         );
         mediaIcons.push('music');
@@ -204,6 +212,7 @@ class DetailedStatus extends ImmutablePureComponent {
             autoplay
             visible={this.props.showMedia}
             onToggleVisibility={this.props.onToggleMediaVisibility}
+            onOpenAltText={this.props.onOpenAltText}
           />,
         );
         mediaIcons.push('video-camera');
@@ -219,6 +228,7 @@ class DetailedStatus extends ImmutablePureComponent {
             onOpenMedia={this.props.onOpenMedia}
             visible={this.props.showMedia}
             onToggleVisibility={this.props.onToggleMediaVisibility}
+            onOpenAltText={this.props.onOpenAltText}
           />,
         );
         mediaIcons.push('picture-o');

--- a/app/javascript/flavours/glitch/features/status/index.js
+++ b/app/javascript/flavours/glitch/features/status/index.js
@@ -416,6 +416,12 @@ class Status extends ImmutablePureComponent {
     this.props.dispatch(openModal('VIDEO', { statusId: this.props.status.get('id'), media, options }));
   }
 
+  handleAltClick = (index) => {
+    const { status } = this.props;
+
+    this.props.dispatch(openModal('ALTTEXT', { statusId: status.get('id'), media: status.getIn(['media_attachments', index ? index : 0])}));
+  }
+
   handleHotkeyOpenMedia = e => {
     const { status } = this.props;
 
@@ -705,6 +711,7 @@ class Status extends ImmutablePureComponent {
                   showMedia={this.state.showMedia}
                   onToggleMediaVisibility={this.handleToggleMediaVisibility}
                   pictureInPicture={pictureInPicture}
+                  onOpenAltText={this.handleAltClick}
                 />
 
                 <ActionBar

--- a/app/javascript/flavours/glitch/features/ui/components/alttext_modal.js
+++ b/app/javascript/flavours/glitch/features/ui/components/alttext_modal.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import PropTypes from 'prop-types';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import Button from 'flavours/glitch/components/button';
+import { injectIntl, FormattedMessage } from 'react-intl';
+
+@injectIntl
+export default class AltTextModal extends ImmutablePureComponent {
+
+  static contextTypes = {
+    router: PropTypes.object,
+  };
+
+  static propTypes = {
+    media: ImmutablePropTypes.map.isRequired,
+    statusId: PropTypes.string,
+    onClose: PropTypes.func.isRequired,
+  };
+
+  render () {
+    const { media, onClose } = this.props;
+
+    return (
+      <div className='modal-root__modal alttext-modal'>
+        <div className='alttext-modal__container'>
+          <pre>{media.get('description')}</pre>
+        </div>
+        <div className='alttext-modal__action-bar'>
+          <Button onClick={onClose} className='alttext-modal__button'>
+            <FormattedMessage id='lightbox.close' defaultMessage='Close' />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/flavours/glitch/features/ui/components/modal_root.js
+++ b/app/javascript/flavours/glitch/features/ui/components/modal_root.js
@@ -16,6 +16,7 @@ import ConfirmationModal from './confirmation_modal';
 import FocalPointModal from './focal_point_modal';
 import DeprecatedSettingsModal from './deprecated_settings_modal';
 import ImageModal from './image_modal';
+import AltTextModal from './alttext_modal';
 import {
   OnboardingModal,
   MuteModal,
@@ -60,6 +61,7 @@ const MODAL_COMPONENTS = {
   'SUBSCRIBED_LANGUAGES': SubscribedLanguagesModal,
   'INTERACTION': InteractionModal,
   'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
+  'ALTTEXT': () => Promise.resolve({ default: AltTextModal }),
 };
 
 export default class ModalRoot extends React.PureComponent {

--- a/app/javascript/flavours/glitch/features/video/index.js
+++ b/app/javascript/flavours/glitch/features/video/index.js
@@ -19,6 +19,7 @@ const messages = defineMessages({
   close: { id: 'video.close', defaultMessage: 'Close video' },
   fullscreen: { id: 'video.fullscreen', defaultMessage: 'Full screen' },
   exit_fullscreen: { id: 'video.exit_fullscreen', defaultMessage: 'Exit full screen' },
+  alt: { id: 'video.alt', defaultMessage: 'Show alt-text' },
 });
 
 export const formatTime = secondsNum => {
@@ -124,6 +125,7 @@ class Video extends React.PureComponent {
     volume: PropTypes.number,
     muted: PropTypes.bool,
     componentIndex: PropTypes.number,
+    onOpenAltText: PropTypes.func,
   };
 
   static defaultProps = {
@@ -525,6 +527,11 @@ class Video extends React.PureComponent {
     this.props.onCloseVideo();
   }
 
+  handleAltClick = () => {
+    this.video.pause();
+    this.props.onOpenAltText();
+  }
+
   getFrameRate () {
     if (this.props.frameRate && isNaN(this.props.frameRate)) {
       // The frame rate is returned as a fraction string so we
@@ -658,6 +665,7 @@ class Video extends React.PureComponent {
             </div>
 
             <div className='video-player__buttons right'>
+              {(!fullscreen && alt) && <button type='button' title={intl.formatMessage(messages.alt)} aria-label={intl.formatMessage(messages.alt)} className='player-button alt-button' onClick={this.handleAltClick}><span>ALT</span></button>}
               {(!onCloseVideo && !editable && !fullscreen && !this.props.alwaysVisible) && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
               {(!fullscreen && onOpenVideo) && <button type='button' title={intl.formatMessage(messages.expand)} aria-label={intl.formatMessage(messages.expand)} className='player-button' onClick={this.handleOpenVideo}><Icon id='expand' fixedWidth /></button>}
               {onCloseVideo && <button type='button' title={intl.formatMessage(messages.close)} aria-label={intl.formatMessage(messages.close)} className='player-button' onClick={this.handleCloseVideo}><Icon id='compress' fixedWidth /></button>}

--- a/app/javascript/flavours/glitch/locales/en.json
+++ b/app/javascript/flavours/glitch/locales/en.json
@@ -200,6 +200,7 @@
   "status.react": "React",
   "status.sensitive_toggle": "Click to view",
   "status.uncollapse": "Uncollapse",
+  "video.alt": "Show alt-text",
   "web_app_crash.change_your_settings": "Change your {settings}",
   "web_app_crash.content": "You could try any of the following:",
   "web_app_crash.debug_info": "Debug information",

--- a/app/javascript/flavours/glitch/styles/components/media.scss
+++ b/app/javascript/flavours/glitch/styles/components/media.scss
@@ -43,18 +43,35 @@
   font-weight: 500;
 }
 
-.media-gallery__gifv__label {
-  display: block;
+.media-gallery__label-container {
+  display: flex;
   position: absolute;
-  color: $primary-text-color;
-  background: rgba($base-overlay-background, 0.5);
   bottom: 6px;
   left: 6px;
+  z-index: 1;
+}
+
+.media-gallery__alt__button {
+  color: $primary-text-color;
+  background: rgba($base-overlay-background, 0.5);
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.9;
+  transition: opacity 0.1s ease;
+  line-height: 18px;
+  border: none;
+  border-radius: 2px;
+}
+
+.media-gallery__gifv__label {
+  color: $primary-text-color;
+  background: rgba($base-overlay-background, 0.5);
+  margin-right: 4px;
   padding: 2px 6px;
   border-radius: 2px;
   font-size: 11px;
   font-weight: 600;
-  z-index: 1;
   pointer-events: none;
   opacity: 0.9;
   transition: opacity 0.1s ease;
@@ -64,6 +81,10 @@
 .media-gallery__gifv {
   &:hover {
     .media-gallery__gifv__label {
+      opacity: 1;
+    }
+
+    .media-gallery__alt__label {
       opacity: 1;
     }
   }
@@ -602,6 +623,10 @@
       &:focus {
         color: $white;
       }
+    }
+
+    .alt-button {
+      font-size: 14px;
     }
   }
 

--- a/app/javascript/flavours/glitch/styles/components/modal.scss
+++ b/app/javascript/flavours/glitch/styles/components/modal.scss
@@ -1379,6 +1379,34 @@ img.modal-warning {
   }
 }
 
+.alttext-modal {
+  max-width: 90vw;
+  background: $ui-base-color;
+  border-radius: 8px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: relative;
+  display: block;
+  padding: 20px;
+
+  &__action-bar {
+    display: flex;
+    justify-content: center;
+    padding-top: 20px;
+  }
+
+  &__container {
+    display: flex;
+    max-width: 600px;
+    justify-content: center;
+
+    pre {
+      white-space: pre-wrap;
+      font-size: 17px;
+    }
+  }
+}
+
 .copypaste {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Wraps labels in a div, so alt button shows next to gif label.

Adds new modal which opens by clicking "alt", which shows the alt-text.

Preview:
Modal:
![Screenshot_2023-01-09_03-11-03](https://user-images.githubusercontent.com/117664621/211433468-95c994a6-a540-492e-b096-94a50b344904.png)
![Screenshot_2023-01-09_03-12-43](https://user-images.githubusercontent.com/117664621/211433475-627205e7-1afe-47cb-a889-1b3cdd0fb56e.png)
Toots:
![Screenshot_2023-01-09_03-13-04](https://user-images.githubusercontent.com/117664621/211433506-c11670c4-e948-42bd-9037-a83bbbe4037a.png)
![Screenshot_2023-01-10_01-17-29](https://user-images.githubusercontent.com/117664621/211433638-0f4cf19b-532e-442e-bbe2-384dd00b0350.png)
Detailed view:
![Screenshot_2023-01-10_01-16-58](https://user-images.githubusercontent.com/117664621/211433669-00ccf694-3e69-4dd9-badf-42c75235bc10.png)

Caveats:
~As seen in the last screenshot, the labels don't have the proper left spacing. I'm not sure why.~ Not introduced by these changes, upstream issue.
~The labels are bigger than default, but I think that's actually good.~ Nope, They have the same size.

Only thing I don't like about this is that the button on video and audio files looks misaligned while being aligned with the other buttons. I think this illusion is caused by the hide button/icon appearing to be smaller than it should be.

This was a huge PITA to get working.