### PR TITLE
SyntaxHighlight: Support highlighting in reply-indicator

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/reply_indicator.jsx
+++ b/app/javascript/flavours/glitch/features/compose/components/reply_indicator.jsx
@@ -10,6 +10,8 @@ import AccountContainer from 'flavours/glitch/containers/account_container';
 import IconButton from 'flavours/glitch/components/icon_button';
 import AttachmentList from 'flavours/glitch/components/attachment_list';
 
+import { highlightCode } from 'flavours/glitch/utils/html';
+
 //  Messages.
 const messages = defineMessages({
   cancel: {
@@ -72,7 +74,7 @@ class ReplyIndicator extends ImmutablePureComponent {
         </header>
         <div
           className='reply-indicator__content translate'
-          dangerouslySetInnerHTML={{ __html: content || '' }}
+          dangerouslySetInnerHTML={{ __html: highlightCode(content) || '' }}
         />
         {attachments.size > 0 && (
           <AttachmentList

--- a/app/javascript/flavours/glitch/utils/html.js
+++ b/app/javascript/flavours/glitch/utils/html.js
@@ -1,5 +1,57 @@
+import highlightjs from 'highlight.js';
+
 export const unescapeHTML = (html) => {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = html.replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<[^>]*>/g, '');
   return wrapper.textContent;
+};
+
+/**
+ * Highlights code in code tags.\
+ * Uses highlight.js to convert content inside code tags to span elements with class attributes
+ * @param {String} content - String containing html code tags
+ * @returns content with highlighted code inside code tags, or content if not found
+ */
+export const highlightCode = (content) => {
+  // highlightJS complains when unescaped html is given
+  highlightjs.configure({ ignoreUnescapedHTML: true });
+
+  // Create a new temporary element to work on
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = content;
+
+  // Get code elements and run highlightJS on each.
+  wrapper.querySelectorAll('code')
+    .forEach((code) => {
+      // Get language from data attribute containing code language of code element
+      let lang = highlightjs.getLanguage(code.dataset.codelang);
+
+      // Check if lang is a valid language
+      if (lang !== undefined) {
+        // Set codelang as class attribute, since highlightElement cannot be given a language
+        // highlightJS will read this attribute and use it to highlight in the proper language
+        code.setAttribute('class', code.dataset.codelang);
+
+        // Set title attribute to language name, i.e. "js" will become "Javascript"
+        code.setAttribute('title', lang.name);
+
+        // Replace <br> as highlightJS removes them, messing up formatting
+        let brTags = Array.from(code.getElementsByTagName('br'));
+        for (let br of brTags) {
+          br.replaceWith('\n');
+        }
+
+        // Highlight the code element
+        highlightjs.highlightElement(code);
+
+        // highlightJS adds own class attribute, remove it again to not mess up styling
+        code.removeAttribute('class');
+      } else {
+        // Remove data attribute as it's not a valid language.
+        delete code.dataset.codelang;
+      }
+    });
+
+  // return content with highlighted code
+  return wrapper.innerHTML;
 };


### PR DESCRIPTION
Ref #20

Moved highlightCode to `util/html.js`

![Screenshot_2023-03-18_15-26-20](https://user-images.githubusercontent.com/117664621/226112106-eae7c701-097c-4ba5-bc52-159f0ffaacc9.png)
