### PR TITLE
Show first unread announcement by default

### DIFF
--- a/app/javascript/flavours/glitch/features/getting_started/components/announcements.jsx
+++ b/app/javascript/flavours/glitch/features/getting_started/components/announcements.jsx
@@ -382,7 +382,7 @@ class Announcements extends ImmutablePureComponent {
   };
 
   state = {
-    index: 0,
+    index: this._findFirstUnread(),
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -399,6 +399,15 @@ class Announcements extends ImmutablePureComponent {
 
   componentDidUpdate () {
     this._markAnnouncementAsRead();
+  }
+
+  /**
+   * Finds the index of the first unread announcement
+   * @returns index of first unread announcement or 0
+   */
+  _findFirstUnread () {
+    const index = this.props.announcements.findIndex((item) => !item.get('read'));
+    return index >= 0 ? index : 0;
   }
 
   _markAnnouncementAsRead () {


### PR DESCRIPTION
Instead of showing the first available announcement, show the first unread announcement by default.