### PR TITLE
Fix CSP error in role badge preview

### DIFF
--- a/app/javascript/flavours/glitch/styles/admin.scss
+++ b/app/javascript/flavours/glitch/styles/admin.scss
@@ -1030,9 +1030,11 @@ a.name-tag,
 
       .account-role {
         color: $ui-secondary-color;
-        background-color: var(--user-role-background, rgba($ui-secondary-color, 0.1));
+        background-color: var(
+          --user-role-background,
+          rgba($ui-secondary-color, 0.1)
+        );
         border-color: var(--user-role-border, rgba($ui-secondary-color, 0.5));
-
       }
     }
 
@@ -1041,9 +1043,14 @@ a.name-tag,
 
       .account-role {
         color: $classic-secondary-color;
-        background-color: var(--user-role-background, rgba($classic-secondary-color, 0.1));
-        border-color: var(--user-role-border, rgba($classic-secondary-color, 0.5));
-
+        background-color: var(
+          --user-role-background,
+          rgba($classic-secondary-color, 0.1)
+        );
+        border-color: var(
+          --user-role-border,
+          rgba($classic-secondary-color, 0.5)
+        );
       }
     }
 
@@ -1052,7 +1059,10 @@ a.name-tag,
 
       .account-role {
         color: $classic-base-color;
-        background-color: var(--user-role-background, rgba($classic-base-color, 0.1));
+        background-color: var(
+          --user-role-background,
+          rgba($classic-base-color, 0.1)
+        );
         border-color: var(--user-role-border, rgba($classic-base-color, 0.5));
       }
     }

--- a/app/javascript/flavours/glitch/styles/admin.scss
+++ b/app/javascript/flavours/glitch/styles/admin.scss
@@ -1030,6 +1030,9 @@ a.name-tag,
 
       .account-role {
         color: $ui-secondary-color;
+        background-color: var(--user-role-background, rgba($ui-secondary-color, 0.1));
+        border-color: var(--user-role-border, rgba($ui-secondary-color, 0.5));
+
       }
     }
 
@@ -1038,6 +1041,9 @@ a.name-tag,
 
       .account-role {
         color: $classic-secondary-color;
+        background-color: var(--user-role-background, rgba($classic-secondary-color, 0.1));
+        border-color: var(--user-role-border, rgba($classic-secondary-color, 0.5));
+
       }
     }
 
@@ -1046,6 +1052,8 @@ a.name-tag,
 
       .account-role {
         color: $classic-base-color;
+        background-color: var(--user-role-background, rgba($classic-base-color, 0.1));
+        border-color: var(--user-role-border, rgba($classic-base-color, 0.5));
       }
     }
   }

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -16,25 +16,19 @@
       .fields-group
         = form.input :color, wrapper: :with_label, input_html: { placeholder: '#000000', type: 'color' }
 
-    -# haml-lint:disable InlineStyles
     - unless current_user.setting_flavour == 'vanilla'
       .fields-row__column.fields-row__column-6
         .user-role__preview
-          :ruby
-            default_style = !form.object.color.empty? ? "background-color: #{form.object.color}39; border-color: #{form.object.color};" : ''
-            default_dark = "background-color: rgba(217, 225, 232, 0.1); border-color: rgba(217, 225, 232, 0.5);"
-            default_light = "background-color: rgba(40, 44, 55, 0.1); border-color: rgba(40, 44, 55, 0.5);"
           .item.dark
             .avatar
-              .account-role{ :style => !default_style.empty? ? default_style : default_dark, :id => 'user-role-preview-1' }= form.object.name
+              .account-role{ class: "user-role-#{form.object.id}", :id => 'user-role-preview-1' }= form.object.name
           .item.light
             .avatar
-              .account-role{ :style => !default_style.empty? ? default_style : default_light, :id => 'user-role-preview-2' }= form.object.name
+              .account-role{ class: "user-role-#{form.object.id}", :id => 'user-role-preview-2' }= form.object.name
           - if current_user.setting_skin != 'default' && current_user.setting_skin != 'mastodon-light'
             .item.current
               .avatar
-                .account-role{ :style => default_style, :id => 'user-role-preview-3' }= form.object.name
-    -# haml-lint:enable InlineStyles
+                .account-role{ class: "user-role-#{form.object.id}", :id => 'user-role-preview-3' }= form.object.name
   %hr.spacer/
 
   .fields-group


### PR DESCRIPTION
FIxes #285 

New problem is: The CSS vars don't update immediately, which is why I used inline styles.
Another solution (more of a workaround) could be to only show the preview once a new color is selected.
That wouldn't be ideal though.
Also the color of the role doesn't update on the roles page too, so that's kinda expected, I guess.