### PR TITLE
Fix being able to bypass `MAX_REACTIONS`

### DIFF
--- a/app/validators/status_reaction_validator.rb
+++ b/app/validators/status_reaction_validator.rb
@@ -19,7 +19,7 @@ class StatusReactionValidator < ActiveModel::Validator
   end
 
   def new_reaction?(reaction)
-    !reaction.status.status_reactions.exists?(status: reaction.status, account: reaction.account, name: reaction.name)
+    !reaction.status.status_reactions.exists?(status: reaction.status, account: reaction.account, name: reaction.name, custom_emoji: reaction.custom_emoji)
   end
 
   def limit_reached?(reaction)


### PR DESCRIPTION
Ref #21

When an account reacts with different custom emojis with the same name, it didn't count as a new reaction and therefore the limit wasn't enforced.