### PR TITLE
Fix keyboard navigation changing settings in local settings

### DIFF
--- a/app/javascript/flavours/glitch/features/local_settings/page/item/index.jsx
+++ b/app/javascript/flavours/glitch/features/local_settings/page/item/index.jsx
@@ -60,8 +60,7 @@ export default class LocalSettingsPageItem extends PureComponent {
               name={id}
               id={optionId}
               value={opt.value}
-              onBlur={handleChange}
-              onChange={handleChange}
+              onClick={handleChange}
               checked={currentValue === opt.value}
               disabled={!enabled}
               {...inputProps}


### PR DESCRIPTION
Also expected this to get merged upstream...

When using keyboard navigation on radio buttons, doing so changed the settings.

Instead of using `onBlur` and `onChange` use `onClick` for radio buttons.