### PR TITLE
Disable confirmation screen when suspending domain

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -104,7 +104,8 @@ module Admin
     end
 
     def requires_confirmation?
-      @domain_block.valid? && (@domain_block.new_record? || @domain_block.severity_changed?) && @domain_block.severity.to_s == 'suspend' && !params[:confirm]
+      # @domain_block.valid? && (@domain_block.new_record? || @domain_block.severity_changed?) && @domain_block.severity.to_s == 'suspend' && !params[:confirm]
+      false
     end
   end
 end

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -88,16 +88,17 @@ RSpec.describe Admin::DomainBlocksController do
           post :create, params: { domain_block: { domain: 'example.com', severity: 'suspend', reject_media: true, reject_reports: true } }
         end
 
-        it 'does not record a block' do
-          expect(DomainBlock.exists?(domain: 'example.com', severity: 'suspend')).to be false
+        it 'records a block' do
+          expect(DomainBlock.exists?(domain: 'example.com', severity: 'suspend')).to be true
         end
 
-        it 'does not call DomainBlockWorker' do
-          expect(DomainBlockWorker).to_not have_received(:perform_async)
+        it 'calls DomainBlockWorker' do
+          expect(DomainBlockWorker).to have_received(:perform_async)
         end
 
-        it 'renders confirm_suspension' do
-          expect(response).to render_template :confirm_suspension
+        it 'redirects with a success message' do
+          expect(flash[:notice]).to eq I18n.t('admin.domain_blocks.created_msg')
+          expect(response).to redirect_to(admin_instances_path(limited: '1'))
         end
       end
 
@@ -131,16 +132,17 @@ RSpec.describe Admin::DomainBlocksController do
           post :create, params: { domain_block: { domain: 'example.com', severity: 'suspend', reject_media: true, reject_reports: true } }
         end
 
-        it 'does not record a block' do
-          expect(DomainBlock.exists?(domain: 'example.com', severity: 'suspend')).to be false
+        it 'updates the record' do
+          expect(DomainBlock.exists?(domain: 'example.com', severity: 'suspend')).to be true
         end
 
-        it 'does not call DomainBlockWorker' do
-          expect(DomainBlockWorker).to_not have_received(:perform_async)
+        it 'calls DomainBlockWorker' do
+          expect(DomainBlockWorker).to have_received(:perform_async)
         end
 
-        it 'renders confirm_suspension' do
-          expect(response).to render_template :confirm_suspension
+        it 'redirects with a success message' do
+          expect(flash[:notice]).to eq I18n.t('admin.domain_blocks.created_msg')
+          expect(response).to redirect_to(admin_instances_path(limited: '1'))
         end
       end
 

--- a/spec/features/admin/domain_blocks_spec.rb
+++ b/spec/features/admin/domain_blocks_spec.rb
@@ -20,7 +20,7 @@ describe 'blocking domains through the moderation interface' do
   end
 
   context 'when suspending a new domain' do
-    it 'presents a confirmation screen before suspending the domain' do
+    it 'suspends the domain' do
       visit new_admin_domain_block_path
 
       fill_in 'domain_block_domain', with: 'example.com'
@@ -28,17 +28,17 @@ describe 'blocking domains through the moderation interface' do
       click_on I18n.t('admin.domain_blocks.new.create')
 
       # It presents a confirmation screen
-      expect(page).to have_title(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
+      # expect(page).to have_title(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
 
       # Confirming creates a block
-      click_on I18n.t('admin.domain_blocks.confirm_suspension.confirm')
+      # click_on I18n.t('admin.domain_blocks.confirm_suspension.confirm')
 
       expect(DomainBlock.exists?(domain: 'example.com', severity: 'suspend')).to be true
     end
   end
 
   context 'when suspending a domain that is already silenced' do
-    it 'presents a confirmation screen before suspending the domain' do
+    it 'suspends the domain' do
       domain_block = Fabricate(:domain_block, domain: 'example.com', severity: 'silence')
 
       visit new_admin_domain_block_path
@@ -48,17 +48,17 @@ describe 'blocking domains through the moderation interface' do
       click_on I18n.t('admin.domain_blocks.new.create')
 
       # It presents a confirmation screen
-      expect(page).to have_title(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
+      # expect(page).to have_title(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
 
       # Confirming updates the block
-      click_on I18n.t('admin.domain_blocks.confirm_suspension.confirm')
+      # click_on I18n.t('admin.domain_blocks.confirm_suspension.confirm')
 
-      expect(domain_block.reload.severity).to eq 'silence'
+      expect(domain_block.reload.severity).to eq 'suspend'
     end
   end
 
   context 'when editing a domain block' do
-    it 'presents a confirmation screen before suspending the domain' do
+    it 'suspends the domain' do
       domain_block = Fabricate(:domain_block, domain: 'example.com', severity: 'silence')
 
       visit edit_admin_domain_block_path(domain_block)
@@ -67,12 +67,12 @@ describe 'blocking domains through the moderation interface' do
       click_on I18n.t('generic.save_changes')
 
       # It presents a confirmation screen
-      expect(page).to have_title(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
+      # expect(page).to have_title(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
 
       # Confirming updates the block
-      click_on I18n.t('admin.domain_blocks.confirm_suspension.confirm')
+      # click_on I18n.t('admin.domain_blocks.confirm_suspension.confirm')
 
-      expect(domain_block.reload.severity).to eq 'silence'
+      expect(domain_block.reload.severity).to eq 'suspend'
     end
   end
 end


### PR DESCRIPTION
This is currently broken and prevents domain blocks from being upgraded.
This could be fixed by using the correct url for editing blocks, but I decided against it as
this screen also introduces a needless extra click when suspending a domain.