### PR TITLE
Fix empty reaction bar displaying in detailed status view

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/announcements.scss
+++ b/app/javascript/flavours/glitch/styles/components/announcements.scss
@@ -231,3 +231,7 @@
     }
   }
 }
+
+.reactions-bar--empty {
+  display: none;
+}

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -384,10 +384,6 @@
   .notification__message {
     margin: -10px 0 10px;
   }
-
-  .reactions-bar--empty {
-    display: none;
-  }
 }
 
 .notification-favourite {


### PR DESCRIPTION
Ref #21 

Moves `reactions-bar--empty` to `announcements.scss` for this rule to be applied in all contexts.