### PR TITLE
Fix collapsed toot scrolling on focus

### DIFF
--- a/app/javascript/flavours/glitch/components/attachment_list.jsx
+++ b/app/javascript/flavours/glitch/components/attachment_list.jsx
@@ -16,10 +16,11 @@ export default class AttachmentList extends ImmutablePureComponent {
   static propTypes = {
     media: ImmutablePropTypes.list.isRequired,
     compact: PropTypes.bool,
+    collapsed: PropTypes.bool,
   };
 
   render () {
-    const { media, compact } = this.props;
+    const { media, compact, collapsed } = this.props;
 
     return (
       <div className={classNames('attachment-list', { compact })}>
@@ -35,7 +36,7 @@ export default class AttachmentList extends ImmutablePureComponent {
 
             return (
               <li key={attachment.get('id')}>
-                <a href={displayUrl} target='_blank' rel='noopener noreferrer'>
+                <a tabIndex={collapsed ? -1 : null} href={displayUrl} target='_blank' rel='noopener noreferrer'>
                   {compact && <Icon id='link' />}
                   {compact && ' ' }
                   {displayUrl ? filename(displayUrl) : <FormattedMessage id='attachments_list.unprocessed' defaultMessage='(unprocessed)' />}

--- a/app/javascript/flavours/glitch/components/poll.jsx
+++ b/app/javascript/flavours/glitch/components/poll.jsx
@@ -50,6 +50,7 @@ class Poll extends ImmutablePureComponent {
     disabled: PropTypes.bool,
     refresh: PropTypes.func,
     onVote: PropTypes.func,
+    collapsed: PropTypes.bool,
   };
 
   state = {
@@ -136,7 +137,7 @@ class Poll extends ImmutablePureComponent {
   };
 
   renderOption (option, optionIndex, showResults) {
-    const { poll, lang, disabled, intl } = this.props;
+    const { poll, lang, disabled, intl, collapsed } = this.props;
     const pollVotesCount  = poll.get('voters_count') || poll.get('votes_count');
     const percent         = pollVotesCount === 0 ? 0 : (option.get('votes_count') / pollVotesCount) * 100;
     const leading         = poll.get('options').filterNot(other => other.get('title') === option.get('title')).every(other => option.get('votes_count') >= other.get('votes_count'));
@@ -155,6 +156,7 @@ class Poll extends ImmutablePureComponent {
       <li key={option.get('title')}>
         <label className={classNames('poll__option', { selectable: !showResults })}>
           <input
+            tabIndex={collapsed ? -1 : null}
             name='vote-options'
             type={poll.get('multiple') ? 'checkbox' : 'radio'}
             value={optionIndex}
@@ -166,7 +168,7 @@ class Poll extends ImmutablePureComponent {
           {!showResults && (
             <span
               className={classNames('poll__input', { checkbox: poll.get('multiple'), active })}
-              tabIndex={0}
+              tabIndex={collapsed ? -1 : 0}
               role={poll.get('multiple') ? 'checkbox' : 'radio'}
               onKeyPress={this.handleOptionKeyPress}
               aria-checked={active}
@@ -209,7 +211,7 @@ class Poll extends ImmutablePureComponent {
   }
 
   render () {
-    const { poll, intl } = this.props;
+    const { poll, intl, collapsed } = this.props;
     const { revealed, expired } = this.state;
 
     if (!poll) {
@@ -235,9 +237,9 @@ class Poll extends ImmutablePureComponent {
         </ul>
 
         <div className='poll__footer'>
-          {!showResults && <button className='button button-secondary' disabled={disabled || !this.context.identity.signedIn} onClick={this.handleVote}><FormattedMessage id='poll.vote' defaultMessage='Vote' /></button>}
-          {!showResults && <><button className='poll__link' onClick={this.handleReveal}><FormattedMessage id='poll.reveal' defaultMessage='See results' /></button> · </>}
-          {showResults && !this.props.disabled && <><button className='poll__link' onClick={this.handleRefresh}><FormattedMessage id='poll.refresh' defaultMessage='Refresh' /></button> · </>}
+          {!showResults && <button tabIndex={collapsed ? -1 : null} className='button button-secondary' disabled={disabled || !this.context.identity.signedIn} onClick={this.handleVote}><FormattedMessage id='poll.vote' defaultMessage='Vote' /></button>}
+          {!showResults && <><button tabIndex={collapsed ? -1 : null} className='poll__link' onClick={this.handleReveal}><FormattedMessage id='poll.reveal' defaultMessage='See results' /></button> · </>}
+          {showResults && !this.props.disabled && <><button tabIndex={collapsed ? -1 : null} className='poll__link' onClick={this.handleRefresh}><FormattedMessage id='poll.refresh' defaultMessage='Refresh' /></button> · </>}
           {votesCount}
           {poll.get('expires_at') && <> · {timeRemaining}</>}
         </div>

--- a/app/javascript/flavours/glitch/components/status.jsx
+++ b/app/javascript/flavours/glitch/components/status.jsx
@@ -656,6 +656,7 @@ class Status extends ImmutablePureComponent {
           <AttachmentList
             compact
             media={status.get('media_attachments')}
+            collapsed={isCollapsed}
             key='media-unknown'
           />,
         );
@@ -758,7 +759,7 @@ class Status extends ImmutablePureComponent {
 
     if (status.get('poll')) {
       const language = status.getIn(['translation', 'language']) || status.get('language');
-      contentMedia.push(<PollContainer key='media-poll' pollId={status.get('poll')} lang={language} />);
+      contentMedia.push(<PollContainer key='media-poll' pollId={status.get('poll')} collapsed={isCollapsed} lang={language} />);
       contentMediaIcons.push('tasks');
     }
 

--- a/app/javascript/flavours/glitch/components/status.jsx
+++ b/app/javascript/flavours/glitch/components/status.jsx
@@ -853,6 +853,7 @@ class Status extends ImmutablePureComponent {
             disabled={!history}
             tagLinks={settings.get('tag_misleading_links')}
             rewriteMentions={settings.get('rewrite_mentions')}
+            collapsed={isCollapsed}
           />
 
           <StatusReactions

--- a/app/javascript/flavours/glitch/components/status_content.jsx
+++ b/app/javascript/flavours/glitch/components/status_content.jsx
@@ -150,7 +150,7 @@ class StatusContent extends PureComponent {
 
   _updateStatusLinks () {
     const node = this.contentsNode;
-    const { tagLinks, rewriteMentions } = this.props;
+    const { tagLinks, rewriteMentions, collapsed } = this.props;
 
     if (!node) {
       return;
@@ -160,6 +160,14 @@ class StatusContent extends PureComponent {
 
     for (var i = 0; i < links.length; ++i) {
       let link = links[i];
+
+      // Fix scrolling in collapsed toots when focusing links by preventing them to be focusable
+      if (collapsed) {
+        link.setAttribute('tabindex', -1);
+      } else {
+        link.removeAttribute('tabindex');
+      }
+
       if (link.classList.contains('status-link')) {
         continue;
       }


### PR DESCRIPTION
There is a fun bug when using keyboard navigation on collapsed toots, where the visible text will scroll to a focusable element, like the refresh button on polls.

This passes `isCollapsed` to the affected elements to set tabIndex to -1

~This unfortunately doesn't work for mentions and links in the content itself.~