### PR TITLE
Re-add toggle for show replies and show boosts in public timelines wh…

### DIFF
--- a/app/javascript/flavours/glitch/features/community_timeline/components/column_settings.jsx
+++ b/app/javascript/flavours/glitch/features/community_timeline/components/column_settings.jsx
@@ -7,6 +7,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import SettingText from 'flavours/glitch/components/setting_text';
 import SettingToggle from 'flavours/glitch/features/notifications/components/setting_toggle';
+import { showReblogsPublicTimelines, showRepliesPublicTimelines } from 'flavours/glitch/initial_state';
 
 const messages = defineMessages({
   filter_regex: { id: 'home.column_settings.filter_regex', defaultMessage: 'Filter out by regular expressions' },
@@ -28,6 +29,8 @@ class ColumnSettings extends PureComponent {
     return (
       <div>
         <div className='column-settings__row'>
+          {showReblogsPublicTimelines && <SettingToggle prefix='community_timeline' settings={settings} settingPath={['shows', 'reblog']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_reblogs' defaultMessage='Show boosts' />} />}
+          {showRepliesPublicTimelines && <SettingToggle prefix='community_timeline' settings={settings} settingPath={['shows', 'reply']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_replies' defaultMessage='Show replies' />} />}
           <SettingToggle settings={settings} settingPath={['other', 'onlyMedia']} onChange={onChange} label={<FormattedMessage id='community.column_settings.media_only' defaultMessage='Media only' />} />
         </div>
 

--- a/app/javascript/flavours/glitch/features/community_timeline/index.jsx
+++ b/app/javascript/flavours/glitch/features/community_timeline/index.jsx
@@ -151,6 +151,7 @@ class CommunityTimeline extends PureComponent {
           emptyMessage={<FormattedMessage id='empty_column.community' defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!' />}
           bindToDocument={!multiColumn}
           regex={this.props.regex}
+          columnId={columnId}
         />
 
         <Helmet>

--- a/app/javascript/flavours/glitch/features/firehose/index.jsx
+++ b/app/javascript/flavours/glitch/features/firehose/index.jsx
@@ -12,7 +12,7 @@ import { connectPublicStream, connectCommunityStream } from 'flavours/glitch/act
 import { expandPublicTimeline, expandCommunityTimeline } from 'flavours/glitch/actions/timelines';
 import { DismissableBanner } from 'flavours/glitch/components/dismissable_banner';
 import SettingText from 'flavours/glitch/components/setting_text';
-import initialState, { domain } from 'flavours/glitch/initial_state';
+import initialState, { domain, showReblogsPublicTimelines, showRepliesPublicTimelines } from 'flavours/glitch/initial_state';
 import { useAppDispatch, useAppSelector } from 'flavours/glitch/store';
 
 import Column from '../../components/column';
@@ -46,6 +46,8 @@ const ColumnSettings = () => {
   return (
     <div>
       <div className='column-settings__row'>
+        {showReblogsPublicTimelines && <SettingToggle settings={settings} settingPath={['shows', 'reblog']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_reblogs' defaultMessage='Show boosts' />} />}
+        {showRepliesPublicTimelines && <SettingToggle settings={settings} settingPath={['shows', 'reply']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_replies' defaultMessage='Show replies' />} />}
         <SettingToggle
           settings={settings}
           settingPath={['onlyMedia']}
@@ -82,21 +84,24 @@ const Firehose = ({ feedType, multiColumn }) => {
   const allowLocalOnly = useAppSelector((state) => state.getIn(['settings', 'firehose', 'allowLocalOnly']));
   const regex = useAppSelector((state) => state.getIn(['settings', 'firehose', 'regex', 'body']));
 
+  const showReblogs = useAppSelector((state) => state.getIn(['settings', 'firehose', 'shows', 'reblog'], true));
+  const showReplies = useAppSelector((state) => state.getIn(['settings', 'firehose', 'shows', 'reply'], true));
+
   const handlePin = useCallback(
     () => {
       switch(feedType) {
       case 'community':
-        dispatch(addColumn('COMMUNITY', { other: { onlyMedia }, regex: { body: regex } }));
+        dispatch(addColumn('COMMUNITY', { other: { onlyMedia }, regex: { body: regex }, shows: { reblog: showReblogs, reply: showReplies} }));
         break;
       case 'public':
-        dispatch(addColumn('PUBLIC', { other: { onlyMedia, allowLocalOnly }, regex: { body: regex }  }));
+        dispatch(addColumn('PUBLIC', { other: { onlyMedia, allowLocalOnly }, regex: { body: regex }, shows: { reblog: showReblogs, reply: showReplies}  }));
         break;
       case 'public:remote':
-        dispatch(addColumn('REMOTE', { other: { onlyMedia, onlyRemote: true }, regex: { body: regex }  }));
+        dispatch(addColumn('REMOTE', { other: { onlyMedia, onlyRemote: true }, regex: { body: regex }, shows: { reblog: showReblogs, reply: showReplies}  }));
         break;
       }
     },
-    [dispatch, onlyMedia, feedType, allowLocalOnly, regex],
+    [dispatch, onlyMedia, feedType, allowLocalOnly, regex, showReblogs, showReplies],
   );
 
   const handleLoadMore = useCallback(
@@ -212,6 +217,7 @@ const Firehose = ({ feedType, multiColumn }) => {
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
           regex={regex}
+          firehose
         />
       </div>
 

--- a/app/javascript/flavours/glitch/features/public_timeline/components/column_settings.jsx
+++ b/app/javascript/flavours/glitch/features/public_timeline/components/column_settings.jsx
@@ -7,6 +7,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import SettingText from 'flavours/glitch/components/setting_text';
 import SettingToggle from 'flavours/glitch/features/notifications/components/setting_toggle';
+import { showReblogsPublicTimelines, showRepliesPublicTimelines } from 'flavours/glitch/initial_state';
 
 const messages = defineMessages({
   filter_regex: { id: 'home.column_settings.filter_regex', defaultMessage: 'Filter out by regular expressions' },
@@ -27,6 +28,8 @@ class ColumnSettings extends PureComponent {
     return (
       <div>
         <div className='column-settings__row'>
+          {showReblogsPublicTimelines && <SettingToggle prefix='public_timeline' settings={settings} settingPath={['shows', 'reblog']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_reblogs' defaultMessage='Show boosts' />} />}
+          {showRepliesPublicTimelines && <SettingToggle prefix='public_timeline' settings={settings} settingPath={['shows', 'reply']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_replies' defaultMessage='Show replies' />} />}
           <SettingToggle settings={settings} settingPath={['other', 'onlyMedia']} onChange={onChange} label={<FormattedMessage id='community.column_settings.media_only' defaultMessage='Media only' />} />
           <SettingToggle settings={settings} settingPath={['other', 'onlyRemote']} onChange={onChange} label={<FormattedMessage id='community.column_settings.remote_only' defaultMessage='Remote only' />} />
           {!settings.getIn(['other', 'onlyRemote']) && <SettingToggle settings={settings} settingPath={['other', 'allowLocalOnly']} onChange={onChange} label={<FormattedMessage id='community.column_settings.allow_local_only' defaultMessage='Show local-only toots' />} />}

--- a/app/javascript/flavours/glitch/features/public_timeline/index.jsx
+++ b/app/javascript/flavours/glitch/features/public_timeline/index.jsx
@@ -156,6 +156,7 @@ class PublicTimeline extends PureComponent {
           emptyMessage={<FormattedMessage id='empty_column.public' defaultMessage='There is nothing here! Write something publicly, or manually follow users from other servers to fill it up' />}
           bindToDocument={!multiColumn}
           regex={this.props.regex}
+          columnId={columnId}
         />
 
         <Helmet>

--- a/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
+++ b/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
@@ -8,6 +8,18 @@ import { scrollTopTimeline, loadPending } from 'flavours/glitch/actions/timeline
 import StatusList from 'flavours/glitch/components/status_list';
 import { me } from 'flavours/glitch/initial_state';
 
+const normalizeTimelineId = timelineId => {
+  if (timelineId.startsWith('public:')) {
+    return 'public';
+  }
+
+  if (timelineId.startsWith('community:')) {
+    return 'community';
+  }
+
+  return timelineId;
+};
+
 const getRegex = createSelector([
   (state, { regex }) => regex,
 ], (rawRegex) => {
@@ -21,8 +33,25 @@ const getRegex = createSelector([
   return regex;
 });
 
+// Settings can both be in column params and in state
+// This destinction didn't matter before the introduction of the firehose column
+// Not sure if oversight or on purpose, but multiple community and public timelines can be pinned, which should each have their own settings
+// There is no distinct timelineId for the firehose column, so an additional prop is parsed which indicates settings should be loaded from firehose
+const getSettings = createSelector([
+  (state, { firehose }) => firehose,
+  (state, { columnId }) => columnId,
+  (state, { type }) => type,
+  (state) => state,
+], (firehose, columnId, type, state) => {
+  const uuid = columnId;
+  const columns = state.getIn(['settings', 'columns']);
+  const index = columns.findIndex(c => c.get('uuid') === uuid);
+
+  return (uuid && index >= 0) ? columns.get(index).get('params') : firehose ? state.getIn(['settings', 'firehose'], ImmutableMap()) : state.getIn(['settings', normalizeTimelineId(type)], ImmutableMap())
+})
+
 const makeGetStatusIds = (pending = false) => createSelector([
-  (state, { type }) => state.getIn(['settings', type], ImmutableMap()),
+  getSettings,
   (state, { type }) => state.getIn(['timelines', type, pending ? 'pendingItems' : 'items'], ImmutableList()),
   (state)           => state.get('statuses'),
   getRegex,
@@ -64,8 +93,8 @@ const makeMapStateToProps = () => {
   const getStatusIds = makeGetStatusIds();
   const getPendingStatusIds = makeGetStatusIds(true);
 
-  const mapStateToProps = (state, { timelineId, regex }) => ({
-    statusIds: getStatusIds(state, { type: timelineId, regex }),
+  const mapStateToProps = (state, { firehose = false, columnId, timelineId, regex }) => ({
+    statusIds: getStatusIds(state, { firehose: firehose, columnId: columnId, type: timelineId, regex }),
     lastId:    state.getIn(['timelines', timelineId, 'items'])?.last(),
     isLoading: state.getIn(['timelines', timelineId, 'isLoading'], true),
     isPartial: state.getIn(['timelines', timelineId, 'isPartial'], false),

--- a/app/javascript/flavours/glitch/initial_state.js
+++ b/app/javascript/flavours/glitch/initial_state.js
@@ -173,6 +173,8 @@ export const visibleReactions = getMeta('visible_reactions');
 export const languages = initialState?.languages;
 export const publishButtonText = getMeta('publish_button_text');
 export const statusPageUrl = getMeta('status_page_url');
+export const showReblogsPublicTimelines = getMeta('show_reblogs_in_public_timelines');
+export const showRepliesPublicTimelines = getMeta('show_replies_in_public_timelines');
 
 // Glitch-soc-specific settings
 export const maxChars = (initialState && initialState.max_toot_chars) || 500;

--- a/app/javascript/flavours/glitch/reducers/settings.js
+++ b/app/javascript/flavours/glitch/reducers/settings.js
@@ -92,18 +92,33 @@ const initialState = ImmutableMap({
     onlyMedia: false,
     allowLocalOnly: true,
 
+    shows: ImmutableMap({
+      reblog: true,
+      reply: true,
+    }),
+
     regex: ImmutableMap({
       body: '',
     }),
   }),
 
   community: ImmutableMap({
+    shows: ImmutableMap({
+      reblog: true,
+      reply: true,
+    }),
+
     regex: ImmutableMap({
       body: '',
     }),
   }),
 
   public: ImmutableMap({
+    shows: ImmutableMap({
+      reblog: true,
+      reply: true,
+    }),
+
     regex: ImmutableMap({
       body: '',
     }),

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -53,6 +53,8 @@ class InitialStateSerializer < ActiveModel::Serializer
       search_preview: Setting.search_preview,
       publish_button_text: Setting.publish_button_text,
       status_page_url: Setting.status_page_url,
+      show_reblogs_in_public_timelines: Setting.show_reblogs_in_public_timelines,
+      show_replies_in_public_timelines: Setting.show_replies_in_public_timelines,
     }
 
     if object.current_account


### PR DESCRIPTION
…en enabled

Ref #88 

The addition of the firehose column broke this feature, but it also was already semi-broken, because of the way column settings are applied.

This adds this feature back and also supports the new firehose column

Adds 2 new attributes to `StatusListContainer`:
- `columnId` (string) - used to read settings from column params
- `firehose` (boolean) - used to indicate to load column settings for firehose column