### PR TITLE
[Oatstodon] Match gradient for collapsed private mentions with background

### DIFF
--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -79,6 +79,15 @@ hr {
   &.status-direct {
     background: lighten($ui-base-color, 8%);
   }
+
+  &.collapsed {
+    &.status-direct > .status__content::after {
+      background: linear-gradient(
+        rgba(lighten($ui-base-color, 8%), 0),
+        rgba(lighten($ui-base-color, 8%), 1)
+      );
+    }
+  }
 }
 
 .focusable {


### PR DESCRIPTION
Ref #76

Oatstodon uses a different background color for private mentions as the mixed colors look bad.
This also uses the background color for the gradient so it doesn't break should the color change upstream