### PR TITLE
Require auth when search is disabled

### DIFF
--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -6,6 +6,7 @@ class Api::V2::SearchController < Api::BaseController
   RESULTS_LIMIT = (ENV['MAX_SEARCH_RESULTS'] || 20).to_i
 
   before_action -> { authorize_if_got_token! :read, :'read:search' }
+  before_action :require_user!, if: :require_auth?
   before_action :validate_search_params!
 
   def index
@@ -40,5 +41,9 @@ class Api::V2::SearchController < Api::BaseController
 
   def search_params
     params.permit(:type, :offset, :min_id, :max_id, :account_id)
+  end
+
+  def require_auth?
+    !Setting.search_preview
   end
 end

--- a/spec/controllers/api/v2/search_controller_spec.rb
+++ b/spec/controllers/api/v2/search_controller_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Api::V2::SearchController do
       let(:search_params) {}
 
       before do
+        Setting.search_preview = true
         get :index, params: search_params
       end
 


### PR DESCRIPTION
While it wasn't possible to use search via the webUI when search was disabled, it was still possible to use the rest API to perform searches.