### PR TITLE
FairyFloss: Fix wrong underline color in link previews

### DIFF
--- a/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
+++ b/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
@@ -246,22 +246,13 @@ body.admin {
 }
 
 // link previews
-
-.status-card.compact {
-  border-color: darken($purple5, 8%);
-  background: $purple5;
-}
-
-.status-card__image {
-  background: $purple3;
-}
-
-.status-card__content {
-  background: $purple5;
-
+// TODO: Remove on refactor
+a.status-card,
+.status-card a {
   &:hover,
+  &:active,
   &:focus {
-    background: darken($purple5, 4%);
+    text-decoration-color: $ui-highlight-color;
   }
 }
 


### PR DESCRIPTION
Fixes the underline being green while the text is orange.

Doesn't fix the color of the text.

Should be considered a quick, dirty fix.
I intend to refactor this skin.