### PR TITLE
Add additional paths to stylelint ignoreFiles

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -6,6 +6,10 @@ module.exports = {
     'app/javascript/styles/win95.scss',
     'node_modules/**/*',
     'vendor/**/*',
+    'public/packs/**/*',
+    'public/packs-test/**/*',
+    'public/assets/**/*',
+    'coverage/**/*',
   ],
   rules: {
     'at-rule-empty-line-before': null,


### PR DESCRIPTION
These paths exist after running `yarn build:development`, `yarn build:production` or `bundle exec rspec`, which makes stylelint take over 10 minutes to evaluate as all css/scss files in those paths are checked unnecessarily.