### PR TITLE
Add reactions count to toot moderation interface

### DIFF
--- a/app/views/admin/statuses/show.html.haml
+++ b/app/views/admin/statuses/show.html.haml
@@ -41,6 +41,9 @@
       %tr
         %th= t('admin.statuses.favourites')
         %td= friendly_number_to_human @status.favourites_count
+      %tr
+        %th= t('admin.statuses.reactions')
+        %td= friendly_number_to_human @status.reactions_count
 
 %hr.spacer/
 

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -83,6 +83,8 @@ en:
       trending_status_sensitive:
         desc_html: When trending toots are enable, allow toots with sensitive media to be elibible. Changes to this setting are not retroactive.
         title: Allow toots with sensitive media to trend
+    statuses:
+      reactions: Reactions
   appearance:
     localization:
       glitch_guide_link: https://crowdin.com/project/glitch-soc


### PR DESCRIPTION
Ref #21

When clicking "open this toot in the moderation interface" the reaction count was missing from the stats.

![Toot metadata with added reaction count (1)](https://github.com/polyamspace/mastodon/assets/117664621/f0e57d68-dd30-4282-8059-92c64ced3819)
