### PR TITLE
Remove public access to streaming API

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -409,17 +409,6 @@ const startWorker = async (workerId) => {
     }
   };
 
-  const PUBLIC_CHANNELS = [
-    'public',
-    'public:media',
-    'public:local',
-    'public:local:media',
-    'public:remote',
-    'public:remote:media',
-    'hashtag',
-    'hashtag:local',
-  ];
-
   /**
    * @param {any} req
    * @param {string} channelName
@@ -427,12 +416,6 @@ const startWorker = async (workerId) => {
    */
   const checkScopes = (req, channelName) => new Promise((resolve, reject) => {
     log.silly(req.requestId, `Checking OAuth scopes for ${channelName}`);
-
-    // When accessing public channels, no scopes are needed
-    if (PUBLIC_CHANNELS.includes(channelName)) {
-      resolve();
-      return;
-    }
 
     // The `read` scope has the highest priority, if the token has it
     // then it can access all streams


### PR DESCRIPTION
Every query to the streaming API now requires an access token with at least `read:statuses` scope, aside from notifications, which still needs `read:notifications`

This API is almost exclusively used by scrapers and legit clients should send a token anyway.