### PR TITLE
Add featured tags to profiles

### DIFF
--- a/app/javascript/flavours/glitch/features/account_timeline/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account_timeline/components/header.jsx
@@ -150,6 +150,7 @@ export default class Header extends ImmutablePureComponent {
           <div className='account__section-headline'>
             <NavLink exact to={`/@${account.get('acct')}`}><FormattedMessage id='account.posts' defaultMessage='Posts' /></NavLink>
             <NavLink exact to={`/@${account.get('acct')}/with_replies`}><FormattedMessage id='account.posts_with_replies' defaultMessage='Posts with replies' /></NavLink>
+            <NavLink exact to={`/@${account.get('acct')}/featured`}><FormattedMessage id='explore.trending_tags' defaultMessage='Hashtags' /></NavLink>
             <NavLink exact to={`/@${account.get('acct')}/media`}><FormattedMessage id='account.media' defaultMessage='Media' /></NavLink>
           </div>
         )}

--- a/app/javascript/flavours/glitch/features/featured/index.jsx
+++ b/app/javascript/flavours/glitch/features/featured/index.jsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import LoadingIndicator from 'flavours/glitch/components/loading_indicator';
+import { fetchFeaturedTags } from 'flavours/glitch/actions/featured_tags';
+import { lookupAccount, fetchAccount } from 'flavours/glitch/actions/accounts';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import Column from 'flavours/glitch/features/ui/components/column';
+import ProfileColumnHeader from 'flavours/glitch/features/account/components/profile_column_header';
+import HeaderContainer from 'flavours/glitch/features/account_timeline/containers/header_container';
+import BundleColumnError from 'flavours/glitch/features/ui/components/bundle_column_error';
+import LimitedAccountHint from '../account_timeline/components/limited_account_hint';
+import { getAccountHidden } from 'flavours/glitch/selectors';
+import { normalizeForLookup } from 'flavours/glitch/reducers/accounts_map';
+import { List as ImmutableList } from 'immutable';
+import Hashtag from 'flavours/glitch/components/hashtag';
+import ScrollableList from 'flavours/glitch/components/scrollable_list';
+
+const messages = defineMessages({
+  lastStatusAt: { id: 'account.featured_tags.last_status_at', defaultMessage: 'Last post on {date}' },
+  empty: { id: 'account.featured_tags.last_status_never', defaultMessage: 'No posts' },
+});
+
+const mapStateToProps = (state, { params: { acct, id } }) => {
+  const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
+
+  if (!accountId) {
+    return {
+      isLoading: true,
+    };
+  }
+
+  return {
+    accountId,
+    acct: state.getIn(['accounts', accountId, 'acct']),
+    remote: !!(state.getIn(['accounts', accountId, 'acct']) !== state.getIn(['accounts', accountId, 'username'])),
+    remoteUrl: state.getIn(['accounts', accountId, 'url']),
+    isAccount: !!state.getIn(['accounts', accountId]),
+    featuredTags: state.getIn(['user_lists', 'featured_tags', accountId, 'items'], ImmutableList()),
+    isLoading: state.getIn(['user_lists', 'featured_tags', accountId, 'isLoading'], true),
+    suspended: state.getIn(['accounts', accountId, 'suspended'], false),
+    hidden: getAccountHidden(state, accountId),
+  };
+};
+
+class Featured extends ImmutablePureComponent {
+
+  static propTypes = {
+    params: PropTypes.shape({
+      acct: PropTypes.string,
+      id: PropTypes.string,
+    }).isRequired,
+    dispatch: PropTypes.func.isRequired,
+    accountId: PropTypes.string,
+    acct: PropTypes.string,
+    remote: PropTypes.bool,
+    remoteUrl: PropTypes.string,
+    multiColumn: PropTypes.bool,
+    intl: PropTypes.object.isRequired,
+    isAccount: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    suspended: PropTypes.bool,
+    hidden: PropTypes.bool,
+    featuredTags: ImmutablePropTypes.list,
+  };
+
+  _load () {
+    const { accountId, isAccount, dispatch } = this.props;
+
+    if (!isAccount) dispatch(fetchAccount(accountId));
+    dispatch(fetchFeaturedTags(accountId));
+  }
+
+  componentDidMount () {
+    const { params: { acct }, accountId, dispatch } = this.props;
+
+    if (accountId) {
+      this._load();
+    } else {
+      dispatch(lookupAccount(acct));
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    const { params: { acct }, accountId, dispatch } = this.props;
+
+    if (prevProps.accountId !== accountId && accountId) {
+      this._load();
+    } else if (prevProps.params.acct !== acct) {
+      dispatch(lookupAccount(acct));
+    }
+  }
+
+  setRef = c => {
+    this.column = c;
+  };
+
+  handleHeaderClick = () => {
+    this.column.scrollTop();
+  };
+
+  render () {
+    const { multiColumn, intl, featuredTags, accountId, acct, isAccount, suspended, hidden, isLoading, remoteUrl } = this.props;
+
+    if (!isAccount) {
+      return (
+        <BundleColumnError multiColumn={multiColumn} errorType='routing' />
+      );
+    }
+
+    if (!featuredTags) {
+      return (
+        <Column>
+          <LoadingIndicator />
+        </Column>
+      );
+    }
+
+    /*NOTE: Limited account hint will never show, most likely because featured tags are still returned for limited accounts,
+     *      while other requests return empty data.
+     */
+    let emptyMessage;
+
+    if (suspended) {
+      emptyMessage = <FormattedMessage id='empty_column.account_suspended' defaultMessage='Account suspended' />;
+    } else if (hidden) {
+      emptyMessage = <LimitedAccountHint accountId={accountId} />;
+    } else {
+      emptyMessage = <FormattedMessage id='account.featured_tags.empty' defaultMessage="This user doesn't feature any hashtags yet." />;
+    }
+
+    /*NOTE: featuredTag.get('url') in Hashtag href attribute always points to the local instance.
+     *      I couldn't find a way to fix that, so it was replaced with `${remoteUrl}/tagged/${featuredTag.get('name')}
+     */
+    return (
+      <Column bindToDocument={!multiColumn} ref={this.setRef}>
+        <ProfileColumnHeader onClick={this.handleHeaderClick} multiColumn={multiColumn} />
+
+        <ScrollableList
+          scrollKey='featured'
+          isLoading={isLoading}
+          prepend={<HeaderContainer accountId={this.props.accountId} />}
+          alwaysPrepend
+          emptyMessage={emptyMessage}
+          bindToDocument={!multiColumn}
+        >
+          {featuredTags.map(featuredTag => (
+            <Hashtag
+              key={featuredTag.get('name')}
+              name={featuredTag.get('name')}
+              href={`${remoteUrl}/tagged/${featuredTag.get('name')}`}
+              to={`/@${acct}/tagged/${featuredTag.get('name')}`}
+              uses={featuredTag.get('statuses_count')}
+              withGraph={false}
+              description={((featuredTag.get('statuses_count') * 1) > 0) ? intl.formatMessage(messages.lastStatusAt, { date: intl.formatDate(featuredTag.get('last_status_at'), { month: 'short', day: '2-digit' }) }) : intl.formatMessage(messages.empty)}
+            />
+          ))}
+        </ScrollableList>
+      </Column>
+    );
+  }
+
+}
+
+export default connect(mapStateToProps)(injectIntl(Featured));

--- a/app/javascript/flavours/glitch/features/ui/index.jsx
+++ b/app/javascript/flavours/glitch/features/ui/index.jsx
@@ -55,6 +55,7 @@ import {
   FollowRecommendations,
   About,
   PrivacyPolicy,
+  Featured,
 } from './util/async-components';
 import { HotKeys } from 'react-hotkeys';
 import initialState, { me, owner, singleUserMode, showTrends, trendsAsLanding } from '../../initial_state';
@@ -217,6 +218,7 @@ class SwitchingColumnsArea extends React.PureComponent {
           <WrappedRoute path={['/accounts/:id/followers', '/users/:acct/followers', '/@:acct/followers']} component={Followers} content={children} />
           <WrappedRoute path={['/accounts/:id/following', '/users/:acct/following', '/@:acct/following']} component={Following} content={children} />
           <WrappedRoute path={['/@:acct/media', '/accounts/:id/media']} component={AccountGallery} content={children} />
+          <WrappedRoute path={['/@:acct/featured', '/accounts/:id/featured']} component={Featured} content={children} />
           <WrappedRoute path='/@:acct/:statusId' exact component={Status} content={children} />
           <WrappedRoute path='/@:acct/:statusId/reblogs' component={Reblogs} content={children} />
           <WrappedRoute path='/@:acct/:statusId/favourites' component={Favourites} content={children} />

--- a/app/javascript/flavours/glitch/features/ui/util/async-components.js
+++ b/app/javascript/flavours/glitch/features/ui/util/async-components.js
@@ -78,6 +78,10 @@ export function Following () {
   return import(/* webpackChunkName: "flavours/glitch/async/following" */'flavours/glitch/features/following');
 }
 
+export function Featured () {
+  return import(/* webpackChunkName: "flavours/glitch/async/featured" */'flavours/glitch/features/featured');
+}
+
 export function Reblogs () {
   return import(/* webpackChunkName: "flavours/glitch/async/reblogs" */'flavours/glitch/features/reblogs');
 }

--- a/app/javascript/flavours/glitch/locales/defaultMessages.json
+++ b/app/javascript/flavours/glitch/locales/defaultMessages.json
@@ -475,6 +475,15 @@
   {
     "descriptors": [
       {
+        "defaultMessage": "This user doesn't feature any hashtags yet.",
+        "id": "account.featured_tags.empty"
+      }
+    ],
+    "path": "app/javascript/flavours/glitch/features/featured/index.json"
+  },
+  {
+    "descriptors": [
+      {
         "defaultMessage": "Misc",
         "id": "column.heading"
       },

--- a/app/javascript/flavours/glitch/locales/en.json
+++ b/app/javascript/flavours/glitch/locales/en.json
@@ -2,6 +2,7 @@
   "about.fork_disclaimer": "Glitch-soc is free open source software forked from Mastodon.",
   "account.add_account_note": "Add note for @{name}",
   "account.disclaimer_full": "Information below may reflect the user's profile incompletely.",
+  "account.featured_tags.empty": "This user doesn't feature any hashtags yet.",
   "account.follows": "Follows",
   "account.joined": "Joined {date}",
   "account.request_follow": "Request follow",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,7 @@ Rails.application.routes.draw do
   constraints(username: /[^@\/.]+/) do
     get '/@:username', to: 'accounts#show', as: :short_account
     get '/@:username/with_replies', to: 'accounts#show', as: :short_account_with_replies
+    get '/@:username/featured', to: 'accounts#show', as: :short_account_featured
     get '/@:username/media', to: 'accounts#show', as: :short_account_media
     get '/@:username/tagged/:tag', to: 'accounts#show', as: :short_account_tag
   end

--- a/spec/routing/accounts_routing_spec.rb
+++ b/spec/routing/accounts_routing_spec.rb
@@ -42,6 +42,10 @@ describe 'Routes under accounts/' do
       expect(get("/@#{username}/media")).to route_to('accounts#show', username: username)
     end
 
+    it 'routes /@:username/featured' do
+      expect(get("/@#{username}/featured")).to route_to('accounts#show', username: username)
+    end
+
     it 'routes /@:username/tagged/:tag' do
       expect(get("/@#{username}/tagged/foo")).to route_to('accounts#show', username: username, tag: 'foo')
     end
@@ -76,6 +80,10 @@ describe 'Routes under accounts/' do
 
     it 'routes /@:username/media' do
       expect(get("/@#{username}/media")).to route_to('home#index', username_with_domain: username, any: 'media')
+    end
+
+    it 'routes /@:username/featured' do
+      expect(get("/@#{username}/featured")).to route_to('home#index', username_with_domain: username, any: 'featured')
     end
 
     it 'routes /@:username/tagged/:tag' do


### PR DESCRIPTION
Adding featured tags back to profiles.
Originally it was intended to also show featured accounts, but those don't federate and are only visible to yourself, so it's useless.

Preview:
![Screenshot_2023-04-16_15-51-28](https://user-images.githubusercontent.com/117664621/232315876-9ae6883d-2641-42a9-afed-1d4b5138ed78.png)
