### PR TITLE
Add `reaction` to `NON_EMAIL_TYPES`

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -8,6 +8,7 @@ class NotifyService < BaseService
     admin.sign_up
     update
     poll
+    reaction
   ).freeze
 
   def call(recipient, type, activity)


### PR DESCRIPTION
Ref #21
When trying to send an e-mail, the service fails with a KeyError as e-mail notifications for reactions are not yet supported.