### PR TITLE
Remove `contain: strict;` from empty-column-indicator

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/columns.scss
+++ b/app/javascript/flavours/glitch/styles/components/columns.scss
@@ -624,9 +624,6 @@ $ui-header-height: 55px;
   flex: 1 1 auto;
   align-items: center;
   justify-content: center;
-  @supports (display: grid) { // hack to fix Chrome <57
-    contain: strict;
-  }
 
   & > span {
     max-width: 500px;


### PR DESCRIPTION
Removes `contain: strict;` from empty-column-indicator.
Not sure what this hack fixed, but that version of Chrome isn't around anymore and it causes issues now.

Before:
(Advanced UI)
![Screenshot_2023-02-15_13-25-58](https://user-images.githubusercontent.com/117664621/219029587-813ce533-264f-44b5-b2c5-2932fb7a4c57.png)
(Simple UI)
![Screenshot_2023-02-15_13-29-50](https://user-images.githubusercontent.com/117664621/219029614-9659a814-71ba-40c9-b3ad-04c6882b217a.png)

After:
(Advanced UI)
![Screenshot_2023-02-15_13-28-53](https://user-images.githubusercontent.com/117664621/219029742-60b73bdc-b31f-4b7a-a82a-ef0754ff8c7b.png)
(Simple UI)
![Screenshot_2023-02-15_13-30-27](https://user-images.githubusercontent.com/117664621/219029755-a4567b16-fcb2-419a-bed3-d02b5b3bd1e5.png)
