### PR TITLE
Add "Replying to:" text to reply-indicator

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/reply_indicator.jsx
+++ b/app/javascript/flavours/glitch/features/compose/components/reply_indicator.jsx
@@ -16,6 +16,10 @@ const messages = defineMessages({
     defaultMessage: 'Cancel',
     id: 'reply_indicator.cancel',
   },
+  replyTo: {
+    defaultMessage: 'Replying to:',
+    id: 'reply_indicator.reply_to',
+  },
 });
 
 
@@ -50,6 +54,7 @@ class ReplyIndicator extends ImmutablePureComponent {
     //  The result.
     return (
       <article className='reply-indicator'>
+        <span className='reply-indicator__reply-to'>{intl.formatMessage(messages.replyTo)}</span>
         <header className='reply-indicator__header'>
           <IconButton
             className='reply-indicator__cancel'

--- a/app/javascript/flavours/glitch/locales/en.json
+++ b/app/javascript/flavours/glitch/locales/en.json
@@ -106,6 +106,7 @@
   "onboarding.page_three.search": "Use the search bar to find people and look at hashtags, such as {illustration} and {introductions}. To look for a person who is not on this instance, use their full handle.",
   "onboarding.page_two.compose": "Write toots from the compose column. You can upload images, change privacy settings, and add content warnings with the icons below.",
   "onboarding.skip": "Skip",
+  "reply_indicator.reply_to": "Replying to:",
   "search.disabled": "Search disabled",
   "settings.always_show_spoilers_field": "Always enable the Content Warning field",
   "settings.auto_collapse": "Automatic collapsing",

--- a/app/javascript/flavours/glitch/styles/components/compose_form.scss
+++ b/app/javascript/flavours/glitch/styles/components/compose_form.scss
@@ -138,6 +138,11 @@
   flex: 0 2 auto;
 }
 
+.reply-indicator__reply-to {
+  font-size: 12px;
+  color: $inverted-text-color;
+}
+
 .reply-indicator__header {
   margin-bottom: 5px;
   overflow: hidden;


### PR DESCRIPTION
Adds a translatable "Replying to:" text to the reply indicator.
Inspired by the oatstodon theme.

**Preview:**
![Screenshot_2023-03-15_01-39-59](https://user-images.githubusercontent.com/117664621/225174226-f2a97766-b06e-443f-96db-deba5e0c00a9.png)
