### PR TITLE
Rename `is_exclusive` to `exclusive`

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -42,6 +42,6 @@ class Api::V1::ListsController < Api::BaseController
   end
 
   def list_params
-    params.permit(:title, :replies_policy, :is_exclusive)
+    params.permit(:title, :replies_policy, :exclusive)
   end
 end

--- a/app/javascript/flavours/glitch/actions/lists.js
+++ b/app/javascript/flavours/glitch/actions/lists.js
@@ -150,10 +150,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset, is_exclusive, replies_policy) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, exclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, exclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/flavours/glitch/features/list_timeline/index.jsx
+++ b/app/javascript/flavours/glitch/features/list_timeline/index.jsx
@@ -151,7 +151,7 @@ class ListTimeline extends React.PureComponent {
     const pinned = !!columnId;
     const title  = list ? list.get('title') : id;
     const replies_policy = list ? list.get('replies_policy') : undefined;
-    const isExclusive = list ? list.get('is_exclusive') : undefined;
+    const isExclusive = list ? list.get('exclusive') : undefined;
 
     if (typeof list === 'undefined') {
       return (

--- a/app/javascript/flavours/glitch/reducers/list_editor.js
+++ b/app/javascript/flavours/glitch/reducers/list_editor.js
@@ -46,7 +46,7 @@ export default function listEditorReducer(state = initialState, action) {
     return state.withMutations(map => {
       map.set('listId', action.list.get('id'));
       map.set('title', action.list.get('title'));
-      map.set('isExclusive', action.list.get('is_exclusive'));
+      map.set('isExclusive', action.list.get('exclusive'));
       map.set('isSubmitting', false);
     });
   case LIST_EDITOR_TITLE_CHANGE:

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -150,10 +150,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset, is_exclusive, replies_policy) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, exclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, exclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/mastodon/features/list_timeline/index.jsx
+++ b/app/javascript/mastodon/features/list_timeline/index.jsx
@@ -151,7 +151,7 @@ class ListTimeline extends React.PureComponent {
     const pinned = !!columnId;
     const title  = list ? list.get('title') : id;
     const replies_policy = list ? list.get('replies_policy') : undefined;
-    const isExclusive = list ? list.get('is_exclusive') : undefined;
+    const isExclusive = list ? list.get('exclusive') : undefined;
 
     if (typeof list === 'undefined') {
       return (

--- a/app/javascript/mastodon/reducers/list_editor.js
+++ b/app/javascript/mastodon/reducers/list_editor.js
@@ -46,7 +46,7 @@ export default function listEditorReducer(state = initialState, action) {
     return state.withMutations(map => {
       map.set('listId', action.list.get('id'));
       map.set('title', action.list.get('title'));
-      map.set('isExclusive', action.list.get('is_exclusive'));
+      map.set('isExclusive', action.list.get('exclusive'));
       map.set('isSubmitting', false);
     });
   case LIST_EDITOR_TITLE_CHANGE:

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -615,7 +615,7 @@ class FeedManager
     crutches[:domain_blocking] = AccountDomainBlock.where(account_id: receiver_id, domain: statuses.flat_map { |s| [s.account.domain, s.reblog&.account&.domain] }.compact).pluck(:domain).index_with(true)
     crutches[:blocked_by]      = Block.where(target_account_id: receiver_id, account_id: statuses.map { |s| [s.account_id, s.reblog&.account_id] }.flatten.compact).pluck(:account_id).index_with(true)
     # Get accounts on exclusive lists which match authors of toots
-    crutches[:exclusive]       = ListAccount.where(list: List.where(account_id: receiver_id, is_exclusive: true), account_id: statuses.map(&:account_id).compact).pluck(:account_id).index_with(true)
+    crutches[:exclusive]       = ListAccount.where(list: List.where(account_id: receiver_id, exclusive: true), account_id: statuses.map(&:account_id).compact).pluck(:account_id).index_with(true)
 
     crutches
   end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -10,7 +10,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  replies_policy :integer          default("list"), not null
-#  is_exclusive   :boolean          default(FALSE)
+#  exclusive      :boolean          default(FALSE)
 #
 
 class List < ApplicationRecord

--- a/app/serializers/rest/list_serializer.rb
+++ b/app/serializers/rest/list_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ListSerializer < ActiveModel::Serializer
-  attributes :id, :title, :replies_policy, :is_exclusive
+  attributes :id, :title, :replies_policy, :exclusive
 
   def id
     object.id.to_s

--- a/db/migrate/20230505093749_polyam_add_exclusive_to_lists.rb
+++ b/db/migrate/20230505093749_polyam_add_exclusive_to_lists.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PolyamAddExclusiveToLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lists, :exclusive, :boolean, default: false
+  end
+end

--- a/db/migrate/20230505094629_polyam_move_is_exclusive_lists.rb
+++ b/db/migrate/20230505094629_polyam_move_is_exclusive_lists.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PolyamMoveIsExclusiveLists < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    List.update_all('exclusive=is_exclusive') # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def down
+    List.update_all('is_exclusive=exclusive') # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/db/migrate/20230505100107_polyam_remove_is_exclusive_list.rb
+++ b/db/migrate/20230505100107_polyam_remove_is_exclusive_list.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PolyamRemoveIsExclusiveList < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :lists, :is_exclusive, :boolean, default: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_03_212843) do
+ActiveRecord::Schema.define(version: 2023_05_05_100107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -540,7 +540,7 @@ ActiveRecord::Schema.define(version: 2023_04_03_212843) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "replies_policy", default: 0, null: false
-    t.boolean "is_exclusive", default: false
+    t.boolean "exclusive", default: false
     t.index ["account_id"], name: "index_lists_on_account_id"
   end
 

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe FeedManager do
       end
 
       it 'returns true for account on exclusive list' do
-        list = Fabricate(:list, account: alice, is_exclusive: true)
+        list = Fabricate(:list, account: alice, exclusive: true)
         alice.follow!(bob)
         list.accounts << bob
         status = Fabricate(:status, text: 'Hello world', account: bob)


### PR DESCRIPTION
Should've changed it from the start :/

strong_migrations prevents the use of rename_column, so a new column is created, values of the old column copied and then the old column gets removed.