### PR TITLE
Don't render alt button above sensitive overlay

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/media.scss
+++ b/app/javascript/flavours/glitch/styles/components/media.scss
@@ -61,7 +61,7 @@
   line-height: 18px;
   border: none;
   border-radius: 4px;
-  z-index: 101;
+  z-index: 1;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Fixes #230 
Partially reverts #201 

This will unfortunately remove the ability to read alt-text before clicking the click to show button.

Preview:
![Screenshot_2023-09-17_16-55-38](https://github.com/polyamspace/mastodon/assets/117664621/65fcd8d5-8937-4f48-9f6b-3c2fe713fdc1)

A remaining issue is that unlike in vanilla, the badges are blurred behind the button.
I don't think that's intentional though, as vanilla broke the backdrop filter in `.spoiler-button__overlay__label`, preventing the blur.