### PR TITLE
Add `reactions_count` to status_stats

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -329,6 +329,10 @@ class Status < ApplicationRecord
     status_stat&.favourites_count || 0
   end
 
+  def reactions_count
+    status_stat&.reactions_count || 0
+  end
+
   def increment_count!(key)
     update_status_stat!(key => public_send(key) + 1)
   end

--- a/app/models/status_reaction.rb
+++ b/app/models/status_reaction.rb
@@ -37,7 +37,7 @@ class StatusReaction < ApplicationRecord
   def increment_cache_counters
     status.increment_count!(:reactions_count)
   end
-  
+
   def decrement_cache_counters
     return if association(:status).loaded? && status.marked_for_destruction?
 

--- a/app/models/status_stat.rb
+++ b/app/models/status_stat.rb
@@ -9,6 +9,7 @@
 #  replies_count    :bigint(8)        default(0), not null
 #  reblogs_count    :bigint(8)        default(0), not null
 #  favourites_count :bigint(8)        default(0), not null
+#  reactions_count  :bigint(8)        default(0), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #
@@ -28,6 +29,10 @@ class StatusStat < ApplicationRecord
 
   def favourites_count
     [attributes['favourites_count'], 0].max
+  end
+
+  def reactions_count
+    [attributes['reactions_count'], 0].max
   end
 
   private

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -6,7 +6,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :language,
              :uri, :url, :replies_count, :reblogs_count,
-             :favourites_count, :edited_at
+             :favourites_count, :reactions_count, :edited_at
 
   attribute :favourited, if: :current_user?
   attribute :reblogged, if: :current_user?

--- a/db/migrate/20230222143034_add_reactions_count.rb
+++ b/db/migrate/20230222143034_add_reactions_count.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReactionsCount < ActiveRecord::Migration[6.1]
   def change
     add_column :status_stats, :reactions_count, :bigint, null: false, default: 0

--- a/db/migrate/20230222143034_add_reactions_count.rb
+++ b/db/migrate/20230222143034_add_reactions_count.rb
@@ -1,0 +1,5 @@
+class AddReactionsCount < ActiveRecord::Migration[6.1]
+  def change
+    add_column :status_stats, :reactions_count, :bigint, null: false, default: 0
+  end
+end

--- a/db/migrate/20230222145758_backfill_reactions_count.rb
+++ b/db/migrate/20230222145758_backfill_reactions_count.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BackfillReactionsCount < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 

--- a/db/migrate/20230222145758_backfill_reactions_count.rb
+++ b/db/migrate/20230222145758_backfill_reactions_count.rb
@@ -1,0 +1,15 @@
+class BackfillReactionsCount < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute <<-SQL.squish
+        INSERT INTO status_stats (status_id, reactions_count, updated_at, created_at)
+        SELECT status_id, count(status_id), greatest(updated_at) AS updated_at, least(created_at) AS created_at
+        FROM status_reactions GROUP BY status_id, updated_at, created_at
+        ON CONFLICT (status_id) DO UPDATE
+        SET reactions_count = EXCLUDED.reactions_count, updated_at = greatest(status_stats.updated_at, EXCLUDED.updated_at)
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -961,6 +961,7 @@ ActiveRecord::Schema.define(version: 2023_05_05_100107) do
     t.bigint "replies_count", default: 0, null: false
     t.bigint "reblogs_count", default: 0, null: false
     t.bigint "favourites_count", default: 0, null: false
+    t.bigint "reactions_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["status_id"], name: "index_status_stats_on_status_id", unique: true

--- a/spec/controllers/api/v1/statuses/reactions_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reactions_controller_spec.rb
@@ -26,6 +26,10 @@ describe Api::V1::Statuses::ReactionsController do
           expect(response).to have_http_status(200)
         end
 
+        it 'updates the reactions count' do
+          expect(status.reactions.count).to eq 1
+        end
+
         it 'updates the reacted attribute' do
           expect(user.account.reacted?(status, '👍')).to be true
         end
@@ -34,6 +38,7 @@ describe Api::V1::Statuses::ReactionsController do
           hash_body = body_as_json
 
           expect(hash_body[:id]).to eq status.id.to_s
+          expect(hash_body[:reactions_count]).to eq 1
           expect(hash_body[:reactions]).to_not be_empty
           expect(hash_body[:reactions][0][:count]).to be 1
           expect(hash_body[:reactions][0][:me]).to be true
@@ -63,6 +68,10 @@ describe Api::V1::Statuses::ReactionsController do
           expect(response).to have_http_status(200)
         end
 
+        it 'updates the reactions count' do
+          expect(status.reactions.count).to eq 0
+        end
+
         it 'updates the reacted attribute' do
           expect(user.account.reacted?(status, '👍')).to be false
         end
@@ -71,6 +80,7 @@ describe Api::V1::Statuses::ReactionsController do
           hash_body = body_as_json
 
           expect(hash_body[:id]).to eq status.id.to_s
+          expect(hash_body[:reactions_count]).to eq 0
           expect(hash_body[:reactions]).to be_empty
         end
       end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -194,6 +194,22 @@ RSpec.describe Status do
     end
   end
 
+  describe '#reactions_count' do
+    it 'is the number of reactions' do
+      Fabricate(:status_reaction, account: bob, status: subject)
+      Fabricate(:status_reaction, account: alice, status: subject)
+
+      expect(subject.reactions_count).to eq 2
+    end
+
+    it 'is decremented when reaction is removed' do
+      reaction = Fabricate(:status_reaction, account: bob, status: subject)
+      expect(subject.reactions_count).to eq 1
+      reaction.destroy
+      expect(subject.reactions_count).to eq 0
+    end
+  end
+
   describe '#proper' do
     it 'is itself for original statuses' do
       expect(subject.proper).to eq subject


### PR DESCRIPTION
Ref #21 

Adds a new column to status_stats containing the amount of reactions.

Adds new migration to backfill `reactions_count` from status_reactions table.