### PR TITLE
Update custom emoji upload form

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -47,7 +47,7 @@ module Admin
     private
 
     def resource_params
-      params.require(:custom_emoji).permit(:shortcode, :image, :visible_in_picker)
+      params.require(:custom_emoji).permit(:shortcode, :image, :visible_in_picker, :category_id)
     end
 
     def filtered_custom_emojis

--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -11,7 +11,7 @@
   .fields-group
     = f.input :image, wrapper: :with_label, input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(' ') }, hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LOCAL_LIMIT))
   .fields-group
-    = f.input :visible_in_picker, as: :boolean, wrapper: :with_label, label: t('admin.custom_emojis.visible_in_picker'), polyam_only: true
+    = f.input :visible_in_picker, as: :boolean, wrapper: :with_label, label: t('admin.custom_emojis.visible_in_picker'), hint: t('admin.custom_emojis.visible_in_picker_hint'), polyam_only: true
 
   .actions
     = f.button :button, t('admin.custom_emojis.upload'), type: :submit

--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -7,7 +7,11 @@
   .fields-group
     = f.input :shortcode, wrapper: :with_label, label: t('admin.custom_emojis.shortcode'), hint: t('admin.custom_emojis.shortcode_hint')
   .fields-group
+    = f.input :category_id, wrapper: :with_label, label: t('admin.reports.category'), hint: t('admin.custom_emojis.category_hint'), collection: CustomEmojiCategory.all, prompt: t('admin.custom_emojis.uncategorized'), polyam_only: true
+  .fields-group
     = f.input :image, wrapper: :with_label, input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(' ') }, hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LOCAL_LIMIT))
+  .fields-group
+    = f.input :visible_in_picker, as: :boolean, wrapper: :with_label, label: t('admin.custom_emojis.visible_in_picker'), polyam_only: true
 
   .actions
     = f.button :button, t('admin.custom_emojis.upload'), type: :submit

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -13,6 +13,8 @@ en:
     custom_emojis:
       batch_copy_error: 'An error occurred while copying some of the selected emoji: %{message}'
       batch_error: 'An error occurred: %{message}'
+      category_hint: Optional. Assign the emoji to a category.
+      visible_in_picker: Show in emoji picker
     registration_filters:
       add_new: Add new filter
       created_msg: Registration text filter successfully created!

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -15,6 +15,7 @@ en:
       batch_error: 'An error occurred: %{message}'
       category_hint: Optional. Assign the emoji to a category.
       visible_in_picker: Show in emoji picker
+      visible_in_picker_hint: Makes this emoji available in the emoji picker and API.
     registration_filters:
       add_new: Add new filter
       created_msg: Registration text filter successfully created!


### PR DESCRIPTION
Add ability to assign a category.
Add checkbox for showing emoji in emoji picker.
Add new translation strings.

Preview:
![Custom emoji upload page with an additional select input and checkbox](https://github.com/polyamspace/mastodon/assets/117664621/576e6433-b95e-44c6-9d5c-1361ef750410)

Some thoughts:
The checkbox looks a bit off without a hint, but the setting is pretty self-explanatory.
I'm not sure I'm happy with the order of the elements, but I think it's good enough.