### PR TITLE
Re-add role badge CSS values

### DIFF
--- a/app/views/custom_css/show.css.erb
+++ b/app/views/custom_css/show.css.erb
@@ -5,6 +5,8 @@
 <%- UserRole.where(highlighted: true).select { |role| role.color.present? }.each do |role| %>
 .user-role-<%= role.id %> {
   --user-role-accent: <%= role.color %>;
+  --user-role-background: <%= role.color + '19' %>;
+  --user-role-border: <%= role.color + '80' %>;
 }
 
 <%- end %>


### PR DESCRIPTION
These were removed upstream, effectively disabling role colors.

I'm also experimenting with adding a preview of badges to role settings.