### PR TITLE
Fix compose form being highlighted when replying

### DIFF
--- a/app/javascript/flavours/glitch/actions/compose.js
+++ b/app/javascript/flavours/glitch/actions/compose.js
@@ -86,6 +86,8 @@ export const COMPOSE_CHANGE_MEDIA_FOCUS       = 'COMPOSE_CHANGE_MEDIA_FOCUS';
 export const COMPOSE_SET_STATUS = 'COMPOSE_SET_STATUS';
 export const COMPOSE_FOCUS = 'COMPOSE_FOCUS';
 
+export * from './compose_typed';
+
 const messages = defineMessages({
   uploadErrorLimit: { id: 'upload_error.limit', defaultMessage: 'File upload limit exceeded.' },
   uploadErrorPoll:  { id: 'upload_error.poll', defaultMessage: 'File upload not allowed with polls.' },

--- a/app/javascript/flavours/glitch/actions/compose_typed.ts
+++ b/app/javascript/flavours/glitch/actions/compose_typed.ts
@@ -1,0 +1,3 @@
+import { createAction } from '@reduxjs/toolkit';
+
+export const removeHighlight = createAction('compose/remove_highlight');

--- a/app/javascript/flavours/glitch/features/compose/components/compose_form.jsx
+++ b/app/javascript/flavours/glitch/features/compose/components/compose_form.jsx
@@ -77,15 +77,13 @@ class ComposeForm extends ImmutablePureComponent {
     onChangeSpoilerness: PropTypes.func,
     onChangeVisibility: PropTypes.func,
     onMediaDescriptionConfirm: PropTypes.func,
+    highlighted: PropTypes.bool,
+    onRemoveHighlight: PropTypes.func,
     ...WithOptionalRouterPropTypes
   };
 
   static defaultProps = {
     autoFocus: false,
-  };
-
-  state = {
-    highlighted: false,
   };
 
   handleChange = (e) => {
@@ -241,6 +239,8 @@ class ComposeForm extends ImmutablePureComponent {
       text,
       preselectOnReply,
       singleColumn,
+      highlighted,
+      onRemoveHighlight,
     } = this.props;
     let selectionEnd, selectionStart;
 
@@ -264,8 +264,7 @@ class ComposeForm extends ImmutablePureComponent {
         Promise.resolve().then(() => {
           textarea.setSelectionRange(selectionStart, selectionEnd);
           textarea.focus();
-          this.setState({highlighted: true});
-          this.timeout = setTimeout(() => this.setState({highlighted: false}), 700);
+          if (highlighted) this.timeout = setTimeout(() => onRemoveHighlight(), 700);
           if (!singleColumn) textarea.scrollIntoView();
         }).catch(console.error);
       }
@@ -310,8 +309,8 @@ class ComposeForm extends ImmutablePureComponent {
       suggestions,
       spoilersAlwaysOn,
       isEditing,
+      highlighted
     } = this.props;
-    const { highlighted } = this.state;
 
     const countText = this.getFulltextForCharacterCounting();
 

--- a/app/javascript/flavours/glitch/features/compose/containers/compose_form_container.js
+++ b/app/javascript/flavours/glitch/features/compose/containers/compose_form_container.js
@@ -13,6 +13,7 @@ import {
   selectComposeSuggestion,
   submitCompose,
   uploadCompose,
+  removeHighlight,
 } from 'flavours/glitch/actions/compose';
 import { changeLocalSetting } from 'flavours/glitch/actions/local_settings';
 import {
@@ -77,6 +78,7 @@ function mapStateToProps (state) {
     preselectOnReply: state.getIn(['local_settings', 'preselect_on_reply']),
     isInReply: state.getIn(['compose', 'in_reply_to']) !== null,
     lang: state.getIn(['compose', 'language']),
+    highlighted: state.getIn(['compose', 'highlighted']),
   };
 }
 
@@ -121,6 +123,10 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
 
   onChangeVisibility(value) {
     dispatch(changeComposeVisibility(value));
+  },
+
+  onRemoveHighlight() {
+    dispatch(removeHighlight());
   },
 
   onMediaDescriptionConfirm(routerHistory, mediaId, overriddenVisibility = null) {

--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -52,6 +52,7 @@ import {
   COMPOSE_CHANGE_MEDIA_FOCUS,
   COMPOSE_SET_STATUS,
   COMPOSE_FOCUS,
+  removeHighlight,
 } from 'flavours/glitch/actions/compose';
 import { REDRAFT } from 'flavours/glitch/actions/statuses';
 import { STORE_HYDRATE } from 'flavours/glitch/actions/store';
@@ -128,6 +129,7 @@ const initialState = ImmutableMap({
     smoothing: false,
   }),
   last_status_in_thread: null,
+  highlighted: false,
 });
 
 const initialPoll = ImmutableMap({
@@ -664,7 +666,9 @@ export default function compose(state = initialState, action) {
   case COMPOSE_LANGUAGE_CHANGE:
     return state.set('language', action.language);
   case COMPOSE_FOCUS:
-    return state.set('focusDate', new Date());
+    return state.set('focusDate', new Date()).set('highlighted', true);
+  case removeHighlight.type:
+    return state.set('highlighted', false);
   default:
     return state;
   }


### PR DESCRIPTION
Fixes #277 

This prevents the compose form from being highlighted outside from onboarding. I'm not sure why it wasn't done this way in the first place.
Okay, I guess this is additional handholding for new users. It just really is distracting for experienced users.

Adds highlighted to state and adds a dispatch to remove highlighting.

~Thinking about this, I probably want to do that properly in typescript.~
Done.