### PR TITLE
Set `default_content_type` default from `settings.yml`

### DIFF
--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -17,7 +17,7 @@ class UserSettings
   setting :default_language, default: nil
   setting :default_sensitive, default: false
   setting :default_privacy, default: nil, in: %w(public unlisted private)
-  setting :default_content_type, default: 'text/plain'
+  setting :default_content_type, default: -> { ::Setting.default_content_type }
   setting :hide_followers_count, default: false
 
   setting_inverse_alias :indexable, :noindex


### PR DESCRIPTION
Another change I expected to be merged upstream.

Since the refactor of user settings, this setting had no effect, so instead of removing it, make it apply again.