### PR TITLE
Don't invalidate already existing reactions

### DIFF
--- a/app/validators/status_reaction_validator.rb
+++ b/app/validators/status_reaction_validator.rb
@@ -9,13 +9,17 @@ class StatusReactionValidator < ActiveModel::Validator
     return if reaction.name.blank?
 
     reaction.errors.add(:name, I18n.t('reactions.errors.unrecognized_emoji')) if reaction.custom_emoji_id.blank? && !unicode_emoji?(reaction.name)
-    reaction.errors.add(:base, I18n.t('reactions.errors.limit_reached')) if reaction.account.local? && limit_reached?(reaction)
+    reaction.errors.add(:base, I18n.t('reactions.errors.limit_reached')) if reaction.account.local? && new_reaction?(reaction) && limit_reached?(reaction)
   end
 
   private
 
   def unicode_emoji?(name)
     SUPPORTED_EMOJIS.include?(name)
+  end
+
+  def new_reaction?(reaction)
+    !reaction.status.status_reactions.exists?(status: reaction.status, account: reaction.account, name: reaction.name)
   end
 
   def limit_reached?(reaction)


### PR DESCRIPTION
Ref #21
This is essentially only needed for the fabricator to work, since right now the validator invalidates a reaction which is already existing.