### PR TITLE
Add background to code blocks

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/modal.scss
+++ b/app/javascript/flavours/glitch/styles/components/modal.scss
@@ -613,6 +613,10 @@
     color: $inverted-text-color;
   }
 
+  .status__content code {
+    color: $primary-text-color;
+  }
+
   .status__content__spoiler-link {
     color: $primary-text-color;
     background: $ui-primary-color;

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -160,6 +160,23 @@
     ol {
       list-style-type: decimal;
     }
+
+    code {
+      background: darken($ui-base-color, 4%);
+      border-radius: 3px;
+      padding: 0 0.3em;
+    }
+
+    pre {
+      background: darken($ui-base-color, 4%);
+      border-radius: 3px;
+      padding: 0.5em;
+    }
+
+    pre code {
+      // prevent padding of code tags inside pre
+      padding: 0;
+    }
   }
 
   a {
@@ -434,6 +451,11 @@
 
       a:hover {
         text-decoration: none;
+      }
+
+      pre,
+      code {
+        padding: 0;
       }
     }
 


### PR DESCRIPTION
Adds background and slight padding to code blocks for better visibility.
Inspired by upstream/#2104

Advanced UI:
![Screenshot_2023-03-02_20-29-25](https://user-images.githubusercontent.com/117664621/222533626-e530b571-82c1-4a66-86e2-2fd330d43f93.png)
![Screenshot_2023-03-02_20-30-18](https://user-images.githubusercontent.com/117664621/222533632-8282dc59-5317-4d90-bc10-c2903cfecfaa.png)

Simple UI:
![Screenshot_2023-03-02_20-28-30](https://user-images.githubusercontent.com/117664621/222533723-804e8ce7-b11a-4a32-b6fc-007479ae6bed.png)
![Screenshot_2023-03-02_20-27-47](https://user-images.githubusercontent.com/117664621/222533733-10d65bbd-5e89-4af7-adb1-f4fad04761b0.png)
