### PR TITLE
Fix audit logs for registration filters linking to invalid path

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -34,7 +34,7 @@ module Admin::ActionLogsHelper
         I18n.t('admin.action_logs.deleted_account')
       end
     when 'RegistrationFilter'
-      link_to log.human_identifier, admin_registration_filters_path(log.target_id)
+      link_to log.human_identifier, edit_admin_registration_filter_path(log.target_id)
     end
   end
 end


### PR DESCRIPTION
Ref #2 

The link in audit logs always linked to a non-existent path. Instead, link to the edit page for that filter.

This will still lead to a 404 when the registration filter was deleted, but that's in line with other logs.