### PR TITLE
Add further restrictions on user created invites

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -272,6 +272,11 @@ MAX_POLL_OPTION_CHARS=100
 # Maximum number of emoji reactions per toot and user (minimum 1)
 MAX_REACTIONS=1
 
+# Maximum amount of active invites
+# MAX_ACTIVE_INVITES=5
+# Maximun amount of invites created in 24h
+# MAX_DAILY_INVITES=20
+
 # Maximum image and video/audio upload sizes
 # Units are in bytes
 # 1048576 bytes equals 1 megabyte

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -25,6 +25,7 @@ class Invite < ApplicationRecord
   scope :available, -> { where(expires_at: nil).or(where('expires_at >= ?', Time.now.utc)) }
 
   validates :comment, length: { maximum: 420 }
+  validates_with InviteValidator
 
   before_validation :set_code
 

--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -6,7 +6,7 @@ class InvitePolicy < ApplicationPolicy
   end
 
   def create?
-    role.can?(:invite_users) && (current_user.created_at <= (Time.now.utc - 7.days) || index?)
+    role.can?(:invite_users) && (current_user.created_at <= (Time.now.utc - 7.days) || unrestricted?)
   end
 
   def unrestricted?

--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -6,7 +6,7 @@ class InvitePolicy < ApplicationPolicy
   end
 
   def create?
-    role.can?(:invite_users)
+    role.can?(:invite_users) && (current_user.created_at <= (Time.now.utc - 7.days) || index?)
   end
 
   def unrestricted?

--- a/app/validators/invite_validator.rb
+++ b/app/validators/invite_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class InviteValidator < ActiveModel::Validator
+  LIMIT = (ENV['MAX_ACTIVE_INVITES'] || 5).to_i
+  DAILY_LIMIT = (ENV['MAX_DAILY_INVITES'] || 20).to_i
+
+  def validate(invite)
+    return if invite.user.can?(:manage_invites)
+
+    invite.errors.add(:base, I18n.t('invites.errors.limit_reached')) if limit_reached?(invite)
+    invite.errors.add(:base, I18n.t('invites.errors.daily_limit_reached')) if daily_limit_reached?(invite)
+  end
+
+  private
+
+  def limit_reached?(invite)
+    invite.user.invites.available.count >= LIMIT
+  end
+
+  def daily_limit_reached?(invite)
+    invite.user.invites.where('created_at >= ?', (Time.now.utc - 24.hours)).count >= DAILY_LIMIT
+  end
+end

--- a/app/validators/invite_validator.rb
+++ b/app/validators/invite_validator.rb
@@ -5,7 +5,7 @@ class InviteValidator < ActiveModel::Validator
   DAILY_LIMIT = (ENV['MAX_DAILY_INVITES'] || 20).to_i
 
   def validate(invite)
-    return if invite.user.can?(:manage_invites)
+    return if invite.user.can?(:bypass_invite_limits)
 
     invite.errors.add(:base, I18n.t('invites.errors.limit_reached')) if limit_reached?(invite)
     invite.errors.add(:base, I18n.t('invites.errors.daily_limit_reached')) if daily_limit_reached?(invite)

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -88,6 +88,9 @@ en:
   generic:
     use_this: Use this
   invites:
+    errors:
+      daily_limit_reached: Daily limit of created invites reached
+      limit_reached: Maximum number of active invites reached
     table:
       comment: Comment
   notification_mailer:

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe InvitesController do
   render_views
 
-  let(:user) { Fabricate(:user) }
+  let(:user) { Fabricate(:user, created_at: 7.days.ago) }
 
   before do
     sign_in user

--- a/spec/policies/invite_policy_spec.rb
+++ b/spec/policies/invite_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe InvitePolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:user, created_at: 7.days.ago).account }
 
   permissions :index? do
     context 'when staff?' do

--- a/spec/validators/invite_validator_spec.rb
+++ b/spec/validators/invite_validator_spec.rb
@@ -25,8 +25,8 @@ describe InviteValidator do
         expect(errors).to have_received(:add)
       end
 
-      context 'when user has manage invite permission' do
-        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+      context 'when user can bypass limits' do
+        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Moderator')) }
 
         it 'does not add error' do
           subject.validate(invite)
@@ -47,8 +47,8 @@ describe InviteValidator do
         expect(errors).to have_received(:add)
       end
 
-      context 'when user has manage invite permission' do
-        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+      context 'when user can bypass limits' do
+        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Moderator')) }
 
         it 'does not add error' do
           subject.validate(invite)

--- a/spec/validators/invite_validator_spec.rb
+++ b/spec/validators/invite_validator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe InviteValidator do
+  let(:user) { Fabricate(:user, created_at: 7.days.ago) }
+  let(:invite) { instance_double(Invite, user: user, errors: errors) }
+  let(:errors) { instance_double(ActiveModel::Errors, add: nil) }
+
+  describe '#validate' do
+    it 'does not add error' do
+      subject.validate(invite)
+      expect(errors).to_not have_received(:add)
+    end
+
+    context 'when active invites limit is reached' do
+      before do
+        5.times do
+          Fabricate(:invite, user: user)
+        end
+      end
+
+      it 'add error' do
+        subject.validate(invite)
+        expect(errors).to have_received(:add)
+      end
+
+      context 'when user has manage invite permission' do
+        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+
+        it 'does not add error' do
+          subject.validate(invite)
+          expect(errors).to_not have_received(:add)
+        end
+      end
+    end
+
+    context 'when daily limit is reached' do
+      before do
+        20.times do
+          Fabricate(:invite, user: user, expires_at: 10.minutes.ago.utc)
+        end
+      end
+
+      it 'adds error' do
+        subject.validate(invite)
+        expect(errors).to have_received(:add)
+      end
+
+      context 'when user has manage invite permission' do
+        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+
+        it 'does not add error' do
+          subject.validate(invite)
+          expect(errors).to_not have_received(:add)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Limit maximum number of active invites to 5.

Limit creation of invites to 20 in the past 24h.

Require accounts to be at least 7 days old to create invites.

These limits can be bypassed by giving the `bypass_invite_limits` permission.

Note:
- 73ef5d4f7b3098de7a3db9027c003b8d9a439cc5 and 4b420de805f8f1a774f598e75e88d570b8850a98 are temporary patches.