### PR TITLE
Fix doorkeeper locales saying "post" instead of "toot"

### DIFF
--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -138,7 +138,7 @@ en:
         push: Push notifications
         reports: Reports
         search: Search
-        statuses: Posts
+        statuses: Toots
     layouts:
       admin:
         nav:
@@ -178,13 +178,13 @@ en:
       read:notifications: see your notifications
       read:reports: see your reports
       read:search: search on your behalf
-      read:statuses: see all posts
+      read:statuses: see all toots
       write: modify all your account's data
       write:accounts: modify your profile
       write:blocks: block accounts and domains
-      write:bookmarks: bookmark posts
+      write:bookmarks: bookmark toots
       write:conversations: mute and delete conversations
-      write:favourites: favorite posts
+      write:favourites: favorite toots
       write:filters: create filters
       write:follows: follow people
       write:lists: create lists
@@ -192,4 +192,4 @@ en:
       write:mutes: mute people and conversations
       write:notifications: clear your notifications
       write:reports: report other people
-      write:statuses: publish posts
+      write:statuses: publish toots


### PR DESCRIPTION
Ref #23 

Finally wrote a script checking locales for "post".