### PR TITLE
Add preview for role badge colors

### DIFF
--- a/app/javascript/flavours/glitch/packs/public.jsx
+++ b/app/javascript/flavours/glitch/packs/public.jsx
@@ -231,6 +231,24 @@ function main() {
       }
     });
   });
+
+  // User role preview
+  Rails.delegate(document, '#user_role_color', 'change', ({ target }) => {
+    for (let i=1; i<=3; i++) {
+      const preview = document.getElementById(`user-role-preview-${i}`);
+
+      preview.style.backgroundColor = `${target.value}19`;
+      preview.style.borderColor = `${target.value}80`;
+    }
+  });
+
+  Rails.delegate(document, '#user_role_name', 'change', ({ target }) => {
+    for (let i=1; i<=3; i++) {
+      const preview = document.getElementById(`user-role-preview-${i}`);
+
+      preview.innerText = target.value;
+    }
+  });
 }
 
 loadPolyfills()

--- a/app/javascript/flavours/glitch/styles/admin.scss
+++ b/app/javascript/flavours/glitch/styles/admin.scss
@@ -1004,6 +1004,51 @@ a.name-tag,
 
 .user-role {
   color: var(--user-role-accent);
+
+  &__preview {
+    display: flex;
+    justify-content: flex-end;
+
+    .avatar {
+      width: 94px;
+    }
+
+    .item {
+      padding: 12px 15px;
+    }
+
+    .account-role {
+      margin: 0 2px;
+      padding: 4px 0;
+      box-sizing: border-box;
+      min-width: 90px;
+      text-align: center;
+    }
+
+    .current {
+      background-color: lighten($ui-base-color, 4%);
+
+      .account-role {
+        color: $ui-secondary-color;
+      }
+    }
+
+    .dark {
+      background-color: lighten($classic-base-color, 4%);
+
+      .account-role {
+        color: $classic-secondary-color;
+      }
+    }
+
+    .light {
+      background-color: lighten($classic-secondary-color, 4%);
+
+      .account-role {
+        color: $classic-base-color;
+      }
+    }
+  }
 }
 
 .announcements-list,

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -11,9 +11,29 @@
     .fields-group
       = form.input :position, wrapper: :with_label, input_html: { max: current_user.role.position - 1 }
 
-  .fields-group
-    = form.input :color, wrapper: :with_label, input_html: { placeholder: '#000000', type: 'color' }
+  .fields-row
+    .fields-row__column.fields-row__column-6
+      .fields-group
+        = form.input :color, wrapper: :with_label, input_html: { placeholder: '#000000', type: 'color' }
 
+    -# haml-lint:disable InlineStyles
+    .fields-row__column.fields-row__column-6
+      .user-role__preview
+        :ruby
+          default_style = !form.object.color.empty? ? "background-color: #{form.object.color}19; border-color: #{form.object.color}80;" : ''
+          default_dark = "background-color: rgba(217, 225, 232, 0.1); border-color: rgba(217, 225, 232, 0.5);"
+          default_light = "background-color: rgba(40, 44, 55, 0.1); border-color: rgba(40, 44, 55, 0.5);"
+        .item.dark
+          .avatar
+            .account-role{ :style => !default_style.empty? ? default_style : default_dark, :id => 'user-role-preview-1' }= form.object.name
+        .item.light
+          .avatar
+            .account-role{ :style => !default_style.empty? ? default_style : default_light, :id => 'user-role-preview-2' }= form.object.name
+        - if current_user.setting_skin != 'default' && current_user.setting_skin != 'mastodon-light'
+          .item.current
+            .avatar
+              .account-role{ :style => default_style, :id => 'user-role-preview-3' }= form.object.name
+    -# haml-lint:enable InlineStyles
   %hr.spacer/
 
   .fields-group

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -17,22 +17,23 @@
         = form.input :color, wrapper: :with_label, input_html: { placeholder: '#000000', type: 'color' }
 
     -# haml-lint:disable InlineStyles
-    .fields-row__column.fields-row__column-6
-      .user-role__preview
-        :ruby
-          default_style = !form.object.color.empty? ? "background-color: #{form.object.color}19; border-color: #{form.object.color}80;" : ''
-          default_dark = "background-color: rgba(217, 225, 232, 0.1); border-color: rgba(217, 225, 232, 0.5);"
-          default_light = "background-color: rgba(40, 44, 55, 0.1); border-color: rgba(40, 44, 55, 0.5);"
-        .item.dark
-          .avatar
-            .account-role{ :style => !default_style.empty? ? default_style : default_dark, :id => 'user-role-preview-1' }= form.object.name
-        .item.light
-          .avatar
-            .account-role{ :style => !default_style.empty? ? default_style : default_light, :id => 'user-role-preview-2' }= form.object.name
-        - if current_user.setting_skin != 'default' && current_user.setting_skin != 'mastodon-light'
-          .item.current
+    - unless current_user.setting_flavour == 'vanilla'
+      .fields-row__column.fields-row__column-6
+        .user-role__preview
+          :ruby
+            default_style = !form.object.color.empty? ? "background-color: #{form.object.color}19; border-color: #{form.object.color}80;" : ''
+            default_dark = "background-color: rgba(217, 225, 232, 0.1); border-color: rgba(217, 225, 232, 0.5);"
+            default_light = "background-color: rgba(40, 44, 55, 0.1); border-color: rgba(40, 44, 55, 0.5);"
+          .item.dark
             .avatar
-              .account-role{ :style => default_style, :id => 'user-role-preview-3' }= form.object.name
+              .account-role{ :style => !default_style.empty? ? default_style : default_dark, :id => 'user-role-preview-1' }= form.object.name
+          .item.light
+            .avatar
+              .account-role{ :style => !default_style.empty? ? default_style : default_light, :id => 'user-role-preview-2' }= form.object.name
+          - if current_user.setting_skin != 'default' && current_user.setting_skin != 'mastodon-light'
+            .item.current
+              .avatar
+                .account-role{ :style => default_style, :id => 'user-role-preview-3' }= form.object.name
     -# haml-lint:enable InlineStyles
   %hr.spacer/
 


### PR DESCRIPTION
It's very hard to gauge from the settings page whether a custom color works in a given theme or not.
This adds a preview, which shows the badge in the default, light and current selected theme, if different.
This should work as long as the selected custom theme does not change classic colors in variables.

Preview:
![User role edit form with preview of badge](https://github.com/polyamspace/mastodon/assets/117664621/806d547b-74db-415c-88fd-a2895451ba9b)

![Same as above but in default theme](https://github.com/polyamspace/mastodon/assets/117664621/1ce4ef7e-f026-4745-8a4b-cc77c3b2f5d0)
