### PR TITLE
Add option to allow toots with sensitive media to trend

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -32,6 +32,7 @@ class Form::AdminSettings
     trends_as_landing_page
     trendable_by_default
     trending_status_cw
+    trending_status_sensitive
     show_application
     show_domain_blocks
     show_domain_blocks_rationale
@@ -69,6 +70,7 @@ class Form::AdminSettings
     trends_as_landing_page
     trendable_by_default
     trending_status_cw
+    trending_status_sensitive
     noindex
     norss
     require_invite_text

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -91,7 +91,7 @@ class Trends::Statuses < Trends::Base
   private
 
   def eligible?(status)
-    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && (status.spoiler_text.blank? || Setting.trending_status_cw) && !status.sensitive? && !status.reply? && valid_locale?(status.language)
+    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && (status.spoiler_text.blank? || Setting.trending_status_cw) && (!status.sensitive? || Setting.trending_status_sensitive) && !status.reply? && valid_locale?(status.language)
   end
 
   def calculate_scores(statuses, at_time)

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -24,11 +24,14 @@
   .fields-group
     = f.input :trending_status_cw, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_cw.title'), hint: t('admin.settings.trending_status_cw.desc_html'), glitch_only: true
 
+  .fields-group
+    = f.input :trending_status_sensitive, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_sensitive.title'), hint: t('admin.settings.trending_status_sensitive.desc_html'), glitch_only: true
+
   %h4= t('admin.settings.discovery.public_timelines')
 
   .fields-group
     = f.input :timeline_preview, as: :boolean, wrapper: :with_label
-  
+
   %h4= t('admin.settings.discovery.search')
 
   .fields-group

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -73,6 +73,9 @@ en:
       trending_status_cw:
         desc_html: When trending toots are enabled, allow toots with Content Warnings to be eligible. Changes to this setting are not retroactive.
         title: Allow toots with Content Warnings to trend
+      trending_status_sensitive:
+        desc_html: When trending toots are enable, allow toots with sensitive media to be elibible. Changes to this setting are not retroactive.
+        title: Allow toots with sensitive media to trend
   appearance:
     localization:
       glitch_guide_link: https://crowdin.com/project/glitch-soc

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,6 +43,7 @@ defaults: &defaults
   trends_as_landing_page: false
   trendable_by_default: false
   trending_status_cw: true
+  trending_status_sensitive: true
   crop_images: true
   visible_reactions: 6
   notification_emails:


### PR DESCRIPTION
Makes toots with sensitive media attachments eligible to trend.
Enabled by default