### PR TITLE
Enhance domain blocks and profile directory CSS

### DIFF
--- a/app/javascript/flavours/glitch/styles/admin.scss
+++ b/app/javascript/flavours/glitch/styles/admin.scss
@@ -1424,7 +1424,6 @@ a.sparkline {
     overflow: hidden;
     text-overflow: ellipsis;
     word-wrap: break-word;
-    max-height: 21px * 2;
     position: relative;
     font-size: 15px;
     line-height: 21px;

--- a/app/javascript/flavours/glitch/styles/components/about.scss
+++ b/app/javascript/flavours/glitch/styles/components/about.scss
@@ -276,13 +276,11 @@
       h6 {
         color: $secondary-text-color;
         font-size: inherit;
-        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       p {
-        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }


### PR DESCRIPTION
Removes max-height from bios in profile directory.
Removes nowrap from domain blocks.

This was in custom CSS since v4, but I might as well make it part of the code base.


Before:

Profile directory:
![Screenshot_2023-02-01_23-49-53](https://user-images.githubusercontent.com/117664621/216183372-a0a1c3d1-8e06-4e97-ae5a-75b3aa495207.png)

Domain blocks:
![Screenshot_2023-02-01_23-50-17](https://user-images.githubusercontent.com/117664621/216183434-2fca68b2-7379-459c-bba5-a0e5bf828242.png)

After:
Profile directory:
![Screenshot_2023-02-01_23-52-48](https://user-images.githubusercontent.com/117664621/216184076-2fba5351-0f79-4a7f-ac85-4e5dffe8957f.png)

Domain blocks:
![Screenshot_2023-02-01_23-34-23](https://user-images.githubusercontent.com/117664621/216182993-2c20f849-210b-450d-b253-35f0df213a3e.png)
