### PR TITLE
Use display name when adding featured tag from suggestion

### DIFF
--- a/app/views/settings/featured_tags/index.html.haml
+++ b/app/views/settings/featured_tags/index.html.haml
@@ -11,7 +11,7 @@
   %p.lead= t('featured_tags.hint_html', limit: @featured_tag.limit)
 
   .fields-group
-    = f.input :name, wrapper: :with_block_label, hint: safe_join([t('simple_form.hints.featured_tag.name'), safe_join(@recently_used_tags.map { |tag| link_to("##{tag.display_name}", settings_featured_tags_path(featured_tag: { name: tag.name }), method: :post) }, ', ')], ' ')
+    = f.input :name, wrapper: :with_block_label, hint: safe_join([t('simple_form.hints.featured_tag.name'), safe_join(@recently_used_tags.map { |tag| link_to("##{tag.display_name}", settings_featured_tags_path(featured_tag: { name: tag.display_name }), method: :post) }, ', ')], ' ')
 
   .actions
     = f.button :button, t('featured_tags.add_new'), type: :submit


### PR DESCRIPTION
When adding a featured hashtag from a suggestion, it uses the tag name which is always all lowercase instead of the display name, which depends on the first use or is set by admins.
This makes the suggestions less useful as in order to show the tag with the proper name it has to be removed and manually added with proper casing.