### PR TITLE
Fix possible duplicate keys in recent search

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/search.jsx
+++ b/app/javascript/flavours/glitch/features/compose/components/search.jsx
@@ -360,7 +360,7 @@ class Search extends PureComponent {
 
               <div className='search__popout__menu'>
                 {recent.size > 0 ? this._getOptions().map(({ label, action, forget }, i) => (
-                  <button key={label} onMouseDown={action} className={classNames('search__popout__menu__item search__popout__menu__item--flex', { selected: selectedOption === i })}>
+                  <button key={i} onMouseDown={action} className={classNames('search__popout__menu__item search__popout__menu__item--flex', { selected: selectedOption === i })}>
                     <span>{label}</span>
                     <button className='icon-button' onMouseDown={forget}><Icon id='times' /></button>
                   </button>


### PR DESCRIPTION
This is a weird one.
When using the same search term and pressing enter and then click "Profiles matching $searchTerm", it appears in recent twice. This itself is not an issue as these are different searches. But trying to dismiss one of these, should remove both and not only one. This results in an undeletable recent search entry as both have been removed in the state, but the UI didn't reflect that. The underlying cause was that the key attribute of the button element was not unique.