### PR TITLE
Exclude threads from "Show replies" toggle

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
+++ b/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
@@ -38,7 +38,7 @@ const makeGetStatusIds = (pending = false) => createSelector([
     }
 
     if (columnSettings.getIn(['shows', 'reply']) === false) {
-      showStatus = showStatus && (statusForId.get('in_reply_to_id') === null || statusForId.get('in_reply_to_account_id') === me);
+      showStatus = showStatus && (statusForId.get('in_reply_to_id') === null || statusForId.get('in_reply_to_account_id') === me || statusForId.get('in_reply_to_account_id') === statusForId.get('account'));
     }
 
     if (columnSettings.getIn(['shows', 'direct']) === false) {


### PR DESCRIPTION
While threads are technically self-replies, I think excluding those as well is rather unexpected for most people.
I think this should be a separate toggle if included at all.