### PR TITLE
Change preview for custom theme

### DIFF
--- a/app/javascript/flavours/glitch/styles/admin.scss
+++ b/app/javascript/flavours/glitch/styles/admin.scss
@@ -1012,19 +1012,7 @@ a.name-tag,
 
     .item {
       padding: 12px 15px;
-    }
-
-    .current {
-      background-color: lighten($ui-base-color, 4%);
-
-      .account-role {
-        color: $ui-secondary-color;
-        background-color: var(
-          --user-role-background,
-          rgba($ui-secondary-color, 0.1)
-        );
-        border-color: var(--user-role-border, rgba($ui-secondary-color, 0.5));
-      }
+      border: none;
     }
 
     .dark {

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -28,7 +28,7 @@
               = person_icon
               %span= form.object.name
           - if current_user.setting_skin != 'default' && current_user.setting_skin != 'mastodon-light'
-            .item.current
+            .item.account__header__bar
               .account-role{ class: "user-role-#{form.object.id}", :id => 'user-role-preview-3' }
                 = person_icon
                 %span= form.object.name


### PR DESCRIPTION
Many custom themes override `account__header__bar` instead or in addition of modifying `ui-base-color`.

Makes the preview more robust by using the same CSS class.