### PR TITLE
Add Oatstodon theme

### DIFF
--- a/app/javascript/flavours/glitch/styles/oatstodon.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon.scss
@@ -1,0 +1,3 @@
+@import 'oatstodon/variables';
+@import 'index';
+@import 'oatstodon/diff';

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -185,21 +185,34 @@ nav,
 // columns
 .column-header,
 .column-back-button,
-.navigation-panel .column-link:nth-child(1),
-.navigation-panel .column-link:nth-child(10),
 .navigation-bar {
   border-radius: $border-radius $border-radius 0 0;
 }
 
 .column > .scrollable,
-.getting-started,
-.navigation-panel .column-link:nth-child(8),
-.navigation-panel .column-link:nth-child(11) {
+.getting-started {
   border-radius: 0 0 $border-radius $border-radius;
 }
 
 .column-link {
   background: $ui-base-color;
+
+  // Applies bottom corners roundening to Lists and App settings
+  &:nth-last-of-type(1),
+  &:nth-of-type(10) {
+    border-radius: 0 0 $border-radius $border-radius;
+  }
+
+  // Applies top corners roundening to Home and Preferences
+  &:nth-of-type(1),
+  &:nth-of-type(11) {
+    border-radius: $border-radius $border-radius 0 0;
+  }
+
+
+  &:hover {
+    color: $white;
+  }
 }
 
 .column-link__badge {

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -426,6 +426,14 @@ nav,
   transition: max-height 1s;
   background: $background-brighter;
 
+  &:hover {
+    max-height: 100%;
+  }
+
+  &__reply-to {
+    color: $secondary-text-color;
+  }
+
   // Fix colors
   &__header > .account.small {
     color: $primary-text-color;
@@ -440,16 +448,6 @@ nav,
       border-left: 3px solid $darker-text-color;
     }
   }
-}
-
-.reply-indicator:hover {
-  max-height: 100%;
-}
-
-.reply-indicator::before {
-  content: 'Replying to:';
-  font-size: 12px;
-  color: $secondary-text-color;
 }
 
 // emoji picker

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -858,6 +858,12 @@ a.mention.hashtag {
       background: $background-brighter;
     }
   }
