### PR TITLE
Change value of `bypass_invite_limits`

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -36,7 +36,8 @@ class UserRole < ApplicationRecord
     manage_roles: (1 << 17),
     manage_user_access: (1 << 18),
     delete_user_data: (1 << 19),
-    bypass_invite_limits: (1 << 20),
+    legacy_bypass_invite_limits: (1 << 20),
+    bypass_invite_limits: (1 << 50),
   }.freeze
 
   module Flags

--- a/db/post_migrate/20230522123100_polyam_change_bypass_invite_permission_value.rb
+++ b/db/post_migrate/20230522123100_polyam_change_bypass_invite_permission_value.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class PolyamChangeBypassInvitePermissionValue < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  class UserRole < ApplicationRecord; end
+
+  def change
+    admin_role     = UserRole.find_by(name: 'Admin')
+    moderator_role = UserRole.find_by(name: 'Moderator')
+    everyone_role  = UserRole.find_by(id: -99)
+
+    legacy_permission = ::UserRole::FLAGS[:legacy_bypass_invite_limits]
+
+    if everyone_role && legacy_permission && everyone_role.permissions == (everyone_role.permissions | legacy_permission)
+      everyone_role.permissions &= ~legacy_permission
+      everyone_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+      everyone_role.save
+    end
+
+    if moderator_role
+      moderator_role.permissions &= ~legacy_permission if legacy_permission && moderator_role.permissions == (moderator_role.permissions | legacy_permission)
+      moderator_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+      moderator_role.save
+    end
+
+    return unless admin_role
+
+    admin_role.permissions &= ~legacy_permission if legacy_permission && admin_role.permissions == (admin_role.permissions | legacy_permission)
+    admin_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+    admin_role.save
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_19_010427) do
+ActiveRecord::Schema.define(version: 2023_05_22_123100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Follow-up to #138 

To avoid possible future conflicts where upstream might add more permissions, change the value to 1 << 50

`legacy_bypass_invite_limits` can be safely removed later.
This is just done, so the migration doesn't remove a permission when run after upstream added new ones.