### PR TITLE
Fix wrong gradient for collapsed private mentions

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -367,8 +367,8 @@
 
     &.status-direct > .status__content::after {
       background: linear-gradient(
-        rgba(lighten($ui-base-color, 8%), 0),
-        rgba(lighten($ui-base-color, 8%), 1)
+        rgba(mix($ui-base-color, $ui-highlight-color, 95%), 0),
+        rgba(mix($ui-base-color, $ui-highlight-color, 95%), 1)
       );
     }
 


### PR DESCRIPTION
Vanilla added a different color for private mentions, but the gradient wasn't updated.