### PR TITLE
Do not link to remote domains in audit log for blocks

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -15,7 +15,7 @@ module Admin::ActionLogsHelper
       link_to log.human_identifier, admin_roles_path(log.target_id)
     when 'Report'
       link_to "##{log.human_identifier.presence || log.target_id}", admin_report_path(log.target_id)
-    when 'DomainBlock', 'DomainAllow', 'EmailDomainBlock', 'UnavailableDomain'
+    when 'DomainAllow', 'EmailDomainBlock', 'UnavailableDomain'
       link_to log.human_identifier, "https://#{log.human_identifier.presence}"
     when 'Status'
       link_to log.human_identifier, log.permalink
@@ -23,7 +23,7 @@ module Admin::ActionLogsHelper
       link_to log.human_identifier, disputes_strike_path(log.target_id)
     when 'Announcement'
       link_to truncate(log.human_identifier), edit_admin_announcement_path(log.target_id)
-    when 'IpBlock', 'Instance', 'CustomEmoji'
+    when 'DomainBlock', 'IpBlock', 'Instance', 'CustomEmoji'
       log.human_identifier
     when 'CanonicalEmailBlock'
       content_tag(:samp, (log.human_identifier.presence || '')[0...7], title: log.human_identifier)


### PR DESCRIPTION
Alternative to #170

Linking to domains can leak information to potential malicious domains when clicked.