### PR TITLE
Fix `unblock_url` leading to 404 when domain block exists

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -34,7 +34,7 @@ module Admin
       # Disallow accidentally downgrading a domain block
       if existing_domain_block.present? && !@domain_block.stricter_than?(existing_domain_block)
         @domain_block.save
-        flash.now[:alert] = I18n.t('admin.domain_blocks.existing_domain_block_html', name: existing_domain_block.domain, unblock_url: admin_domain_block_path(existing_domain_block)).html_safe
+        flash.now[:alert] = I18n.t('admin.domain_blocks.existing_domain_block_html', name: existing_domain_block.domain, unblock_url: admin_instance_path(existing_domain_block.domain)).html_safe
         @domain_block.errors.delete(:domain)
         return render :new
       end


### PR DESCRIPTION
Clicking the url in the message leads to a 404 as it used the wrong path.

Remaining issue:
I need to dig deeper, but I'm sure this is supposed to prevent a domain block from being created when one with a higher severity already exist, hence the warning message.
But it still creates the block.