### PR TITLE
Port role badge redesign

### DIFF
--- a/app/javascript/flavours/glitch/components/badge.jsx
+++ b/app/javascript/flavours/glitch/components/badge.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+
+import { FormattedMessage } from 'react-intl';
+
+import { ReactComponent as GroupsIcon } from '@material-symbols/svg-600/outlined/group.svg';
+import { ReactComponent as PersonIcon } from '@material-symbols/svg-600/outlined/person.svg';
+import { ReactComponent as SmartToyIcon } from '@material-symbols/svg-600/outlined/smart_toy.svg';
+
+
+export const Badge = ({ icon, label, domain }) => (
+  <div className='account-role'>
+    {icon}
+    {label}
+    {domain && <span className='account-role__domain'>{domain}</span>}
+  </div>
+);
+
+Badge.propTypes = {
+  icon: PropTypes.node,
+  label: PropTypes.node,
+  domain: PropTypes.node,
+};
+
+Badge.defaultProps = {
+  icon: <PersonIcon />,
+};
+
+export const GroupBadge = () => (
+  <Badge icon={<GroupsIcon />} label={<FormattedMessage id='account.badges.group' defaultMessage='Group' />} />
+);
+
+export const AutomatedBadge = () => (
+  <Badge icon={<SmartToyIcon />} label={<FormattedMessage id='account.badges.bot' defaultMessage='Automated' />} />
+);

