### PR TITLE
Fix reaction bar being hidden in announcements

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/announcements.scss
+++ b/app/javascript/flavours/glitch/styles/components/announcements.scss
@@ -231,7 +231,3 @@
     }
   }
 }
-
-.reactions-bar--empty {
-  display: none;
-}

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -384,6 +384,10 @@
   .notification__message {
     margin: -10px 0 10px;
   }
+
+  .reactions-bar--empty {
+    display: none;
+  }
 }
 
 .notification-favourite {
@@ -594,6 +598,10 @@
   .video-player,
   .audio-player {
     margin-top: 8px;
+  }
+
+  .reactions-bar--empty {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Ref #21 
Follow-up to #93 

Adding `.reactions-bar--empty` to `announcements.scss` unfortunately causes the reaction bar to be hidden in announcements, which prevents users from adding reactions.
This actually fixes the issue #93 was supposed to fix.