### PR TITLE
[Homogay] Fix wrong background for elefriend

### DIFF
--- a/app/javascript/flavours/glitch/styles/homogay/diff.scss
+++ b/app/javascript/flavours/glitch/styles/homogay/diff.scss
@@ -358,7 +358,8 @@ body {
 
 .mbstobon-0,
 .mbstobon-1,
-.mbstobon-2 {
+.mbstobon-2,
+.mbstobon-3 {
   .drawer__inner__mastodon {
     background-color: $ui-base-color;
   }


### PR DESCRIPTION
When loading the advanced UI, the mascot in the left bottom corner had the wrong background color.