### PR TITLE
Search in private index by default

### DIFF
--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -56,10 +56,10 @@ class SearchQueryTransformer < Parslet::Transform
 
     def indexes
       case @flags['in']
-      when 'library'
-        [StatusesIndex]
-      else
+      when 'all'
         [PublicStatusesIndex, StatusesIndex]
+      else
+        [StatusesIndex]
       end
     end
 


### PR DESCRIPTION
Fixes #220 

Instead of searching public and private indexes by default, only search in private index (old search behaviour), unless `in:all` is specified.