### PR TITLE
Fix scope order warning in trends RefreshScheduler

### DIFF
--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -62,13 +62,13 @@ class Trends::Statuses < Trends::Base
   def refresh(at_time = Time.now.utc)
     # First, recalculate scores for statuses that were trending previously. We split the queries
     # to avoid having to load all of the IDs into Ruby just to send them back into Postgres
-    Status.where(id: StatusTrend.select(:status_id)).includes(:status_stat, :account).find_in_batches(batch_size: BATCH_SIZE) do |statuses|
+    Status.where(id: StatusTrend.select(:status_id)).includes(:status_stat, :account).reorder(nil).find_in_batches(batch_size: BATCH_SIZE) do |statuses|
       calculate_scores(statuses, at_time)
     end
 
     # Then, calculate scores for statuses that were used today. There are potentially some
     # duplicate items here that we might process one more time, but that should be fine
-    Status.where(id: recently_used_ids(at_time)).includes(:status_stat, :account).find_in_batches(batch_size: BATCH_SIZE) do |statuses|
+    Status.where(id: recently_used_ids(at_time)).includes(:status_stat, :account).reorder(nil).find_in_batches(batch_size: BATCH_SIZE) do |statuses|
       calculate_scores(statuses, at_time)
     end
 


### PR DESCRIPTION
610cf6c3713e414995ea1a57110db400ccb88dd2 caused sidekiq logs to be spammed with `Scoped order is ignored, it's forced to be batch order`.
This is because `find_in_batches` discards any existing order and emits a warning.
