### PR TITLE
Ensure status reactions always refer to original status

### DIFF
--- a/app/models/status_reaction.rb
+++ b/app/models/status_reaction.rb
@@ -24,6 +24,10 @@ class StatusReaction < ApplicationRecord
   validates :name, presence: true
   validates_with StatusReactionValidator
 
+  before_validation do
+    self.status = status.reblog if status&.reblog?
+  end
+
   before_validation :set_custom_emoji
 
   after_create :increment_cache_counters


### PR DESCRIPTION
This prevents status reactions somehow being attached to a reblog instead of the reblogged status.

That scenario is not possible via the webUI but who knows.