### PR TITLE
Add a reminder when publishing new toots with media that has no image description

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -36,6 +36,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_default_privacy,
       :setting_default_sensitive,
       :setting_default_language,
+      :setting_alt_text_reminder,
       :setting_unfollow_modal,
       :setting_boost_modal,
       :setting_favourite_modal,

--- a/app/javascript/flavours/glitch/actions/compose.js
+++ b/app/javascript/flavours/glitch/actions/compose.js
@@ -163,7 +163,7 @@ export function directCompose(account, routerHistory) {
   };
 }
 
-export function submitCompose(routerHistory) {
+export function submitCompose(routerHistory, checkAltText = true) {
   return function (dispatch, getState) {
     let status     = getState().getIn(['compose', 'text'], '');
     const media    = getState().getIn(['compose', 'media_attachments']);
@@ -177,6 +177,20 @@ export function submitCompose(routerHistory) {
 
     if (getState().getIn(['compose', 'advanced_options', 'do_not_federate'])) {
       status = status + ' 👁️';
+    }
+
+    // If the user has image description reminders enabled and any media attached to
+    // the compose form, check for image description.
+    if (checkAltText && getState().getIn(['compose', 'alt_text_reminder']) && media.size > 0) {
+      // If there are any attachments that are missing descriptions, display the warning modal.
+      if (media.some((attach) => attach.get('description') === null || attach.get('description') === '')) {
+        dispatch(openModal( 'ALT_TEXT_WARNING', {
+          onSubmitCompose: () => {
+            dispatch(submitCompose(routerHistory, false));
+          },
+        }));
+        return;
+      }
     }
 
     dispatch(submitComposeRequest());

--- a/app/javascript/flavours/glitch/features/ui/components/alt_text_warning_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/alt_text_warning_modal.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import Button from 'flavours/glitch/components/button';
+import { closeModal } from 'flavours/glitch/actions/modal';
+
+const mapDispatchToProps = dispatch => {
+  return {
+    onClose() {
+      dispatch(closeModal());
+    },
+  };
+};
+
+// This modal is displayed when a user attempts to submit a post with an image
+// or video file that has no alt text.
+export default @connect(null, mapDispatchToProps)
+@injectIntl
+class AltTextWarningModal extends React.PureComponent {
+
+  static propTypes = {
+    onClose: PropTypes.func.isRequired,
+    onSubmitCompose: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  componentDidMount() {
+    this.button.focus();
+  }
+
+  handleClick = () => {
+    this.props.onSubmitCompose();
+    this.props.onClose();
+  };
+
+  handleCancel = () => {
+    this.props.onClose();
+  };
+
+  setRef = (c) => {
+    this.button = c;
+  };
+
+  render () {
+    return (
+      <div className='modal-root__modal alt-text-warning-modal'>
+        <div className='alt-text-warning-modal__container'>
+          <h4 className='alt-text-warning-modal__title'>
+            <FormattedMessage
+              id='compose_form.alt_text_warning.header'
+              defaultMessage='Your attachments are missing a description!'
+            />
+          </h4>
+          <p>
+            <FormattedMessage
+              id='compose_form.alt_text_warning.message'
+              defaultMessage="Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon."
+            />
+          </p>
+        </div>
+
+        <div className='alt-text-warning-modal__action-bar'>
+          <Button onClick={this.handleCancel}>
+            <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
+          </Button>
+          <Button onClick={this.handleClick} ref={this.setRef} className='confirmation-modal__cancel-button'>
+            <FormattedMessage id='compose_form.publish' defaultMessage='Publish' />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/flavours/glitch/features/ui/components/modal_root.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/modal_root.jsx
@@ -32,6 +32,7 @@ import {
   InteractionModal,
   SubscribedLanguagesModal,
   ClosedRegistrationsModal,
+  AltTextWarningModal,
 } from 'flavours/glitch/features/ui/util/async-components';
 import { Helmet } from 'react-helmet';
 
@@ -62,6 +63,7 @@ const MODAL_COMPONENTS = {
   'INTERACTION': InteractionModal,
   'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
   'ALTTEXT': () => Promise.resolve({ default: AltTextModal }),
+  'ALT_TEXT_WARNING': AltTextWarningModal,
 };
 
 export default class ModalRoot extends React.PureComponent {

--- a/app/javascript/flavours/glitch/features/ui/util/async-components.js
+++ b/app/javascript/flavours/glitch/features/ui/util/async-components.js
@@ -154,6 +154,10 @@ export function EmbedModal () {
   return import(/* webpackChunkName: "flavours/glitch/async/embed_modal" */'flavours/glitch/features/ui/components/embed_modal');
 }
 
+export function AltTextWarningModal () {
+  return import(/* webpackChunkName: "flavours/glitch/async/alt_text_warning_modal" */'flavours/glitch/features/ui/components/alt_text_warning_modal');
+}
+
 export function GettingStartedMisc () {
   return import(/* webpackChunkName: "flavours/glitch/async/getting_started_misc" */'flavours/glitch/features/getting_started_misc');
 }

--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -103,6 +103,7 @@ const initialState = ImmutableMap({
   default_privacy: 'public',
   default_sensitive: false,
   default_language: 'en',
+  alt_text_reminder: true,
   resetFileKey: Math.floor((Math.random() * 0x10000)),
   idempotencyKey: null,
   tagHistory: ImmutableList(),

--- a/app/javascript/flavours/glitch/styles/components/modal.scss
+++ b/app/javascript/flavours/glitch/styles/components/modal.scss
@@ -419,7 +419,8 @@
 .actions-modal,
 .mute-modal,
 .block-modal,
-.compare-history-modal {
+.compare-history-modal,
+.alt-text-warning-modal {
   background: lighten($ui-secondary-color, 8%);
   color: $inverted-text-color;
   border-radius: 8px;
@@ -488,7 +489,8 @@
 .boost-modal__action-bar,
 .confirmation-modal__action-bar,
 .mute-modal__action-bar,
-.block-modal__action-bar {
+.block-modal__action-bar,
+.alt-text-warning-modal__action-bar {
   display: flex;
   justify-content: space-between;
   background: $ui-secondary-color;
@@ -504,6 +506,19 @@
 
   .button {
     flex: 0 0 auto;
+  }
+}
+
+.alt-text-warning-modal {
+  &__title {
+    font-size: 21px;
+    line-height: 26px;
+    font-weight: 700;
+    margin-bottom: 15px;
+
+    @media screen and (max-height: 800px) {
+      font-size: 18px;
+    }
   }
 }
 
@@ -998,7 +1013,8 @@
 .confirmation-modal__container,
 .mute-modal__container,
 .block-modal__container,
-.report-modal__target {
+.report-modal__target,
+.alt-text-warning-modal__container {
   padding: 30px;
   font-size: 16px;
 

--- a/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
+++ b/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
@@ -548,7 +548,8 @@ a.mention,
 .mute-modal,
 .block-modal,
 .boost-modal,
-.confirmation-modal {
+.confirmation-modal,
+.alt-text-warning-modal {
   background: lighten($purple2, 8%);
   color: $primary-text-color;
 

--- a/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
@@ -374,6 +374,7 @@ html {
 .error-modal,
 .onboarding-modal,
 .compare-history-modal,
+.alt-text-warning-modal,
 .report-modal__comment .setting-text__wrapper,
 .report-modal__comment .setting-text,
 .announcements,
@@ -464,6 +465,7 @@ html {
 .confirmation-modal__action-bar,
 .mute-modal__action-bar,
 .block-modal__action-bar,
+.alt-text-warning-modal__action-bar,
 .onboarding-modal__paginator,
 .error-modal__footer {
   background: darken($ui-base-color, 6%);

--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -617,7 +617,8 @@ a.mention.hashtag {
 .mute-modal,
 .block-modal,
 .boost-modal,
-.confirmation-modal {
+.confirmation-modal,
+.alt-text-warning-modal {
   background: lighten($ui-base-color, 8%);
   color: $primary-text-color;
 

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -148,7 +148,7 @@ export function directCompose(account, routerHistory) {
   };
 }
 
-export function submitCompose(routerHistory) {
+export function submitCompose(routerHistory, checkAltText = true) {
   return function (dispatch, getState) {
     const status   = getState().getIn(['compose', 'text'], '');
     const media    = getState().getIn(['compose', 'media_attachments']);
@@ -156,6 +156,20 @@ export function submitCompose(routerHistory) {
 
     if ((!status || !status.length) && media.size === 0) {
       return;
+    }
+
+    // If the user has image description reminders enabled and any media attached to
+    // the compose form, check for image description.
+    if (checkAltText && getState().getIn(['compose', 'alt_text_reminder']) && media.size > 0) {
+      // If there are any attachments that are missing descriptions, display the warning modal.
+      if (media.some((attach) => attach.get('description') === null || attach.get('description') === '')) {
+        dispatch(openModal( 'ALT_TEXT_WARNING', {
+          onSubmitCompose: () => {
+            dispatch(submitCompose(routerHistory, false));
+          },
+        }));
+        return;
+      }
     }
 
     dispatch(submitComposeRequest());

--- a/app/javascript/mastodon/features/ui/components/alt_text_warning_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/alt_text_warning_modal.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import Button from '../../../components/button';
+import { closeModal } from '../../../actions/modal';
+
+const makeMapStateToProps = () => {
+  const mapStateToProps = state => ({
+    media: state.getIn(['compose', 'media_attachments']),
+  });
+
+  return mapStateToProps;
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    onClose() {
+      dispatch(closeModal());
+    },
+  };
+};
+
+// This modal is displayed when a user attempts to submit a post with an image
+// or video file that has no alt text.
+export default @connect(makeMapStateToProps, mapDispatchToProps)
+@injectIntl
+class AltTextWarningModal extends React.PureComponent {
+
+  static propTypes = {
+    onClose: PropTypes.func.isRequired,
+    onSubmitCompose: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  componentDidMount() {
+    this.button.focus();
+  }
+
+  handleClick = () => {
+    this.props.onSubmitCompose();
+    this.props.onClose();
+  };
+
+  handleCancel = () => {
+    this.props.onClose();
+  };
+
+  setRef = (c) => {
+    this.button = c;
+  };
+
+  render () {
+    return (
+      <div className='modal-root__modal alt-text-warning-modal'>
+        <div className='alt-text-warning-modal__container'>
+          <h4 className='alt-text-warning-modal__title'>
+            <FormattedMessage
+              id='compose_form.alt_text_warning.header'
+              defaultMessage='Your attachments are missing a description!'
+            />
+          </h4>
+          <p>
+            <FormattedMessage
+              id='compose_form.alt_text_warning.message'
+              defaultMessage="Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon."
+            />
+          </p>
+        </div>
+
+        <div className='alt-text-warning-modal__action-bar'>
+          <Button onClick={this.handleCancel}>
+            <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
+          </Button>
+          <Button onClick={this.handleClick} ref={this.setRef} className='confirmation-modal__cancel-button'>
+            <FormattedMessage id='compose_form.publish' defaultMessage='Publish' />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/ui/components/modal_root.jsx
+++ b/app/javascript/mastodon/features/ui/components/modal_root.jsx
@@ -25,6 +25,7 @@ import {
   InteractionModal,
   SubscribedLanguagesModal,
   ClosedRegistrationsModal,
+  AltTextWarningModal,
 } from 'mastodon/features/ui/util/async-components';
 import { Helmet } from 'react-helmet';
 
@@ -48,6 +49,7 @@ const MODAL_COMPONENTS = {
   'SUBSCRIBED_LANGUAGES': SubscribedLanguagesModal,
   'INTERACTION': InteractionModal,
   'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
+  'ALT_TEXT_WARNING': AltTextWarningModal,
 };
 
 export default class ModalRoot extends React.PureComponent {

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -134,6 +134,10 @@ export function EmbedModal () {
   return import(/* webpackChunkName: "modals/embed_modal" */'../components/embed_modal');
 }
 
+export function AltTextWarningModal () {
+  return import(/* webpackChunkName: "modals/alt_text_warning_modal" */'../components/alt_text_warning_modal');
+}
+
 export function ListEditor () {
   return import(/* webpackChunkName: "features/list_editor" */'../../list_editor');
 }

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -130,6 +130,8 @@
   "community.column_settings.remote_only": "Remote only",
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
+  "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
+  "compose_form.alt_text_warning.message": "Descriptions are for users with visual or audio impairments that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
   "compose_form.direct_message_warning_learn_more": "Learn more",
   "compose_form.encryption_warning": "Toots on Mastodon are not end-to-end encrypted. Do not share any sensitive information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is not public. Only public toots can be searched by hashtag.",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -82,6 +82,7 @@ const initialState = ImmutableMap({
   default_privacy: 'public',
   default_sensitive: false,
   default_language: 'en',
+  alt_text_reminder: true,
   resetFileKey: Math.floor((Math.random() * 0x10000)),
   idempotencyKey: null,
   tagHistory: ImmutableList(),

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -374,6 +374,7 @@ html {
 .error-modal,
 .onboarding-modal,
 .compare-history-modal,
+.alt-text-warning-modal,
 .report-modal__comment .setting-text__wrapper,
 .report-modal__comment .setting-text,
 .announcements,
@@ -464,6 +465,7 @@ html {
 .confirmation-modal__action-bar,
 .mute-modal__action-bar,
 .block-modal__action-bar,
+.alt-text-warning-modal__action-bar,
 .onboarding-modal__paginator,
 .error-modal__footer {
   background: darken($ui-base-color, 6%);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5295,7 +5295,8 @@ a.status-card.compact:hover {
 .actions-modal,
 .mute-modal,
 .block-modal,
-.compare-history-modal {
+.compare-history-modal,
+.alt-text-warning-modal {
   background: lighten($ui-secondary-color, 8%);
   color: $inverted-text-color;
   border-radius: 8px;
@@ -5332,6 +5333,7 @@ a.status-card.compact:hover {
 .boost-modal__action-bar,
 .confirmation-modal__action-bar,
 .mute-modal__action-bar,
+.alt-text-warning-modal__action-bar,
 .block-modal__action-bar {
   display: flex;
   justify-content: space-between;
@@ -5364,6 +5366,19 @@ a.status-card.compact:hover {
 .report-modal {
   width: 90vw;
   max-width: 700px;
+}
+
+.alt-text-warning-modal {
+  &__title {
+    font-size: 21px;
+    line-height: 26px;
+    font-weight: 700;
+    margin-bottom: 15px;
+
+    @media screen and (max-height: 800px) {
+      font-size: 18px;
+    }
+  }
 }
 
 .report-dialog-modal {
@@ -5769,6 +5784,7 @@ a.status-card.compact:hover {
 
 .confirmation-modal__container,
 .mute-modal__container,
+.alt-text-warning-modal__container,
 .block-modal__container,
 .report-modal__target {
   padding: 30px;

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -20,6 +20,7 @@ class UserSettingsDecorator
     user.settings['default_privacy']     = default_privacy_preference if change?('setting_default_privacy')
     user.settings['default_sensitive']   = default_sensitive_preference if change?('setting_default_sensitive')
     user.settings['default_language']    = default_language_preference if change?('setting_default_language')
+    user.settings['alt_text_reminder']   = alt_text_reminder_preference if change?('setting_alt_text_reminder')
     user.settings['unfollow_modal']      = unfollow_modal_preference if change?('setting_unfollow_modal')
     user.settings['boost_modal']         = boost_modal_preference if change?('setting_boost_modal')
     user.settings['favourite_modal']     = favourite_modal_preference if change?('setting_favourite_modal')
@@ -135,6 +136,10 @@ class UserSettingsDecorator
 
   def default_language_preference
     settings['setting_default_language']
+  end
+
+  def alt_text_reminder_preference
+    boolean_cast_setting 'setting_alt_text_reminder'
   end
 
   def aggregate_reblogs_preference

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,7 +136,7 @@ class User < ApplicationRecord
            :reduce_motion, :system_font_ui, :noindex, :norss, :flavour, :skin, :display_media, :hide_followers_count,
            :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
            :advanced_layout, :use_blurhash, :use_pending_items, :trends, :crop_images, :visible_reactions,
-           :disable_swiping, :notification_sound, :always_send_emails, :default_content_type, :system_emoji_font,
+           :disable_swiping, :notification_sound, :always_send_emails, :alt_text_reminder, :default_content_type, :system_emoji_font,
            to: :settings, prefix: :setting, allow_nil: false
 
   delegate :can?, to: :role

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -101,6 +101,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:default_privacy]   = object.visibility || object.current_account.user.setting_default_privacy
       store[:default_sensitive] = object.current_account.user.setting_default_sensitive
       store[:default_language]  = object.current_account.user.preferred_posting_language
+      store[:alt_text_reminder] = object.current_account.user.setting_alt_text_reminder
     end
 
     store[:text] = object.text if object.text

--- a/app/serializers/rest/preferences_serializer.rb
+++ b/app/serializers/rest/preferences_serializer.rb
@@ -4,6 +4,7 @@ class REST::PreferencesSerializer < ActiveModel::Serializer
   attribute :posting_default_privacy, key: 'posting:default:visibility'
   attribute :posting_default_sensitive, key: 'posting:default:sensitive'
   attribute :posting_default_language, key: 'posting:default:language'
+  attribute :posting_alt_text_reminder, key: 'posting:default:alt_text_reminder'
 
   attribute :reading_default_sensitive_media, key: 'reading:expand:media'
   attribute :reading_default_sensitive_text, key: 'reading:expand:spoilers'
@@ -19,6 +20,10 @@ class REST::PreferencesSerializer < ActiveModel::Serializer
 
   def posting_default_language
     object.user.preferred_posting_language
+  end
+
+  def posting_alt_text_reminder
+    object.user.setting_alt_text_reminder
   end
 
   def reading_default_sensitive_media

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -33,7 +33,7 @@
     = f.input :setting_default_sensitive, as: :boolean, wrapper: :with_label
 
   .fields-group
-    = f.input :setting_alt_text_reminder, as: :boolean, wrapper: :with_label, recommended: true
+    = f.input :setting_alt_text_reminder, as: :boolean, wrapper: :with_label, polyam_only: true
 
   .fields-group
     = f.input :setting_show_application, as: :boolean, wrapper: :with_label, recommended: true

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -33,6 +33,9 @@
     = f.input :setting_default_sensitive, as: :boolean, wrapper: :with_label
 
   .fields-group
+    = f.input :setting_alt_text_reminder, as: :boolean, wrapper: :with_label, recommended: true
+
+  .fields-group
     = f.input :setting_show_application, as: :boolean, wrapper: :with_label, recommended: true
 
   .fields-group

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -5,6 +5,7 @@ en:
     hints:
       defaults:
         fields: You can have up to %{count} items displayed as a table on your profile
+        setting_alt_text_reminder: A reminder will be presented when attempting to post media without an image description
         setting_default_content_type_html: When writing toots, assume they are written in raw HTML, unless specified otherwise
         setting_default_content_type_markdown: When writing toots, assume they are using Markdown for rich text formatting, unless specified otherwise
         setting_default_content_type_plain: When writing toots, assume they are plain text with no special formatting, unless specified otherwise (default Mastodon behavior)
@@ -19,6 +20,7 @@ en:
         comment: Optional. You can enter for whom the invite is for, or reason for creating it
     labels:
       defaults:
+        setting_alt_text_reminder: Display reminder to add image descriptions when posting media
         setting_default_content_type: Default format for toots
         setting_default_content_type_html: HTML
         setting_default_content_type_markdown: Markdown

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@ defaults: &defaults
   reduce_motion: false
   disable_swiping: false
   show_application: false
+  alt_text_reminder: true
   system_font_ui: false
   system_emoji_font: false
   noindex: false

--- a/spec/lib/user_settings_decorator_spec.rb
+++ b/spec/lib/user_settings_decorator_spec.rb
@@ -35,6 +35,13 @@ describe UserSettingsDecorator do
       expect(user.settings['default_sensitive']).to be true
     end
 
+    it 'updates the user settings value for alt text reminder' do
+      values = { 'setting_alt_text_reminder' => '0' }
+
+      settings.update(values)
+      expect(user.settings['alt_text_reminder']).to eq false
+    end
+
     it 'updates the user settings value for unfollow modal' do
       values = { 'setting_unfollow_modal' => '0' }
 


### PR DESCRIPTION
Port of mastodon/#21679

Changes:
- Moved locales to glitch
- Changed file extension of `alt_text_warning_modal.js` to `.jsx`
- Changed buttons from "Go back" to "Back" and "Publish anyway" to "Publish"
Removed the replaced strings.
- Removed rubocop disable comments in `user_settings_decorator.rb`
- a67ee0310efb5e2518d3760276206f0714fa04bc