### PR TITLE
Move alt-text reminder setting

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -53,6 +53,7 @@
       = ff.input :'web.reblog_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
       = ff.input :'web.favourite_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_favourite_modal'), glitch_only: true
       = ff.input :'web.delete_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_delete_modal')
+      = ff.input :'web.alt_text_reminder', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_alt_text_reminder'), polyam_only: true
 
     %h4= t 'appearance.sensitive_content'
 

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -24,9 +24,6 @@
       = ff.input :default_sensitive, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_default_sensitive'), hint: I18n.t('simple_form.hints.defaults.setting_default_sensitive')
 
     .fields-group
-      = ff.input :'web.alt_text_reminder', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_alt_text_reminder'), hint: I18n.t('simple_form.hints.defaults.setting_alt_text_reminder'), polyam_only: true
-
-    .fields-group
       = ff.input :default_content_type, collection: ['text/plain', 'text/markdown', 'text/html'], wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_default_content_type'), include_blank: false, label_method: ->(item) { safe_join([t("simple_form.labels.defaults.setting_default_content_type_#{item.split('/')[1]}"), content_tag(:span, t("simple_form.hints.defaults.setting_default_content_type_#{item.split('/')[1]}"), class: 'hint')]) }, required: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', glitch_only: true
 
   %h4= t 'preferences.public_timelines'

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -4,7 +4,6 @@ en:
     glitch_only: glitch-soc
     hints:
       defaults:
-        setting_alt_text_reminder: A reminder will be presented when attempting to toot media without an image description
         setting_default_content_type_html: When writing toots, assume they are written in raw HTML, unless specified otherwise
         setting_default_content_type_markdown: When writing toots, assume they are using Markdown for rich text formatting, unless specified otherwise
         setting_default_content_type_plain: When writing toots, assume they are plain text with no special formatting, unless specified otherwise (default Mastodon behavior)
@@ -19,7 +18,7 @@ en:
         comment: Optional. You can enter for whom the invite is for, or reason for creating it
     labels:
       defaults:
-        setting_alt_text_reminder: Display reminder to add image descriptions when tooting media
+        setting_alt_text_reminder: Show confirmation dialog before tooting media without descriptions (applies to Glitch flavour only)
         setting_default_content_type: Default format for toots
         setting_default_content_type_html: HTML
         setting_default_content_type_markdown: Markdown


### PR DESCRIPTION
Moves the setting to the other confirmation dialogs instead of hiding it in other.