### PR TITLE
Fix playback not continuing when opening media modal

### DIFF
--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.jsx
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.jsx
@@ -81,7 +81,9 @@ class DetailedStatus extends ImmutablePureComponent {
   };
 
   handleOpenVideo = (options) => {
-    this.props.onOpenVideo(this.props.status.getIn(['media_attachments', 0]), options);
+    const { status } = this.props;
+    const lang = status.getIn(['translation', 'language']) || status.get('language');
+    this.props.onOpenVideo(this.props.status.getIn(['media_attachments', 0]), lang, options);
   };
 
   handleAltClick = (index) => {

--- a/app/javascript/flavours/glitch/features/video/index.jsx
+++ b/app/javascript/flavours/glitch/features/video/index.jsx
@@ -485,7 +485,7 @@ class Video extends PureComponent {
   handleOpenVideo = () => {
     this.video.pause();
 
-    this.props.onOpenVideo(this.props.lang, {
+    this.props.onOpenVideo({
       startTime: this.video.currentTime,
       autoPlay: !this.state.paused,
       defaultVolume: this.state.volume,


### PR DESCRIPTION
When opening the video modal (by clicking "Expand"), the playback is supposed to continue at the current volume.
This behaviour has been broken for a while, because a `lang` prop was passed to the handlers which only expected `options`. There is no point in passing `lang` as it is set later and the modal doesn't do anything with it.

A nice to have adjacent to this would be to pass the current time and volume back to the attachment when closing the modal, but passing props back to components is currently not supported afaik.