### PR TITLE
Change registration to be approval only by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,7 +9,7 @@ defaults: &defaults
   site_terms: ''
   site_contact_username: ''
   site_contact_email: ''
-  registrations_mode: 'open'
+  registrations_mode: 'approved'
   profile_directory: true
   closed_registrations_message: ''
   timeline_preview: false
@@ -45,7 +45,7 @@ defaults: &defaults
   show_domain_blocks: 'disabled'
   show_domain_blocks_rationale: 'disabled'
   outgoing_spoilers: ''
-  require_invite_text: false
+  require_invite_text: true
   backups_retention_period: 7
   search_preview: false
   invite_text_filter: ''

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -12,7 +12,7 @@ Fabricator(:account) do
   private_key         { private_key }
   suspended_at        { |attrs| attrs[:suspended] ? Time.now.utc : nil }
   silenced_at         { |attrs| attrs[:silenced] ? Time.now.utc : nil }
-  user                { |attrs| attrs[:domain].nil? ? Fabricate.build(:user, account: nil) : nil }
+  user                { |attrs| attrs[:domain].nil? ? Fabricate.build(:user, account: nil, approved: true) : nil }
   uri                 { |attrs| attrs[:domain].nil? ? '' : "https://#{attrs[:domain]}/users/#{attrs[:username]}" }
   discoverable        true
 end

--- a/spec/fabricators/invite_request_fabricator.rb
+++ b/spec/fabricators/invite_request_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:user_invite_request) do
+  user { Fabricate.build(:user, account: nil) }
+  text 'Let me in!'
+end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -7,4 +7,5 @@ Fabricator(:user) do
   confirmed_at { Time.zone.now }
   current_sign_in_at { Time.zone.now }
   agreement true
+  invite_request { Fabricate.build(:user_invite_request, user: nil) }
 end


### PR DESCRIPTION
Instead of open registrations being the default, changes it to approval only and also requires an invite text.

I joked about upstream needing to remove the open registrations option, which gave me the idea to change the defaults.

One caveat is, creating an admin account is optional in the setup, but without one, new accounts cannot be approved via the web interface.
It should still be possible to create new accounts via tootctl though.