--- a/app/javascript/flavours/glitch/components/badge.jsx
+++ b/app/javascript/flavours/glitch/components/badge.jsx
@@ -2,13 +2,15 @@ import PropTypes from 'prop-types';
 
 import { FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
+
 import { ReactComponent as GroupsIcon } from '@material-symbols/svg-600/outlined/group.svg';
 import { ReactComponent as PersonIcon } from '@material-symbols/svg-600/outlined/person.svg';
 import { ReactComponent as SmartToyIcon } from '@material-symbols/svg-600/outlined/smart_toy.svg';
 
 
-export const Badge = ({ icon, label, domain }) => (
-  <div className='account-role'>
+export const Badge = ({ icon, label, domain, className }) => (
+  <div className={classNames('account-role', className)}>
     {icon}
     {label}
     {domain && <span className='account-role__domain'>{domain}</span>}
@@ -19,6 +21,7 @@ Badge.propTypes = {
   icon: PropTypes.node,
   label: PropTypes.node,
   domain: PropTypes.node,
+  className: PropTypes.string,
 };
 
 Badge.defaultProps = {

--- a/app/javascript/flavours/glitch/features/account/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account/components/header.jsx
@@ -328,7 +328,7 @@ class Header extends ImmutablePureComponent {
     }
 
     account.get('roles', []).forEach((role) => {
-      badges.push(<Badge key={`role-badge-${role.get('id')}`} label={<span>{role.get('name')}</span>} domain={domain} />);
+      badges.push(<Badge key={`role-badge-${role.get('id')}`} className={`user-role-${role.get('id')}`} label={<span>{role.get('name')}</span>} domain={domain} />);
     });
 
     let roleBadge = null;

--- a/app/javascript/flavours/glitch/features/account/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account/components/header.jsx
@@ -10,6 +10,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import { Avatar } from 'flavours/glitch/components/avatar';
+import { Badge, AutomatedBadge, GroupBadge } from 'flavours/glitch/components/badge';
 import { Button } from 'flavours/glitch/components/button';
 import { Icon } from 'flavours/glitch/components/icon';
 import { IconButton } from 'flavours/glitch/components/icon_button';
@@ -321,28 +322,13 @@ class Header extends ImmutablePureComponent {
     const badges = [];
 
     if (account.get('bot')) {
-      badges.push(
-        <div key='bot-badge' className='account-role bot'>
-          <Icon id='cogs' /> { ' ' }
-          <FormattedMessage id='account.badges.bot' defaultMessage='Automated' />
-        </div>
-      );
+      badges.push(<AutomatedBadge key='bot-badge' />);
     } else if (account.get('group')) {
-      badges.push(
-        <div key='group-badge' className='account-role group'>
-          <Icon id='users' /> { ' ' }
-          <FormattedMessage id='account.badges.group' defaultMessage='Group' />
-        </div>
-      );
+      badges.push(<GroupBadge key='group-badge' />);
     }
 
     account.get('roles', []).forEach((role) => {
-      badges.push(
-        <div key={`role-badge-${role.get('id')}`} className={`account-role user-role-${account.getIn(['roles', 0, 'id'])}`}>
-          <Icon id='circle' /> { ' ' }
-          <span>{role.get('name')} ({domain})</span>
-        </div>
-      );
+      badges.push(<Badge key={`role-badge-${role.get('id')}`} label={<span>{role.get('name')}</span>} domain={domain} />);
     });
 
     let roleBadge = null;

--- a/app/javascript/flavours/glitch/features/account/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account/components/header.jsx
@@ -328,7 +328,7 @@ class Header extends ImmutablePureComponent {
     }
 
     account.get('roles', []).forEach((role) => {
-      badges.push(<Badge key={`role-badge-${role.get('id')}`} className={`user-role-${role.get('id')}`} label={<span>{role.get('name')}</span>} domain={domain} />);
+      badges.push(<Badge key={`role-badge-${role.get('id')}`} className={`user-role-${role.get('id')}`} label={<span>{role.get('name')}</span>} />);
     });
 
     let roleBadge = null;

--- a/app/javascript/flavours/glitch/features/account/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account/components/header.jsx
@@ -331,9 +331,9 @@ class Header extends ImmutablePureComponent {
       badges.push(<Badge key={`role-badge-${role.get('id')}`} className={`user-role-${role.get('id')}`} label={<span>{role.get('name')}</span>} />);
     });
 
-    let roleBadge = null;
+    let pinnedBadge = null;
     if (account.getIn(['roles', 0])) {
-      roleBadge = (<div key='role' className={`account-role user-role-${account.getIn(['roles', 0, 'id'])}`}>{account.getIn(['roles', 0, 'name'])}</div>);
+      pinnedBadge = (<Badge key='pinned-badge' icon={null} className={`pinned user-role-${account.getIn(['roles', 0, 'id'])}`} label={<span>{account.getIn(['roles', 0, 'name'])}</span>} />);
     }
 
     return (
@@ -352,7 +352,7 @@ class Header extends ImmutablePureComponent {
           <div className='account__header__tabs'>
             <a className='avatar' href={account.get('avatar')} rel='noopener noreferrer' target='_blank' onClick={this.handleAvatarClick}>
               <Avatar account={suspended || hidden ? undefined : account} size={90} />
-              {roleBadge}
+              {pinnedBadge}
             </a>
 
             {!suspended && (

--- a/app/javascript/flavours/glitch/features/account/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account/components/header.jsx
@@ -331,11 +331,6 @@ class Header extends ImmutablePureComponent {
       badges.push(<Badge key={`role-badge-${role.get('id')}`} className={`user-role-${role.get('id')}`} label={<span>{role.get('name')}</span>} />);
     });
 
-    let pinnedBadge = null;
-    if (account.getIn(['roles', 0])) {
-      pinnedBadge = (<Badge key='pinned-badge' icon={null} className={`pinned user-role-${account.getIn(['roles', 0, 'id'])}`} label={<span>{account.getIn(['roles', 0, 'name'])}</span>} />);
-    }
-
     return (
       <div className={classNames('account__header', { inactive: !!account.get('moved') })} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
         {!(suspended || hidden || account.get('moved')) && account.getIn(['relationship', 'requested_by']) && <FollowRequestNoteContainer account={account} />}
@@ -352,7 +347,6 @@ class Header extends ImmutablePureComponent {
           <div className='account__header__tabs'>
             <a className='avatar' href={account.get('avatar')} rel='noopener noreferrer' target='_blank' onClick={this.handleAvatarClick}>
               <Avatar account={suspended || hidden ? undefined : account} size={90} />
-              {pinnedBadge}
             </a>
 
             {!suspended && (

--- a/app/javascript/flavours/glitch/features/account/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account/components/header.jsx
@@ -318,15 +318,32 @@ class Header extends ImmutablePureComponent {
     const acct            = isLocal && domain ? `${account.get('acct')}@${domain}` : account.get('acct');
     const isIndexable     = !account.get('noindex');
 
-    let badge;
+    const badges = [];
 
     if (account.get('bot')) {
-      badge = (<div className='account-role bot'><FormattedMessage id='account.badges.bot' defaultMessage='Automated' /></div>);
+      badges.push(
+        <div key='bot-badge' className='account-role bot'>
+          <Icon id='cogs' /> { ' ' }
+          <FormattedMessage id='account.badges.bot' defaultMessage='Automated' />
+        </div>
+      );
     } else if (account.get('group')) {
-      badge = (<div className='account-role group'><FormattedMessage id='account.badges.group' defaultMessage='Group' /></div>);
-    } else {
-      badge = null;
+      badges.push(
+        <div key='group-badge' className='account-role group'>
+          <Icon id='users' /> { ' ' }
+          <FormattedMessage id='account.badges.group' defaultMessage='Group' />
+        </div>
+      );
     }
+
+    account.get('roles', []).forEach((role) => {
+      badges.push(
+        <div key={`role-badge-${role.get('id')}`} className={`account-role user-role-${account.getIn(['roles', 0, 'id'])}`}>
+          <Icon id='circle' /> { ' ' }
+          <span>{role.get('name')} ({domain})</span>
+        </div>
+      );
+    });
 
     let roleBadge = null;
     if (account.getIn(['roles', 0])) {
@@ -368,12 +385,18 @@ class Header extends ImmutablePureComponent {
 
           <div className='account__header__tabs__name'>
             <h1>
-              <span dangerouslySetInnerHTML={displayNameHtml} /> {badge}
+              <span dangerouslySetInnerHTML={displayNameHtml} />
               <small>
                 <span>@{acct}</span> {lockedIcon}
               </small>
             </h1>
           </div>
+
+          {badges.length > 0 && (
+            <div className='account__header__badges'>
+              {badges}
+            </div>
+          )}
 
           {signedIn && <AccountNoteContainer account={account} />}
 

--- a/app/javascript/flavours/glitch/styles/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/accounts.scss
@@ -201,24 +201,36 @@
   display: inline-block;
   padding: 4px 6px;
   cursor: default;
-  border-radius: 3px;
+  border-radius: 4px;
   font-size: 12px;
   line-height: 12px;
   font-weight: 500;
   color: $ui-secondary-color;
-  background-color: var(--user-role-background, rgba($ui-secondary-color, 0.1));
-  border: 1px solid var(--user-role-border, rgba($ui-secondary-color, 0.5));
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
 
-  &.moderator {
+.information-badge,
+.simple_form .recommended,
+.simple_form .not_recommended {
+  background-color: rgba($ui-secondary-color, 0.1);
+  border: 1px solid rgba($ui-secondary-color, 0.5);
+}
+
+.account-role {
+  border: 1px solid $highlight-text-color;
+
+  .fa {
+    color: var(--user-role-accent, $highlight-text-color);
+  }
+}
+
+.information-badge {
+  &.superapp {
     color: $success-green;
     background-color: rgba($success-green, 0.1);
     border-color: rgba($success-green, 0.5);
-  }
-
-  &.admin {
-    color: lighten($error-red, 12%);
-    background-color: rgba(lighten($error-red, 12%), 0.1);
-    border-color: rgba(lighten($error-red, 12%), 0.5);
   }
 }
 

--- a/app/javascript/flavours/glitch/styles/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/accounts.scss
@@ -191,7 +191,6 @@
   }
 }
 
-.account-role,
 .information-badge,
 .simple_form .overridden,
 .simple_form .recommended,
@@ -219,10 +218,30 @@
 }
 
 .account-role {
+  display: inline-flex;
+  padding: 4px;
+  padding-inline-end: 8px;
   border: 1px solid $highlight-text-color;
+  color: $highlight-text-color;
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  line-height: 16px;
+  gap: 4px;
+  border-radius: 6px;
+  align-items: center;
 
-  .fa {
-    color: var(--user-role-accent, $highlight-text-color);
+  svg {
+    width: auto;
+    height: 15px;
+    opacity: 0.85;
+    fill: currentColor;
+  }
+
+  &__domain {
+    font-weight: 400;
+    opacity: 0.75;
+    letter-spacing: 0;
   }
 }
 

--- a/app/javascript/flavours/glitch/styles/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/accounts.scss
@@ -239,6 +239,17 @@
     opacity: 0.75;
     letter-spacing: 0;
   }
+
+  &.pinned {
+    margin: 0 2px;
+    padding: 4px 0;
+    min-width: 90px;
+    text-align: center;
+    box-sizing: border-box;
+    justify-content: center;
+    line-height: 12px;
+    border-radius: 4px;
+  }
 }
 
 .information-badge {

--- a/app/javascript/flavours/glitch/styles/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/accounts.scss
@@ -221,8 +221,9 @@
   display: inline-flex;
   padding: 4px;
   padding-inline-end: 8px;
-  border: 1px solid $highlight-text-color;
-  color: $highlight-text-color;
+  border: 1px solid var(--user-role-border, rgba($ui-secondary-color, 0.5));
+  background-color: var(--user-role-background, rgba($ui-secondary-color, 0.1));
+  color: $ui-secondary-color;
   font-weight: 500;
   font-size: 12px;
   letter-spacing: 0.5px;

--- a/app/javascript/flavours/glitch/styles/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/accounts.scss
@@ -208,11 +208,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-}
-
-.information-badge,
-.simple_form .recommended,
-.simple_form .not_recommended {
   background-color: rgba($ui-secondary-color, 0.1);
   border: 1px solid rgba($ui-secondary-color, 0.5);
 }

--- a/app/javascript/flavours/glitch/styles/components/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/components/accounts.scss
@@ -579,6 +579,17 @@
     }
   }
 
+  &__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 5px 10px;
+
+    .account-role {
+      line-height: unset;
+    }
+  }
+
   &__tabs {
     display: flex;
     align-items: flex-end;
@@ -588,14 +599,6 @@
     height: 130px;
     overflow: hidden;
     margin-inline-start: -2px; // aligns the pfp with content below
-
-    .account-role {
-      margin: 0 2px;
-      padding: 4px 0;
-      box-sizing: border-box;
-      min-width: 90px;
-      text-align: center;
-    }
 
     &__buttons {
       display: flex;

--- a/app/javascript/flavours/glitch/styles/components/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/components/accounts.scss
@@ -592,11 +592,10 @@
 
   &__tabs {
     display: flex;
-    align-items: flex-end;
+    align-items: flex-start;
     justify-content: space-between;
     padding: 7px 10px;
-    margin-top: -81px;
-    height: 130px;
+    margin-top: -55px;
     overflow: hidden;
     margin-inline-start: -2px; // aligns the pfp with content below
 


### PR DESCRIPTION
I can't decide whether to remove the old badge, or keeping it and removing the new badge.

Preview:
![User profile with an owner badge below the profile picture and an automated badge below the display name](https://github.com/polyamspace/mastodon/assets/117664621/63c2a074-f621-437c-8990-050a55cef83a)

Additional changes:
- 246dfb3c57700dab26f29a9e49e164f465f7941f
- 00ed7f38acf5e81e2c550dc2a902fb60bdacb67c
- c5935ed5fa346931645bfe602ebfe2dbf6e9d59d
- 8e70d6a63bafd125acd472eeec9905f2bddc28ed (I'm unsure whether to keep it at all, it's kinda useless now :/)
- da549865b6605dfe044eb34682bad403317170ea