### PR TITLE
Keep Syntax Highlight in translations

### DIFF
--- a/app/javascript/flavours/glitch/components/status_content.jsx
+++ b/app/javascript/flavours/glitch/components/status_content.jsx
@@ -330,7 +330,7 @@ class StatusContent extends PureComponent {
     const targetLanguages = this.props.languages?.get(status.get('language') || 'und');
     const renderTranslate = this.props.onTranslate && this.context.identity.signedIn && ['public', 'unlisted'].includes(status.get('visibility')) && status.get('search_index').trim().length > 0 && targetLanguages?.includes(contentLocale);
 
-    const content = { __html: status.getIn(['translation', 'contentHtml']) || highlightCode(status.get('contentHtml')) };
+    const content = { __html: highlightCode(status.getIn(['translation', 'contentHtml']) || status.get('contentHtml')) };
     const spoilerContent = { __html: status.getIn(['translation', 'spoilerHtml']) || status.get('spoilerHtml') };
     const language = status.getIn(['translation', 'language']) || status.get('language');
     const classNames = classnames('status__content', {


### PR DESCRIPTION
Ref #20

I didn't have a translation backend configured, so I was reluctant to make this change, but now I do.
Keeps syntax highlighting in translations.