### PR TITLE
Add `build:development:legacy`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "postversion": "git push --tags",
     "build:development": "cross-env RAILS_ENV=development NODE_ENV=development ./bin/webpack",
+    "build:development:legacy": "cross-env RAILS_ENV=development NODE_ENV=development NODE_OPTIONS=--openssl-legacy-provider ./bin/webpack",
     "build:production": "cross-env RAILS_ENV=production NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider ./bin/webpack",
     "manage:translations": "node ./config/webpack/translationRunner.js",
     "start": "node ./streaming/index.js",


### PR DESCRIPTION
Adds a new command to do dev builds for modern systems requiring the `openssl-legacy-provider` flag.
This flag is not supported in workflows, but local builds fail without it.