### PR TITLE
SyntaxHighlight: Don't allow arbitrary data

### DIFF
--- a/app/lib/advanced_text_formatter.rb
+++ b/app/lib/advanced_text_formatter.rb
@@ -8,6 +8,8 @@ class AdvancedTextFormatter < TextFormatter
     end
 
     def block_code(code, language)
+      # Check that language only contains allowed characters when not nil
+      language = language.match(/^[a-zA-Z0-9.#+-]+$/) unless language.nil?
       # Looks wrong, but sets title to language correctly. One downside is, it adds an empty attribute when no lang specified.
       <<~HTML
         <pre><code data-codelang="#{language}">#{ERB::Util.h(code).gsub("\n", '<br/>')}</code></pre>

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -79,7 +79,7 @@ class Sanitize
         'blockquote' => %w(cite),
         'ol'         => %w(start reversed),
         'li'         => %w(value),
-        'code'       => [:data],
+        'code'       => %w(data-codelang),
       },
 
       add_attributes: {


### PR DESCRIPTION
Ref: #20 
Technically security.

Changes sanitation to only allow `data-codelang` attribute on code blocks.
Checks that `language` only contains allowed characters.