### PR TITLE
Fix reacted list only showing latest reacting accounts

### DIFF
--- a/app/javascript/flavours/glitch/features/reactions/index.jsx
+++ b/app/javascript/flavours/glitch/features/reactions/index.jsx
@@ -8,7 +8,9 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-import { fetchReactions } from 'flavours/glitch/actions/interactions';
+import { debounce } from 'lodash';
+
+import { fetchReactions, expandReactions } from 'flavours/glitch/actions/interactions';
 import ColumnHeader from 'flavours/glitch/components/column_header';
 import { Icon } from 'flavours/glitch/components/icon';
 import { LoadingIndicator } from 'flavours/glitch/components/loading_indicator';
@@ -22,7 +24,9 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = (state, props) => ({
-  accountIds: state.getIn(['user_lists', 'reacted_by', props.params.statusId]),
+  accountIds: state.getIn(['user_lists', 'reacted_by', props.params.statusId, 'items']),
+  hasMore: !!state.getIn(['user_lists', 'reacted_by', props.params.statusId, 'next']),
+  isLoading: state.getIn(['user_lists', 'reacted_by', props.params.statusId, 'isLoading'], true),
 });
 
 class Reactions extends ImmutablePureComponent {
@@ -31,6 +35,8 @@ class Reactions extends ImmutablePureComponent {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
     accountIds: ImmutablePropTypes.list,
+    hasMore: PropTypes.bool,
+    isLoading: PropTypes.bool,
     multiColumn: PropTypes.bool,
     intl: PropTypes.object.isRequired,
   };
@@ -41,15 +47,13 @@ class Reactions extends ImmutablePureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.params.statusId !== this.props.params.statusId && nextProps.params.statusId) {
-      this.props.dispatch(fetchReactions(nextProps.params.statusId));
-    }
-  }
-
   handleHeaderClick = () => {
     this.column.scrollTop();
   };
+
+  handleLoadMore = debounce(() => {
+    this.props.dispatch(expandReactions(this.props.params.statusId));
+  }, 300, { leading: true});
 
   setRef = c => {
     this.column = c;
@@ -60,7 +64,7 @@ class Reactions extends ImmutablePureComponent {
   };
 
   render () {
-    const { intl, accountIds, multiColumn } = this.props;
+    const { intl, accountIds, hasMore, isLoading, multiColumn } = this.props;
 
     if (!accountIds) {
       return (
@@ -87,6 +91,9 @@ class Reactions extends ImmutablePureComponent {
 
         <ScrollableList
           scrollKey='reactions'
+          onLoadMore={this.handleLoadMore}
+          hasMore={hasMore}
+          isLoading={isLoading}
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >

--- a/app/javascript/flavours/glitch/reducers/user_lists.js
+++ b/app/javascript/flavours/glitch/reducers/user_lists.js
@@ -56,7 +56,12 @@ import {
   FAVOURITES_EXPAND_REQUEST,
   FAVOURITES_EXPAND_SUCCESS,
   FAVOURITES_EXPAND_FAIL,
+  REACTIONS_FETCH_REQUEST,
   REACTIONS_FETCH_SUCCESS,
+  REACTIONS_FETCH_FAIL,
+  REACTIONS_EXPAND_REQUEST,
+  REACTIONS_EXPAND_SUCCESS,
+  REACTIONS_EXPAND_FAIL,
 } from 'flavours/glitch/actions/interactions';
 import {
   MUTES_FETCH_REQUEST,
@@ -164,7 +169,15 @@ export default function userLists(state = initialState, action) {
   case FAVOURITES_EXPAND_FAIL:
     return state.setIn(['favourited_by', action.id, 'isLoading'], false);
   case REACTIONS_FETCH_SUCCESS:
-    return state.setIn(['reacted_by', action.id], ImmutableList(action.accounts.map(item => item.id)));
+    return normalizeList(state, ['reacted_by', action.id], action.accounts, action.next);
+  case REACTIONS_EXPAND_SUCCESS:
+    return appendToList(state, ['reacted_by', action.id], action.accounts, action.next);
+  case REACTIONS_FETCH_REQUEST:
+  case REACTIONS_EXPAND_REQUEST:
+    return state.setIn(['reacted_by', action.id, 'isLoading'], true);
+  case REACTIONS_FETCH_FAIL:
+  case REACTIONS_EXPAND_FAIL:
+    return state.setIn(['reacted_by', action.id, 'isLoading'], false);
   case NOTIFICATIONS_UPDATE:
     return action.notification.type === 'follow_request' ? normalizeFollowRequest(state, action.notification) : state;
   case FOLLOW_REQUESTS_FETCH_SUCCESS:


### PR DESCRIPTION
Ref #21 

Same as 871ab8485434d9c89dddb14a2ee1fda8ad60035e and beb5fcd0dc158218fd3c82e7d545a53f7dc904b7 as I think reactions are also affected by it.

This also adds follow/unfollow buttons to every account in the list.
