### PR TITLE
Make alt button clickable on sensitive media

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/media.scss
+++ b/app/javascript/flavours/glitch/styles/components/media.scss
@@ -61,7 +61,7 @@
   line-height: 18px;
   border: none;
   border-radius: 4px;
-  z-index: 1;
+  z-index: 101;
 }
 
 .media-gallery__gifv__label {

--- a/app/javascript/flavours/glitch/styles/components/media.scss
+++ b/app/javascript/flavours/glitch/styles/components/media.scss
@@ -62,6 +62,11 @@
   border: none;
   border-radius: 4px;
   z-index: 101;
+
+  &:hover,
+  &:focus {
+    background-color: rgba($black, 0.9);
+  }
 }
 
 .media-gallery__gifv__label {


### PR DESCRIPTION
Ref #34 

The alt button is visible on the sensitive media overlay, but not clickable because of the z-index.

This changes the z-index so the button is clickable and opens the alt-text-modal.

Might be a good idea to revert the styling of the badges back to before and change the opacity on hover, so it's more clear it's clickable.