### PR TITLE
Invite restriction improvements

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -276,6 +276,8 @@ MAX_REACTIONS=1
 # MAX_ACTIVE_INVITES=5
 # Maximun amount of invites created in 24h
 # MAX_DAILY_INVITES=20
+# Minimum amount of days an account has to exist before being able to create invites
+# MIN_DAYS_BEFORE_INVITE=7
 
 # Maximum image and video/audio upload sizes
 # Units are in bytes

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -36,7 +36,6 @@ class UserRole < ApplicationRecord
     manage_roles: (1 << 17),
     manage_user_access: (1 << 18),
     delete_user_data: (1 << 19),
-    legacy_bypass_invite_limits: (1 << 20),
     bypass_invite_limits: (1 << 50),
   }.freeze
 

--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -6,7 +6,7 @@ class InvitePolicy < ApplicationPolicy
   end
 
   def create?
-    role.can?(:invite_users) && (current_user.created_at <= (Time.now.utc - 7.days) || unrestricted?)
+    role.can?(:invite_users) && (current_user.created_at <= InviteValidator::MIN_ACCOUNT_AGE.ago || unrestricted?)
   end
 
   def unrestricted?

--- a/app/validators/invite_validator.rb
+++ b/app/validators/invite_validator.rb
@@ -3,6 +3,7 @@
 class InviteValidator < ActiveModel::Validator
   LIMIT = (ENV['MAX_ACTIVE_INVITES'] || 5).to_i
   DAILY_LIMIT = (ENV['MAX_DAILY_INVITES'] || 20).to_i
+  MIN_ACCOUNT_AGE = (ENV['MIN_DAYS_BEFORE_INVITE'] || 7).to_i.days
 
   def validate(invite)
     return if invite.user.can?(:bypass_invite_limits)

--- a/app/validators/invite_validator.rb
+++ b/app/validators/invite_validator.rb
@@ -18,6 +18,6 @@ class InviteValidator < ActiveModel::Validator
   end
 
   def daily_limit_reached?(invite)
-    invite.user.invites.where('created_at >= ?', (Time.now.utc - 24.hours)).count >= DAILY_LIMIT
+    invite.user.invites.where(created_at: 1.day.ago...).count >= DAILY_LIMIT
   end
 end

--- a/db/post_migrate/20230519010427_polyam_add_invite_limit_bypass.rb
+++ b/db/post_migrate/20230519010427_polyam_add_invite_limit_bypass.rb
@@ -3,20 +3,24 @@
 class PolyamAddInviteLimitBypass < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
-  class UserRole < ApplicationRecord; end
+  class UserRole < ApplicationRecord
+    FLAGS = {
+      bypass_invite_limits: (1 << 20),
+    }.freeze
+  end
 
   def change
     admin_role     = UserRole.find_by(name: 'Admin')
     moderator_role = UserRole.find_by(name: 'Moderator')
 
     if admin_role
-      admin_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+      admin_role.permissions |= UserRole::FLAGS[:bypass_invite_limits]
       admin_role.save
     end
 
     return unless moderator_role
 
-    moderator_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+    moderator_role.permissions |= UserRole::FLAGS[:bypass_invite_limits]
     moderator_role.save
   end
 end

--- a/db/post_migrate/20230522123100_polyam_change_bypass_invite_permission_value.rb
+++ b/db/post_migrate/20230522123100_polyam_change_bypass_invite_permission_value.rb
@@ -3,31 +3,36 @@
 class PolyamChangeBypassInvitePermissionValue < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
-  class UserRole < ApplicationRecord; end
+  class UserRole < ApplicationRecord
+    FLAGS = {
+      legacy_bypass_invite_limits: (1 << 20),
+      bypass_invite_limits: (1 << 50),
+    }.freeze
+  end
 
   def change
     admin_role     = UserRole.find_by(name: 'Admin')
     moderator_role = UserRole.find_by(name: 'Moderator')
     everyone_role  = UserRole.find_by(id: -99)
 
-    legacy_permission = ::UserRole::FLAGS[:legacy_bypass_invite_limits]
+    legacy_permission = UserRole::FLAGS[:legacy_bypass_invite_limits]
 
     if everyone_role && legacy_permission && everyone_role.permissions == (everyone_role.permissions | legacy_permission)
       everyone_role.permissions &= ~legacy_permission
-      everyone_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+      everyone_role.permissions |= UserRole::FLAGS[:bypass_invite_limits]
       everyone_role.save
     end
 
     if moderator_role
       moderator_role.permissions &= ~legacy_permission if legacy_permission && moderator_role.permissions == (moderator_role.permissions | legacy_permission)
-      moderator_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+      moderator_role.permissions |= UserRole::FLAGS[:bypass_invite_limits]
       moderator_role.save
     end
 
     return unless admin_role
 
     admin_role.permissions &= ~legacy_permission if legacy_permission && admin_role.permissions == (admin_role.permissions | legacy_permission)
-    admin_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+    admin_role.permissions |= UserRole::FLAGS[:bypass_invite_limits]
     admin_role.save
   end
 end

--- a/spec/validators/invite_validator_spec.rb
+++ b/spec/validators/invite_validator_spec.rb
@@ -38,7 +38,7 @@ describe InviteValidator do
     context 'when daily limit is reached' do
       before do
         20.times do
-          Fabricate(:invite, user: user, expires_at: 10.minutes.ago.utc)
+          Fabricate(:invite, user: user, expires_at: 10.minutes.ago)
         end
       end
 


### PR DESCRIPTION
Ref #137 

Split-off from #197 

New env var:
- `MIN_DAYS_BEFORE_INVITE` - Amount of days an account has to exist before being able to create invites.

Fixes old migrations from failing when permissions are removed.

Removes using UTC in specs as local timezone is used.
