### PR TITLE
Fix scrolling to top in firehose column

### DIFF
--- a/app/javascript/flavours/glitch/components/column.jsx
+++ b/app/javascript/flavours/glitch/components/column.jsx
@@ -18,7 +18,7 @@ export default class Column extends PureComponent {
   };
 
   scrollTop () {
-    const scrollable = this.props.bindToDocument ? document.scrollingElement : this.node.querySelector('.scrollable');
+    const scrollable = this.props.bindToDocument ? document.scrollingElement : this.node.querySelector('.scrollable:not(.scrollable--flex)');
 
     if (!scrollable) {
       return;


### PR DESCRIPTION
The unusual way the firehose column is wrapped causes querySelector to get the wrong scrollable element which prevents scrolling to top in the advanced UI.

Instead of having to rewrite the firehose column, this change will select the correct element for scrolling.