### PR TITLE
Add polyam_only label to some settings

### DIFF
--- a/app/javascript/flavours/glitch/styles/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/accounts.scss
@@ -208,7 +208,8 @@
 .account-role,
 .simple_form .recommended,
 .simple_form .not_recommended,
-.simple_form .glitch_only {
+.simple_form .glitch_only,
+.simple_form .polyam_only {
   display: inline-block;
   padding: 4px 6px;
   cursor: default;
@@ -243,6 +244,12 @@
   color: lighten($warning-red, 12%);
   background-color: rgba(lighten($warning-red, 12%), 0.1);
   border-color: rgba(lighten($warning-red, 12%), 0.5);
+}
+
+.simple_form .polyam_only {
+  color: lighten($warning-red, 18%);
+  background-color: rgba(lighten($warning-red, 18%), 0.1);
+  border-color: rgba(lighten($warning-red, 18%), 0.5);
 }
 
 .account__header__fields {

--- a/app/javascript/flavours/glitch/styles/forms.scss
+++ b/app/javascript/flavours/glitch/styles/forms.scss
@@ -105,7 +105,8 @@ code {
 
       .recommended,
       .not_recommended,
-      .glitch_only {
+      .glitch_only,
+      .polyam_only {
         position: absolute;
         margin: 0 4px;
         margin-top: -2px;

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -204,7 +204,8 @@
 .account-role,
 .simple_form .recommended,
 .simple_form .not_recommended,
-.simple_form .glitch_only {
+.simple_form .glitch_only,
+.simple_form .polyam_only {
   display: inline-block;
   padding: 4px 6px;
   cursor: default;
@@ -239,6 +240,12 @@
   color: lighten($warning-red, 12%);
   background-color: rgba(lighten($warning-red, 12%), 0.1);
   border-color: rgba(lighten($warning-red, 12%), 0.5);
+}
+
+.simple_form .polyam_only {
+  color: lighten($warning-red, 18%);
+  background-color: rgba(lighten($warning-red, 18%), 0.1);
+  border-color: rgba(lighten($warning-red, 18%), 0.5);
 }
 
 .account__header__fields {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -105,7 +105,8 @@ code {
 
       .recommended,
       .not_recommended,
-      .glitch_only {
+      .glitch_only,
+      .polyam_only {
         position: absolute;
         margin: 0 4px;
         margin-top: -2px;

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -28,7 +28,7 @@
           = t('admin.site_uploads.delete')
 
   .fields-group
-    = f.input :publish_button_text, wrapper: :with_block_label
+    = f.input :publish_button_text, wrapper: :with_block_label, polyam_only: true
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -25,7 +25,7 @@
     = f.input :trending_status_cw, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_cw.title'), hint: t('admin.settings.trending_status_cw.desc_html'), glitch_only: true
 
   .fields-group
-    = f.input :trending_status_sensitive, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_sensitive.title'), hint: t('admin.settings.trending_status_sensitive.desc_html'), glitch_only: true
+    = f.input :trending_status_sensitive, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_sensitive.title'), hint: t('admin.settings.trending_status_sensitive.desc_html'), polyam_only: true
 
   %h4= t('admin.settings.discovery.public_timelines')
 
@@ -35,7 +35,7 @@
   %h4= t('admin.settings.discovery.search')
 
   .fields-group
-    = f.input :search_preview, as: :boolean, wrapper: :with_label, glitch_only: true
+    = f.input :search_preview, as: :boolean, wrapper: :with_label, polyam_only: true
 
   .fields-group
     = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')
@@ -43,7 +43,7 @@
   %h4= t('admin.settings.discovery.rss')
 
   .fields-group
-    = f.input :norss, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_norss.title'), hint: t('admin.settings.default_norss.desc_html'), glitch_only: true
+    = f.input :norss, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_norss.title'), hint: t('admin.settings.default_norss.desc_html'), polyam_only: true
 
   %h4= t('admin.settings.discovery.publish_statistics')
 

--- a/app/views/admin/settings/other/show.html.haml
+++ b/app/views/admin/settings/other/show.html.haml
@@ -20,7 +20,7 @@
     = f.input :show_replies_in_public_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_replies_in_public_timelines.title'), hint: t('admin.settings.show_replies_in_public_timelines.desc_html'), glitch_only: true
 
   .fields-group
-    = f.input :show_application, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_show_application.title'), hint: t('admin.settings.default_show_application.desc_html'), glitch_only: true
+    = f.input :show_application, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_show_application.title'), hint: t('admin.settings.default_show_application.desc_html'), polyam_only: true
 
   .fields-group
     = f.input :outgoing_spoilers, wrapper: :with_label, label: t('admin.settings.outgoing_spoilers.title'), hint: t('admin.settings.outgoing_spoilers.desc_html'), glitch_only: true

--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -31,7 +31,7 @@
   %h4= t 'notifications.other_settings'
 
   .fields-group
-    = f.input :setting_notification_sound, collection: NotificationSounds.instance.names, label_method: lambda { |sound| t("sounds.#{sound}", default: sound) }, wrapper: :with_label, include_blank: false, glitch_only: true
+    = f.input :setting_notification_sound, collection: NotificationSounds.instance.names, label_method: lambda { |sound| t("sounds.#{sound}", default: sound) }, wrapper: :with_label, include_blank: false, polyam_only: true
 
   .fields-group
     = f.simple_fields_for :interactions, hash_to_object(current_user.settings.interactions) do |ff|

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -27,9 +27,18 @@ module GlitchOnlyComponent
   end
 end
 
+module PolyamOnlyComponent
+  def polyam_only(_wrapper_options = nil)
+    return unless options[:polyam_only]
+    options[:label_text] = ->(raw_label_text, _required_label_text, _label_present) { safe_join([raw_label_text, ' ', content_tag(:span, I18n.t('simple_form.polyam_only'), class: 'polyam_only')]) }
+    nil
+  end
+end
+
 SimpleForm.include_component(AppendComponent)
 SimpleForm.include_component(RecommendedComponent)
 SimpleForm.include_component(GlitchOnlyComponent)
+SimpleForm.include_component(PolyamOnlyComponent)
 
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a
@@ -88,6 +97,7 @@ SimpleForm.setup do |config|
     b.wrapper tag: :div, class: :label_input do |ba|
       ba.optional :recommended
       ba.optional :glitch_only
+      ba.optional :polyam_only
       ba.use :label
 
       ba.wrapper tag: :div, class: :label_input__wrapper do |bb|
@@ -109,6 +119,7 @@ SimpleForm.setup do |config|
 
   config.wrappers :with_block_label, class: [:input, :with_block_label], hint_class: :field_with_hint, error_class: :field_with_errors do |b|
     b.use :html5
+    b.optional :polyam_only
     b.use :label
     b.use :hint, wrap_with: { tag: :span, class: :hint }
     b.use :input, wrap_with: { tag: :div, class: :label_input }

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -2,6 +2,7 @@
 en:
   simple_form:
     glitch_only: glitch-soc
+    polyam_only: polyam-glitch
     hints:
       defaults:
         fields: You can have up to %{count} items displayed as a table on your profile


### PR DESCRIPTION
Same reason as why upstream added it:
Making it clear these are specific to polyam-glitch and avoid reporting issues upstream.

Additionally enabled it for block label elements.
Changed some settings to have polyam-glitch instead of glitch-soc label.