### PR TITLE
Add "Show threads" setting to home timeline

### DIFF
--- a/app/javascript/flavours/glitch/features/home_timeline/components/column_settings.jsx
+++ b/app/javascript/flavours/glitch/features/home_timeline/components/column_settings.jsx
@@ -35,6 +35,10 @@ class ColumnSettings extends React.PureComponent {
         </div>
 
         <div className='column-settings__row'>
+          <SettingToggle prefix='home_timeline' settings={settings} settingPath={['shows', 'thread']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_threads' defaultMessage='Show threads' />} />
+        </div>
+
+        <div className='column-settings__row'>
           <SettingToggle prefix='home_timeline' settings={settings} settingPath={['shows', 'direct']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_direct' defaultMessage='Show DMs' />} />
         </div>
 

--- a/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
+++ b/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
@@ -41,6 +41,10 @@ const makeGetStatusIds = (pending = false) => createSelector([
       showStatus = showStatus && (statusForId.get('in_reply_to_id') === null || statusForId.get('in_reply_to_account_id') === me || statusForId.get('in_reply_to_account_id') === statusForId.get('account'));
     }
 
+    if (columnSettings.getIn(['shows', 'thread']) === false) {
+      showStatus = showStatus && statusForId.get('in_reply_to_account_id') !== statusForId.get('account');
+    }
+
     if (columnSettings.getIn(['shows', 'direct']) === false) {
       showStatus = showStatus && statusForId.get('visibility') !== 'direct';
     }

--- a/app/javascript/flavours/glitch/locales/en.json
+++ b/app/javascript/flavours/glitch/locales/en.json
@@ -57,6 +57,7 @@
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.filter_regex": "Filter out by regular expressions",
   "home.column_settings.show_direct": "Show DMs",
+  "home.column_settings.show_threads": "Show threads",
   "home.settings": "Column settings",
   "keyboard_shortcuts.bookmark": "to bookmark",
   "keyboard_shortcuts.secondary_toot": "to send toot using secondary privacy setting",

--- a/app/javascript/flavours/glitch/reducers/settings.js
+++ b/app/javascript/flavours/glitch/reducers/settings.js
@@ -24,6 +24,7 @@ const initialState = ImmutableMap({
     shows: ImmutableMap({
       reblog: true,
       reply: true,
+      thread: true,
       direct: true,
     }),
 


### PR DESCRIPTION
With the exclusion of self-replies from the "Show replies" toggle, I think it makes sense to include a separate one for self-replies.

Preview:
![Screenshot_2023-03-22_03-32-37](https://user-images.githubusercontent.com/117664621/226786871-105d86a6-116e-442d-a8e9-ea514cbe4660.png)