+
+  .content-wrapper,
+  .sidebar-wrapper--empty {
+    background: $background;
+  }
+
   .sidebar {
     ul a {
       background: $background-brighter;

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -210,11 +210,15 @@ nav,
   }
 
 
-  &:hover {
+  &:hover,
+  &:active,
+  &:focus {
+    background: $ui-base-color;
     color: $white;
   }
 }
 
+.icon-with-badge__badge,
 .column-link__badge {
   background-color: $accent;
   animation-name: flash;
@@ -226,6 +230,7 @@ nav,
 .column-header,
 .column-header__button,
 .column-header__button.active,
+.column-header__button.active:hover,
 .column-header__back-button,
 .column-header__collapsible-inner {
   background: $background-brighter;

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -1,0 +1,731 @@
+html {
+  scrollbar-color: $background-brighter rgba(0, 0, 0, 10%);
+}
+
+body {
+  background-color: $app-background;
+}
+
+hr {
+  opacity: 0;
+}
+
+.button {
+  background-color: $accent;
+
+  &:active,
+  &:hover,
+  &:focus {
+    background-color: $accent-bright;
+  }
+}
+
+.icon-button {
+  &.inverted {
+    color: $accent-secondary;
+
+    &:active,
+    &:hover,
+    &:focus {
+      background: rgba($accent-secondary, 0.25);
+      color: $accent-secondary;
+    }
+  }
+
+  &.star-icon.active {
+    color: $accent;
+  }
+}
+
+.text-icon-button {
+  color: $accent-secondary;
+
+  &:active,
+  &:hover,
+  &:focus {
+    color: $accent-secondary;
+    background: rgba($accent-secondary, 0.25);
+  }
+}
+
+.status__content__spoiler-link {
+  background: $accent-secondary;
+
+  &:hover {
+    background: lighten($accent-secondary, 3%);
+  }
+}
+
+.status__content {
+  .status__content__spoiler-link {
+    background: $accent-secondary;
+
+    &:focus,
+    &:hover {
+      background: lighten($accent-secondary, 3%);
+    }
+  }
+}
+
+.status {
+  border-bottom: none;
+
+  &.light {
+    .status__content {
+      color: $primary-text-color;
+    }
+
+    .display-name {
+      strong {
+        color: $primary-text-color;
+      }
+    }
+  }
+
+}
+
+.dropdown-menu {
+  background: $ui-base-color;
+
+  &__container__header {
+    color: $primary-text-color;
+  }
+
+  &__item {
+    color: $primary-text-color;
+
+    a,
+    button {
+      background: $ui-base-color;
+
+      &:hover,
+      &:active,
+      &:focus {
+        color: $primary-text-color;
+      }
+    }
+  }
+
+  &__separator {
+    opacity: 0;
+  }
+
+  // Do the following two even work?
+  &__arrow {
+    border-bottom-color: $ui-base-color;
+  }
+
+  &__arrow.top {
+    border-top-color: $ui-base-color;
+  }
+}
+
+a.mention,
+a.mention.hashtag {
+  color: $accent;
+}
+
+// glitch-soc
+
+.glitch.local-settings {
+  // fixes white outline in navigation
+  background: $ui-base-color;
+
+  &__page {
+    background: $background-brighter;
+    border-bottom: none;
+    color: $primary-text-color;
+  }
+
+  &__navigation,
+  &__navigation__item {
+    background: $ui-base-color;
+    color: $primary-text-color;
+  }
+
+  &__navigation__item {
+    border-top: none;
+    border-bottom: none;
+
+    &:hover {
+      background: $background-brighter;
+    }
+  }
+}
+
+// roundening
+
+// compose
+.drawer > div,
+nav,
+.search,
+.drawer__header a,
+.drawer--header a,
+.search__input {
+  border-radius: $border-radius;
+}
+
+.search-popout {
+  background: $ui-base-color;
+  color: $primary-text-color;
+
+  em {
+    color: $accent;
+  }
+}
+
+.drawer--header a {
+  &:hover,
+  &:focus {
+    background: rgba($accent-secondary, 0.1);
+    color: $accent;
+  }
+}
+
+// columns
+.column-header,
+.column-back-button,
+.navigation-panel .column-link:nth-child(1),
+.navigation-panel .column-link:nth-child(10),
+.navigation-bar {
+  border-radius: $border-radius $border-radius 0 0;
+}
+
+.column > .scrollable,
+.getting-started,
+.navigation-panel .column-link:nth-child(8),
+.navigation-panel .column-link:nth-child(11) {
+  border-radius: 0 0 $border-radius $border-radius;
+}
+
+.column-link {
+  background: $ui-base-color;
+}
+
+.column-link__badge {
+  background-color: $accent;
+  animation-name: flash;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-direction: alternate-reverse;
+}
+
+.column-header,
+.column-header__button,
+.column-header__button.active,
+.column-header__back-button,
+.column-header__collapsible-inner {
+  background: $background-brighter;
+  border-bottom: none;
+}
+
+.column-header {
+  .active,
+  &__icon {
+    text-shadow: 0 0 10px rgba($accent, 0.4);
+  }
+
+  &__wrapper {
+    &:active {
+      box-shadow: 0 1px 0 rgba($accent, 0.3);
+
+      &::before {
+        background: radial-gradient(ellipse, rgba($accent, 0.23) 0%, rgba($accent, 0) 60%);
+      }
+    }
+  }
+}
+
+.notification__filter-bar {
+  background: $background-brighter;
+  border-bottom: none;
+
+  & > button {
+    background: $background-brighter;
+    border-bottom: none;
+  }
+
+  a.active {
+    color: $accent;
+
+    &::before,
+    &::after {
+      border-color: transparent transparent $ui-base-color;
+    }
+  }
+
+  button.active {
+    border-bottom: 3px solid $accent;
+    color: $accent;
+
+    &::after,
+    &::before {
+      opacity: 0;
+      border-color: transparent transparent $ui-base-color;
+    }
+  }
+
+  button:not(.active):hover {
+    top: -3px;
+  }
+}
+
+.notification__favourite-icon-wrapper .fa.star-icon {
+  color: $accent;
+}
+
+.account {
+  &__action-bar,
+  &__action-bar__tab {
+    border: none;
+  }
+
+  &__disclaimer,
+  &__action-bar-links {
+    background: $background-brighter;
+  }
+
+  &__header {
+    &__bar {
+      border-top: none;
+      border-bottom: none;
+      background: $background-brighter;
+    }
+
+    &__fields,
+    &__fields dl,
+    &__bio &__fields {
+      border-top: none;
+      border-bottom: none;
+    }
+
+    &__fields dt {
+      color: $primary-text-color;
+    }
+  }
+
+  &__section-headline {
+    background: $background-brighter;
+    border-bottom: none;
+
+    a.active {
+      color: $accent;
+
+      &::before,
+      &::after {
+        border-color: transparent transparent $ui-base-color;
+      }
+    }
+
+    button.active {
+      color: $accent;
+
+      &::before,
+      &::after {
+        border-color: transparent transparent $ui-base-color;
+      }
+    }
+  }
+}
+
+// compose
+
+.drawer {
+  &__inner,
+  &--header {
+    background: $ui-base-color;
+    color: $primary-text-color;
+  }
+}
+
+.drawer__inner__mastodon {
+  background: $ui-base-color url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 234.80078 31.757813" width="234.80078" height="31.757812"><path d="M19.599609 0c-1.05 0-2.10039.375-2.90039 1.125L0 16.925781v14.832031h234.80078V17.025391l-16.5-15.900391c-1.6-1.5-4.20078-1.5-5.80078 0l-13.80078 13.099609c-1.6 1.5-4.19883 1.5-5.79883 0L179.09961 1.125c-1.6-1.5-4.19883-1.5-5.79883 0L159.5 14.224609c-1.6 1.5-4.20078 1.5-5.80078 0L139.90039 1.125c-1.6-1.5-4.20078-1.5-5.80078 0l-13.79883 13.099609c-1.6 1.5-4.20078 1.5-5.80078 0L100.69922 1.125c-1.600001-1.5-4.198829-1.5-5.798829 0l-13.59961 13.099609c-1.6 1.5-4.200781 1.5-5.800781 0L61.699219 1.125c-1.6-1.5-4.198828-1.5-5.798828 0L42.099609 14.224609c-1.6 1.5-4.198828 1.5-5.798828 0L22.5 1.125C21.7.375 20.649609 0 19.599609 0z" fill="#{hex-color($ui-base-color)}"/></svg>') no-repeat bottom / 100% auto;
+}
+
+@for $i from 0 through 3 {
+  .mbstobon-#{$i} .drawer__inner__mastodon {
+    @if $i == 3 {
+      background: url('~flavours/glitch/images/wave-drawer.png') no-repeat bottom / 100% auto, $ui-base-color;
+    } @else {
+      background: url('~flavours/glitch/images/wave-drawer-glitched.png') no-repeat bottom / 100% auto, $ui-base-color;
+    }
+
+    & > .mastodon {
+      background: url("~flavours/glitch/images/mbstobon-ui-#{$i}.png") no-repeat left bottom / contain;
+
+      @if $i != 3 {
+        filter: contrast(50%) brightness(50%);
+      }
+    }
+  }
+}
+
+.compose-form {
+  &__buttons-wrapper {
+    background: $background-brighter;
+  }
+
+  &__poll-wrapper select {
+    background-color: $background-brighter;
+    color: $primary-text-color;
+  }
+
+  &__modifiers {
+    background: $background-brighter;
+    color: $primary-text-color;
+  }
+
+  .spoiler-input__input,
+  .autosuggest-textarea label .autosuggest-textarea__textarea,
+  .poll__option input,
+  &__autosuggest-wrapper {
+    background: $background-brighter;
+    color: $primary-text-color;
+  }
+
+  // Restore default color for better readability
+  &__upload {
+    .icon-button {
+      color: $classic-secondary-color;
+
+      &:hover,
+      &:active,
+      &:focus {
+        color: lighten($classic-secondary-color, 7%)
+      }
+    }
+  }
+}
+
+.character-counter {
+  color: $primary-text-color;
+}
+
+.privacy-dropdown {
+  &__dropdown,
+  &.active .privacy-dropdown__value {
+    background: $background-brighter;
+    color: $primary-text-color;
+  }
+}
+
+.privacy-dropdown__option {
+  // icon color
+  color: $primary-text-color;
+
+  .privacy-dropdown__option__content {
+    strong {
+      color: $primary-text-color;
+    }
+  }
+}
+
+.reply-indicator {
+  max-height: 38px;
+  overflow-y: hidden;
+  transition: max-height 1s;
+  background: $background-brighter;
+
+  // Fix colors
+  &__header > .account.small {
+    color: $primary-text-color;
+  }
+
+  &__content {
+    color: $primary-text-color;
+
+    // NOTE: This should be fixed with glitch-soc rich text scss refactor
+    blockquote {
+      color: $darker-text-color;
+      border-left: 3px solid $darker-text-color;
+    }
+  }
+}
+
+.reply-indicator:hover {
+  max-height: 100%;
+}
+
+.reply-indicator::before {
+  content: 'Replying to:';
+  font-size: 12px;
+  color: $secondary-text-color;
+}
+
+// emoji picker
+
+.emoji-mart-scroll,
+.emoji-mart-search,
+.emoji-mart-category-label > span,
+.emoji-picker-dropdown__menu,
+.emoji-picker-dropdown__modifiers__menu {
+  background: $ui-base-color;
+  color: $primary-text-color;
+}
+
+.emoji-mart-search {
+  input {
+    background: $background-brighter;
+    color: $primary-text-color;
+  }
+}
+
+.emoji-picker-dropdown__modifiers__menu {
+  button {
+    &:hover {
+      background: $background-brighter;
+    }
+  }
+}
+
+.emoji-mart-bar:first-child {
+  background: $background-brighter;
+  border-bottom: none;
+}
+
+.emoji-mart-anchor-bar {
+  background: $accent;
+}
+
+.emoji-mart-anchor {
+  color: $accent-secondary;
+
+  &:hover {
+    color: darken($accent-secondary, 4%);
+  }
+}
+
+// Copied from glitch-soc style. Doesn't get applied with above rule otherwise for some reason.
+.emoji-mart-anchor-selected {
+  color: $highlight-text-color;
+
+  &:hover {
+    color: darken($highlight-text-color, 4%);
+  }
+}
+
+// language dropdown
+
+.language-dropdown {
+  &__dropdown {
+    &__results {
+      &__item {
+        color: $primary-text-color;
+
+        &:focus,
+        &:active,
+        &:hover {
+          background: lighten($ui-base-color, 4%);
+        }
+      }
+    }
+  }
+}
+
+// modals
+
+.mute-modal,
+.block-modal,
+.boost-modal,
+.confirmation-modal {
+  background: lighten($ui-base-color, 8%);
+  color: $primary-text-color;
+
+  &__action-bar {
+    background: $ui-base-color;
+
+    & > div {
+      color: $darker-text-color;
+    }
+  }
+
+  &__cancel-button,
+  &__secondary-button {
+    color: $primary-text-color;
+    background: darken($ui-highlight-color, 3%);
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: $primary-text-color;
+      background: $ui-highlight-color;
+    }
+  }
+
+  .setting-toggle__label {
+    color: $primary-text-color;
+  }
+
+  .status__content__spoiler-link {
+    color: $inverted-text-color;
+  }
+}
+
+.actions-modal {
+  background: lighten($ui-base-color, 8%);
+  color: $primary-text-color;
+
+  .status {
+    background: $ui-base-color;
+  }
+
+  ul {
+    li:not(:empty) {
+      a {
+        color: $primary-text-color;
+      }
+    }
+  }
+}
+
+.compare-history-modal {
+  background: $ui-base-color;
+  color: $primary-text-color;
+
+  .status__content {
+    color: $primary-text-color;
+
+    hr {
+      background-color: $ui-base-lighter-color;
+    }
+  }
+}
+
+// media description modal
+.report-modal {
+  background: lighten($ui-base-color, 8%);
+
+  &__target {
+    background-color: lighten($ui-base-color, 8%);
+    color: $primary-text-color
+  }
+
+  &__comment {
+    background: lighten($ui-base-color, 8%);
+    color: $primary-text-color;
+
+    .setting-text {
+      background: $background-brighter;
+      color: $primary-text-color;
+
+      &:hover,
+      &:focus,
+      &:active {
+        color: $primary-text-color;
+      }
+    }
+
+    .setting-text-label {
+      color: $primary-text-color;
+    }
+  }
+}
+
+// Also applies to filter-modal
+.report-dialog-modal {
+  background: lighten($ui-base-color, 8%);
+  color: $primary-text-color;
+
+  &__lead {
+    color: $darker-text-color;
+
+    a {
+      color: $ui-highlight-color;
+    }
+  }
+
+  &__statuses {
+    background: $ui-base-color;
+    color: $primary-text-color;
+  }
+
+  &__textarea {
+    background: $background-brighter;
+    color: $primary-text-color;
+  }
+
+  .status__content,
+  .status__content p {
+    color: $primary-text-color;
+  }
+
+  .status__content__spoiler-link {
+    color: $inverted-text-color;
+    background: $accent-secondary;
+
+    &:hover {
+      background: lighten($accent-secondary, 3%);
+    }
+  }
+
+  .poll__option.dialog-option {
+    & > .poll__option__text {
+      color: $primary-text-color;
+
+      strong {
+        color: $primary-text-color;
+      }
+
+      .detailed-status__display-name {
+        color: $darker-text-color;
+      }
+    }
+  }
+
+  .dialog-option .poll__input {
+    border-color: $primary-text-color;
+
+    &:active,
+    &:focus,
+    &:hover {
+      border-color: lighten($ui-base-color, 33%);
+    }
+
+    &.active {
+      border-color: $primary-text-color;
+    }
+  }
+
+  .button.button-secondary {
+    color: $primary-text-color;
+
+    &:hover,
+    &:focus,
+    &:active {
+      border-color: darken($primary-text-color, 15%);
+      color: darken($primary-text-color, 15%);
+    }
+  }
+
+  // specific to filter-modal
+
+  .emoji-mart-scroll,
+  .emoji-mart-search {
+    background: $ui-base-color;
+    color: $primary-text-color;
+
+    input {
+      color: $primary-text-color;
+    }
+  }
+
+  .language-dropdown__dropdown__results__item {
+    color: $primary-text-color;
+
+    &:hover {
+      background: lighten($ui-base-color, 4%);
+    }
+  }
+}
+
+// Animations
+
+@keyframes flash {
+  from {
+    background: $accent;
+  }
+
+  to {
+    background: $accent-secondary;
+  }
+}

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -84,6 +84,26 @@ hr {
 
 }
 
+.reactions-bar {
+  &__item {
+    background: $ui-base-color;
+    color: $primary-text-color;
+
+    &:hover {
+      background: rgba($accent-secondary, 0.1);
+    }
+
+    &.active {
+      background: rgba($accent-secondary, 0.25);
+      color: $accent-secondary;
+
+      .reactions-bar__item__count {
+        color: $accent;
+      }
+    }
+  }
+}
+
 .dropdown-menu {
   background: $ui-base-color;
 

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -154,7 +154,7 @@ a.mention.hashtag {
   color: $accent;
 }
 
-// glitch-soc
+// local settings
 
 .glitch.local-settings {
   // fixes white outline in navigation
@@ -182,39 +182,9 @@ a.mention.hashtag {
   }
 }
 
-// roundening
-
-// compose
-.drawer > div,
-nav,
-.search,
-.drawer__header a,
-.drawer--header a,
-.search__input {
-  border-radius: $border-radius;
-}
-
-.search-popout {
-  background: $ui-base-color;
-  color: $primary-text-color;
-
-  em {
-    color: $accent;
-  }
-}
-
-.drawer--header a {
-  &:hover,
-  &:focus {
-    background: rgba($accent-secondary, 0.1);
-    color: $accent;
-  }
-}
-
 // columns
-.column-header,
-.column-back-button,
-.navigation-bar {
+
+.column-back-button {
   border-radius: $border-radius $border-radius 0 0;
 }
 
@@ -256,20 +226,32 @@ nav,
   animation-direction: alternate-reverse;
 }
 
-.column-header,
-.column-header__button,
-.column-header__button.active,
-.column-header__button.active:hover,
-.column-header__back-button,
-.column-header__collapsible-inner {
+.column-header {
   background: $background-brighter;
   border-bottom: none;
-}
+  border-radius: $border-radius $border-radius 0 0;
 
-.column-header {
-  .active,
-  &__icon {
-    text-shadow: 0 0 10px rgba($accent, 0.4);
+  &.active {
+    .column-header__icon {
+      text-shadow: 0 0 10px rgba($accent, 0.4);
+    }
+  }
+
+  &__button {
+    background: $background-brighter;
+
+    &.active,
+    &.active:hover {
+      background: $background-brighter;
+    }
+  }
+
+  &__back-button {
+    background: $background-brighter;
+  }
+
+  &__collapsible-inner {
+    background: $background-brighter;
   }
 
   &__wrapper {
@@ -394,10 +376,37 @@ nav,
 // compose
 
 .drawer {
+  & > div {
+    border-radius: $border-radius;
+  }
+
   &__inner,
   &--header {
     background: $ui-base-color;
     color: $primary-text-color;
+  }
+}
+
+.drawer--header {
+  border-radius: $border-radius;
+
+  a {
+    border-radius: $border-radius;
+
+    &:hover,
+    &:focus {
+      background: rgba($accent-secondary, 0.1);
+      color: $accent;
+    }
+  }
+}
+
+.search-popout {
+  background: $ui-base-color;
+  color: $primary-text-color;
+
+  em {
+    color: $accent;
   }
 }
 
@@ -406,6 +415,8 @@ nav,
   color: $primary-text-color;
   border-radius: $border-radius;
 }
+
+// glitch mascot
 
 .drawer__inner__mastodon {
   background: $ui-base-color url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 234.80078 31.757813" width="234.80078" height="31.757812"><path d="M19.599609 0c-1.05 0-2.10039.375-2.90039 1.125L0 16.925781v14.832031h234.80078V17.025391l-16.5-15.900391c-1.6-1.5-4.20078-1.5-5.80078 0l-13.80078 13.099609c-1.6 1.5-4.19883 1.5-5.79883 0L179.09961 1.125c-1.6-1.5-4.19883-1.5-5.79883 0L159.5 14.224609c-1.6 1.5-4.20078 1.5-5.80078 0L139.90039 1.125c-1.6-1.5-4.20078-1.5-5.80078 0l-13.79883 13.099609c-1.6 1.5-4.20078 1.5-5.80078 0L100.69922 1.125c-1.600001-1.5-4.198829-1.5-5.798829 0l-13.59961 13.099609c-1.6 1.5-4.200781 1.5-5.800781 0L61.699219 1.125c-1.6-1.5-4.198828-1.5-5.798828 0L42.099609 14.224609c-1.6 1.5-4.198828 1.5-5.798828 0L22.5 1.125C21.7.375 20.649609 0 19.599609 0z" fill="#{hex-color($ui-base-color)}"/></svg>') no-repeat bottom / 100% auto;
@@ -481,15 +492,15 @@ nav,
     background: $background-brighter;
     color: $primary-text-color;
   }
-}
 
-.privacy-dropdown__option {
-  // icon color
-  color: $primary-text-color;
+  &__option {
+    // icon color
+    color: $primary-text-color;
 
-  .privacy-dropdown__option__content {
-    strong {
-      color: $primary-text-color;
+    .privacy-dropdown__option__content {
+      strong {
+        color: $primary-text-color;
+      }
     }
   }
 }

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -350,6 +350,12 @@ nav,
   }
 }
 
+.navigation-bar {
+  background: $ui-base-color;
+  color: $primary-text-color;
+  border-radius: $border-radius;
+}
+
 .drawer__inner__mastodon {
   background: $ui-base-color url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 234.80078 31.757813" width="234.80078" height="31.757812"><path d="M19.599609 0c-1.05 0-2.10039.375-2.90039 1.125L0 16.925781v14.832031h234.80078V17.025391l-16.5-15.900391c-1.6-1.5-4.20078-1.5-5.80078 0l-13.80078 13.099609c-1.6 1.5-4.19883 1.5-5.79883 0L179.09961 1.125c-1.6-1.5-4.19883-1.5-5.79883 0L159.5 14.224609c-1.6 1.5-4.20078 1.5-5.80078 0L139.90039 1.125c-1.6-1.5-4.20078-1.5-5.80078 0l-13.79883 13.099609c-1.6 1.5-4.20078 1.5-5.80078 0L100.69922 1.125c-1.600001-1.5-4.198829-1.5-5.798829 0l-13.59961 13.099609c-1.6 1.5-4.200781 1.5-5.800781 0L61.699219 1.125c-1.6-1.5-4.198828-1.5-5.798828 0L42.099609 14.224609c-1.6 1.5-4.198828 1.5-5.798828 0L22.5 1.125C21.7.375 20.649609 0 19.599609 0z" fill="#{hex-color($ui-base-color)}"/></svg>') no-repeat bottom / 100% auto;
 }
@@ -370,6 +376,11 @@ nav,
       }
     }
   }
+}
+
+// Fixes white corners in simpleUI
+.compose-panel .compose-form__autosuggest-wrapper {
+  background: transparent;
 }
 
 .compose-form {

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -380,14 +380,14 @@ a.mention.hashtag {
     border-radius: $border-radius;
   }
 
-  &__inner,
-  &--header {
+  &__inner {
     background: $ui-base-color;
-    color: $primary-text-color;
   }
 }
 
 .drawer--header {
+  background: $ui-base-color;
+  color: $primary-text-color;
   border-radius: $border-radius;
 
   a {
@@ -418,6 +418,10 @@ a.mention.hashtag {
   background: $ui-base-color;
   color: $primary-text-color;
   border-radius: $border-radius;
+
+  .acct {
+    color: $primary-text-color;
+  }
 }
 
 // glitch mascot

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -274,6 +274,10 @@ nav,
   }
 }
 
+.announcements {
+  background: $background-brighter;
+}
+
 .notification__filter-bar {
   background: $background-brighter;
   border-bottom: none;

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -306,14 +306,26 @@ nav,
 
   &__section-headline {
     background: $background-brighter;
+    color: $accent;
     border-bottom: none;
 
-    a.active {
-      color: $accent;
+    .active {
+      border-bottom: 3px solid $accent;
+    }
 
-      &::before,
-      &::after {
-        border-color: transparent transparent $ui-base-color;
+    a {
+      &:hover {
+        color: $white;
+      }
+
+      &.active {
+        color: $accent;
+
+        &::before,
+        &::after {
+          display: none;
+          border-color: transparent transparent $ui-base-color;
+        }
       }
     }
 
@@ -430,11 +442,12 @@ nav,
     max-height: 100%;
   }
 
+  // Fix colors
+
   &__reply-to {
     color: $secondary-text-color;
   }
 
-  // Fix colors
   &__header > .account.small {
     color: $primary-text-color;
   }
@@ -442,7 +455,6 @@ nav,
   &__content {
     color: $primary-text-color;
 
-    // NOTE: This should be fixed with glitch-soc rich text scss refactor
     blockquote {
       color: $darker-text-color;
       border-left: 3px solid $darker-text-color;

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -517,6 +517,14 @@ nav,
         &:hover {
           background: lighten($ui-base-color, 4%);
         }
+
+        &.active {
+          color: $inverted-text-color;
+
+          .language-dropdown__dropdown__results__item__common-name {
+            color: $lighter-text-color;
+          }
+        }
       }
     }
   }

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -855,25 +855,20 @@ a.mention.hashtag {
 
   .sidebar-wrapper {
     &__inner {
-      background: $background-brighter;
+      background: $background;
     }
-  }
-
-  .content-wrapper,
-  .sidebar-wrapper--empty {
-    background: $background;
   }
 
   .sidebar {
     ul a {
-      background: $background-brighter;
+      background: $background;
 
       &:hover {
-        background: $background-brighter;
+        background: $background;
       }
 
       &.selected {
-        background: $background-brighter;
+        background: $background;
       }
     }
 

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -401,6 +401,10 @@ a.mention.hashtag {
   }
 }
 
+.search__input {
+  background: $background-brighter;
+}
+
 .search-popout {
   background: $ui-base-color;
   color: $primary-text-color;

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -90,7 +90,17 @@ hr {
       }
     }
   }
+}
 
+.detailed-status {
+  &__action-bar {
+    border-top: none;
+    border-bottom: none;
+  }
+}
+
+.conversation {
+  border-bottom: none;
 }
 
 .reactions-bar {

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -18,6 +18,15 @@ hr {
   &:focus {
     background-color: $accent-bright;
   }
+
+  &.button-secondary {
+    &:hover,
+    &:active,
+    &:focus {
+      color: $white;
+      border-color: transparent;
+    }
+  }
 }
 
 .icon-button {
@@ -763,8 +772,8 @@ nav,
     &:hover,
     &:focus,
     &:active {
-      border-color: darken($primary-text-color, 15%);
-      color: darken($primary-text-color, 15%);
+      border-color: transparent;
+      color: $white;
     }
   }
 

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -828,3 +828,77 @@ a.mention.hashtag {
     background: $accent-secondary;
   }
 }
+
+// admin interface
+
+.admin-wrapper {
+  .content {
+    h2,
+    h3 {
+      color: $primary-text-color;
+    }
+
+    h4 {
+      border-bottom: none;
+    }
+  }
+
+  .sidebar-wrapper {
+    &__inner {
+      background: $background-brighter;
+    }
+  }
+  .sidebar {
+    ul a {
+      background: $background-brighter;
+
+      &:hover {
+        background: $background-brighter;
+      }
+
+      &.selected {
+        background: $background-brighter;
+      }
+    }
+
+    ul {
+      .simple-navigation-active-leaf a {
+        background: $accent;
+
+        &:hover {
+          background: $accent-bright;
+        }
+      }
+    }
+  }
+}
+
+.announcements-list,
+.filters-list {
+  &__item {
+    &__title {
+      color: $primary-text-color;
+    }
+
+    a.announcements-list__item__title {
+      &:hover,
+      &:active,
+      &:focus {
+        color: $white;
+      }
+    }
+  }
+}
+
+.table {
+  &.horizontal-table {
+    & > tbody > tr > th,
+    & > tbody > tr > td {
+      border: none;
+    }
+
+    & > tbody > tr {
+      border: 1px solid lighten($ui-base-color, 8%);
+    }
+  }
+}

--- a/app/javascript/flavours/glitch/styles/oatstodon/variables.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/variables.scss
@@ -19,15 +19,15 @@ $classic-secondary-color: #d9e1e8;    // Pattens Blue
 $classic-highlight-color: #6364ff;    // Brand purple
 
 // text color
-$primary-text-color: #d9e1e8 !default; // oatstodon text-color
-$secondary-text-color: #606984 !default; // oatstodon text-color-secondary
-$action-button-color: #3e5b54 !default; // oatstodon accent-color-secondary
+$primary-text-color: $text !default; // oatstodon text-color
+$secondary-text-color: $text-secondary !default; // oatstodon text-color-secondary
+$action-button-color: $accent-secondary !default; // oatstodon accent-color-secondary
 $dark-text-color: lighten($classic-base-color, 26%) !default; // default Mastodon color
 $lighter-text-color: $secondary-text-color !default;
 
 // UI
-$ui-base-color: #121225 !default; // oatstodon background-color
-$ui-highlight-color: #27b791 !default; // oatstodon accent-color
+$ui-base-color: $background !default; // oatstodon background-color
+$ui-highlight-color: $accent !default; // oatstodon accent-color
 
 // Border
 $border-radius: 5px !default;

--- a/app/javascript/flavours/glitch/styles/oatstodon/variables.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/variables.scss
@@ -1,0 +1,33 @@
+$white: #ffffff;
+
+// Oatstodon colors
+$text: #d9e1e8;
+$text-secondary: #606984;
+
+$background: #121225;
+$background-brighter: #16162f;
+$app-background: #080811;
+
+$accent: #27b791;
+$accent-secondary: #3e5b54;
+$accent-bright: #5cc1a2;
+
+// Values from the classic Mastodon UI
+$classic-base-color: #282c37;         // Midnight Express
+$classic-primary-color: #9baec8;      // Echo Blue
+$classic-secondary-color: #d9e1e8;    // Pattens Blue
+$classic-highlight-color: #6364ff;    // Brand purple
+
+// text color
+$primary-text-color: #d9e1e8 !default; // oatstodon text-color
+$secondary-text-color: #606984 !default; // oatstodon text-color-secondary
+$action-button-color: #3e5b54 !default; // oatstodon accent-color-secondary
+$dark-text-color: lighten($classic-base-color, 26%) !default; // default Mastodon color
+$lighter-text-color: $secondary-text-color !default;
+
+// UI
+$ui-base-color: #121225 !default; // oatstodon background-color
+$ui-highlight-color: #27b791 !default; // oatstodon accent-color
+
+// Border
+$border-radius: 5px !default;

--- a/app/javascript/skins/glitch/oatstodon/common.scss
+++ b/app/javascript/skins/glitch/oatstodon/common.scss
@@ -1,0 +1,1 @@
+@import 'flavours/glitch/styles/oatstodon';

--- a/app/javascript/skins/glitch/oatstodon/names.yml
+++ b/app/javascript/skins/glitch/oatstodon/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    glitch:
+      oatstodon: Oatstodon


### PR DESCRIPTION
Port of https://gist.github.com/oatmealine/8081dcc0e0cc4ae04491bcbc1f023f8a

Applied some changes:
- Changed color of icons in emoji-picker to be more readable
- Changed color of show more button
- Changed color of language dropdown
- Moved "Replying to:" to the frontend to offer translations
- Kept default background for inputs in admin interface
- Removed borders on grouped mentioned only toots
- Kept some borders in admin interface for better readability
- Kept backgrounds in admin interface

Known issues:
- "Replying to:" text will be missing and spacing will be a bit off without #77

**Screenshots**

WebUI:
![Screenshot_2023-03-17_15-56-18](https://user-images.githubusercontent.com/117664621/225941057-8a73d2b3-f3e7-4a6c-a6a9-ed946065ae84.png)

Settings:
![Screenshot_2023-03-17_16-59-11](https://user-images.githubusercontent.com/117664621/225956504-a290e2fa-c9bf-4772-b537-f89a4f0c13c1.png)
