### PR TITLE
Remove serialisation of statuses_count

### DIFF
--- a/app/serializers/rest/featured_tag_serializer.rb
+++ b/app/serializers/rest/featured_tag_serializer.rb
@@ -17,10 +17,6 @@ class REST::FeaturedTagSerializer < ActiveModel::Serializer
     object.display_name
   end
 
-  def statuses_count
-    object.statuses_count.to_s
-  end
-
   def last_status_at
     object.last_status_at&.to_date&.iso8601
   end


### PR DESCRIPTION
React throws an invalid prop error when viewing featured tags because statuses_count is expected to be a number, but it's serialised as a string.
~As it's an int in the database and react is expecting a number, this removes the string conversion.~
This removes the serialisation for statuses_count as it seems like it doesn't need to be serialised.

This should not have any negative side effects.
