### PR TITLE
Fix color of code blocks in reply-indicator

### DIFF
--- a/app/javascript/flavours/glitch/styles/rich_text.scss
+++ b/app/javascript/flavours/glitch/styles/rich_text.scss
@@ -113,4 +113,8 @@
     border-left-color: $inverted-text-color;
     color: $inverted-text-color;
   }
+
+  code {
+    color: $primary-text-color;
+  }
 }


### PR DESCRIPTION
Missed this while merging upstream.