### PR TITLE
Fix NameError when requesting archives

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -101,8 +101,8 @@ class BackupService < BaseService
     actor[:likes]       = 'likes.json'
     actor[:bookmarks]   = 'bookmarks.json'
 
-    download_to_zip(tar, account.avatar, "avatar#{File.extname(account.avatar.path)}") if account.avatar.exists?
-    download_to_zip(tar, account.header, "header#{File.extname(account.header.path)}") if account.header.exists?
+    download_to_zip(zipfile, account.avatar, "avatar#{File.extname(account.avatar.path)}") if account.avatar.exists?
+    download_to_zip(zipfile, account.header, "header#{File.extname(account.header.path)}") if account.header.exists?
 
     json = Oj.dump(actor)
 


### PR DESCRIPTION
`tar` was renamed to `zipfile` in a recent refactor, but was still used, causing requesting archives to never succeed.