### PR TITLE
Fix missing not null for exclusive in lists

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -10,7 +10,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  replies_policy :integer          default("list"), not null
-#  exclusive      :boolean          default(FALSE)
+#  exclusive      :boolean          default(FALSE), not null
 #
 
 class List < ApplicationRecord

--- a/db/migrate/20221125104951_add_is_exclusive_to_list.rb
+++ b/db/migrate/20221125104951_add_is_exclusive_to_list.rb
@@ -2,6 +2,6 @@
 
 class AddIsExclusiveToList < ActiveRecord::Migration[6.1]
   def change
-    add_column :lists, :is_exclusive, :boolean, default: false
+    add_column :lists, :is_exclusive, :boolean, default: false # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20230505093749_polyam_add_exclusive_to_lists.rb
+++ b/db/migrate/20230505093749_polyam_add_exclusive_to_lists.rb
@@ -2,6 +2,6 @@
 
 class PolyamAddExclusiveToLists < ActiveRecord::Migration[6.1]
   def change
-    add_column :lists, :exclusive, :boolean, default: false
+    add_column :lists, :exclusive, :boolean, default: false # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20230517195218_polyam_set_exclusive_not_null.rb
+++ b/db/migrate/20230517195218_polyam_set_exclusive_not_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PolyamSetExclusiveNotNull < ActiveRecord::Migration[6.1]
+  def change
+    add_check_constraint :lists, 'exclusive IS NOT NULL', name: 'lists_exclusive_null', validate: false
+  end
+end

--- a/db/migrate/20230517195554_polyam_validate_exclusive_not_null.rb
+++ b/db/migrate/20230517195554_polyam_validate_exclusive_not_null.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PolyamValidateExclusiveNotNull < ActiveRecord::Migration[6.1]
+  def change
+    validate_check_constraint :lists, name: 'lists_exclusive_null'
+    change_column_null :lists, :exclusive, false
+    remove_check_constraint :lists, name: 'lists_exclusive_null'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_17_153317) do
+ActiveRecord::Schema.define(version: 2023_05_17_195554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -567,7 +567,7 @@ ActiveRecord::Schema.define(version: 2023_05_17_153317) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "replies_policy", default: 0, null: false
-    t.boolean "exclusive", default: false
+    t.boolean "exclusive", default: false, null: false
     t.index ["account_id"], name: "index_lists_on_account_id"
   end
 


### PR DESCRIPTION
Follow-up to #115

I knew I should've set `null: false`, but I didn't because ???

Changing old and already run migrations doesn't make sense, so Rails/ThreeStateBooleanColumn was disabled in old migrations.