### PR TITLE
Fix crash when opening alt-text and alt-text-warning modal

### DIFF
--- a/app/javascript/flavours/glitch/actions/compose.js
+++ b/app/javascript/flavours/glitch/actions/compose.js
@@ -187,11 +187,11 @@ export function submitCompose(routerHistory, checkAltText = true) {
     if (checkAltText && getState().getIn(['compose', 'alt_text_reminder']) && media.size > 0) {
       // If there are any attachments that are missing descriptions, display the warning modal.
       if (media.some((attach) => attach.get('description') === null || attach.get('description') === '')) {
-        dispatch(openModal( 'ALT_TEXT_WARNING', {
+        dispatch(openModal({ modalType: 'ALT_TEXT_WARNING', modalProps: {
           onSubmitCompose: () => {
             dispatch(submitCompose(routerHistory, false));
           },
-        }));
+        }}));
         return;
       }
     }

--- a/app/javascript/flavours/glitch/containers/status_container.js
+++ b/app/javascript/flavours/glitch/containers/status_container.js
@@ -257,7 +257,7 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
   },
 
   onOpenAltText (statusId, media) {
-    dispatch(openModal('ALTTEXT', { statusId, media }));
+    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { statusId, media }}));
   },
 
   onBlock (status) {

--- a/app/javascript/flavours/glitch/features/account_gallery/index.jsx
+++ b/app/javascript/flavours/glitch/features/account_gallery/index.jsx
@@ -172,7 +172,7 @@ class AccountGallery extends ImmutablePureComponent {
     const { dispatch } = this.props;
     const statusId = attachment.getIn(['status', 'id']);
 
-    dispatch(openModal('ALTTEXT', { media: attachment, statusId }));
+    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: attachment, statusId } }));
   };
 
   handleRef = c => {

--- a/app/javascript/flavours/glitch/features/status/index.jsx
+++ b/app/javascript/flavours/glitch/features/status/index.jsx
@@ -451,7 +451,7 @@ class Status extends ImmutablePureComponent {
   handleAltClick = (index) => {
     const { status } = this.props;
 
-    this.props.dispatch(openModal('ALTTEXT', { statusId: status.get('id'), media: status.getIn(['media_attachments', index ? index : 0]) }));
+    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { statusId: status.get('id'), media: status.getIn(['media_attachments', index ? index : 0]) } }));
   };
 
   handleHotkeyOpenMedia = e => {

--- a/app/javascript/flavours/glitch/features/ui/components/alt_text_warning_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/alt_text_warning_modal.jsx
@@ -11,7 +11,7 @@ import Button from 'flavours/glitch/components/button';
 const mapDispatchToProps = dispatch => {
   return {
     onClose() {
-      dispatch(closeModal());
+      dispatch(closeModal({ modalType: 'ALT_TEXT_WARNING', ignoreFocus: false }));
     },
   };
 };

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -175,11 +175,11 @@ export function submitCompose(routerHistory, checkAltText = true) {
     if (checkAltText && getState().getIn(['compose', 'alt_text_reminder']) && media.size > 0) {
       // If there are any attachments that are missing descriptions, display the warning modal.
       if (media.some((attach) => attach.get('description') === null || attach.get('description') === '')) {
-        dispatch(openModal( 'ALT_TEXT_WARNING', {
+        dispatch(openModal({ modalType: 'ALT_TEXT_WARNING', modalProps: {
           onSubmitCompose: () => {
             dispatch(submitCompose(routerHistory, false));
           },
-        }));
+        }}));
         return;
       }
     }

--- a/app/javascript/mastodon/features/ui/components/alt_text_warning_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/alt_text_warning_modal.jsx
@@ -19,7 +19,7 @@ const makeMapStateToProps = () => {
 const mapDispatchToProps = dispatch => {
   return {
     onClose() {
-      dispatch(closeModal());
+      dispatch(closeModal({ modalType: 'ALT_TEXT_WARNING', ignoreFocus: false }));
     },
   };
 };


### PR DESCRIPTION
Missed that upstream changed how modals are handled.