### PR TITLE
Add endorsed accounts to profiles

### DIFF
--- a/app/controllers/api/v1/accounts/pins_controller.rb
+++ b/app/controllers/api/v1/accounts/pins_controller.rb
@@ -90,7 +90,7 @@ class Api::V1::Accounts::PinsController < Api::BaseController
   end
 
   def limit
-    params[:limit].to_i
+    params[:limit].to_i || DEFAULT_ACCOUNTS_LIMIT
   end
 
   def unlimited?

--- a/app/controllers/api/v1/accounts/pins_controller.rb
+++ b/app/controllers/api/v1/accounts/pins_controller.rb
@@ -3,9 +3,16 @@
 class Api::V1::Accounts::PinsController < Api::BaseController
   include Authorization
 
-  before_action -> { doorkeeper_authorize! :write, :'write:accounts' }
-  before_action :require_user!
+  before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, except: [:index]
+  before_action :require_user!, except: [:index]
   before_action :set_account
+  after_action :insert_pagination_headers, except: [:create, :destroy]
+
+  def index
+    cache_if_unauthenticated!
+    @accounts = load_accounts
+    render json: @accounts, each_serializer: REST::AccountSerializer
+  end
 
   def create
     AccountPin.find_or_create_by!(account: current_account, target_account: @account)
@@ -26,5 +33,67 @@ class Api::V1::Accounts::PinsController < Api::BaseController
 
   def relationships_presenter
     AccountRelationshipsPresenter.new([@account.id], current_user.account_id)
+  end
+
+  def load_accounts
+    return [] if hide_results?
+
+    if unlimited?
+      endorsed_accounts.all
+    else
+      endorsed_accounts.paginate_by_max_id(
+        limit_param(limit),
+        params[:max_id],
+        params[:since_id]
+      )
+    end
+  end
+
+  def endorsed_accounts
+    @account.endorsed_accounts
+  end
+
+  def hide_results?
+    @account.suspended? || (current_account && @account.blocking?(current_account))
+  end
+
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
+
+  def next_path
+    return if unlimited?
+
+    api_v1_account_pinned_index_url pagination_params(max_id: pagination_max_id) if records_continue?
+  end
+
+  def prev_path
+    return if unlimited?
+
+    api_v1_account_pinned_index_url pagination_params(since_id: pagination_since_id) unless @accounts.empty?
+  end
+
+  def pagination_max_id
+    @accounts.last.id
+  end
+
+  def pagination_since_id
+    @accounts.first.id
+  end
+
+  def records_continue?
+    @accounts.size == limit_param(limit)
+  end
+
+  def pagination_params(core_params)
+    params.slice(:limit).permit(:limit).merge(core_params)
+  end
+
+  def limit
+    params[:limit].to_i
+  end
+
+  def unlimited?
+    params[:limit] == '0'
   end
 end

--- a/app/javascript/flavours/glitch/features/account_timeline/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account_timeline/components/header.jsx
@@ -163,7 +163,7 @@ class Header extends ImmutablePureComponent {
           </div>
         )}
         {!(hideTabs || hidden) && featured && (
-          <div className='account__section-headline'>
+          <div className='account__section-headline featured'>
             <NavLink isActive={this.isFeaturedPageActive} exact to={`/@${account.get('acct')}/featured/tags`}><FormattedMessage id='explore.trending_tags' defaultMessage='Hashtags' /></NavLink>
             <NavLink exact to={`/@${account.get('acct')}/featured/accounts`}><FormattedMessage id='explore.suggested_follows' defaultMessage='People' /></NavLink>
           </div>

--- a/app/javascript/flavours/glitch/features/account_timeline/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/account_timeline/components/header.jsx
@@ -36,6 +36,7 @@ class Header extends ImmutablePureComponent {
     hideTabs: PropTypes.bool,
     domain: PropTypes.string.isRequired,
     hidden: PropTypes.bool,
+    featured: PropTypes.bool,
     ...WithRouterPropTypes,
   };
 
@@ -111,8 +112,12 @@ class Header extends ImmutablePureComponent {
     this.props.onOpenAvatar(this.props.account);
   };
 
+  isFeaturedPageActive = (_, location) => {
+    return !location.pathname.match(/(\/featured\/accounts)\/?$/);
+  };
+
   render () {
-    const { account, hidden, hideTabs } = this.props;
+    const { account, hidden, hideTabs, featured } = this.props;
 
     if (account === null) {
       return null;
@@ -153,8 +158,14 @@ class Header extends ImmutablePureComponent {
           <div className='account__section-headline'>
             <NavLink exact to={`/@${account.get('acct')}`}><FormattedMessage id='account.posts' defaultMessage='Posts' /></NavLink>
             <NavLink exact to={`/@${account.get('acct')}/with_replies`}><FormattedMessage id='account.posts_with_replies' defaultMessage='Posts and replies' /></NavLink>
-            <NavLink exact to={`/@${account.get('acct')}/featured`}><FormattedMessage id='explore.trending_tags' defaultMessage='Hashtags' /></NavLink>
+            <NavLink to={`/@${account.get('acct')}/featured`}><FormattedMessage id='account.featured' defaultMessage='Featured' /></NavLink>
             <NavLink exact to={`/@${account.get('acct')}/media`}><FormattedMessage id='account.media' defaultMessage='Media' /></NavLink>
+          </div>
+        )}
+        {!(hideTabs || hidden) && featured && (
+          <div className='account__section-headline'>
+            <NavLink isActive={this.isFeaturedPageActive} exact to={`/@${account.get('acct')}/featured/tags`}><FormattedMessage id='explore.trending_tags' defaultMessage='Hashtags' /></NavLink>
+            <NavLink exact to={`/@${account.get('acct')}/featured/accounts`}><FormattedMessage id='explore.suggested_follows' defaultMessage='People' /></NavLink>
           </div>
         )}
       </div>

--- a/app/javascript/flavours/glitch/features/featured/index.jsx
+++ b/app/javascript/flavours/glitch/features/featured/index.jsx
@@ -39,11 +39,12 @@ const Featured = ({ params, multiColumn, type }) => {
   const acct = useAppSelector((state) => state.getIn(['accounts', accountId, 'acct']));
   const remoteUrl = useAppSelector((state) => state.getIn(['accounts', accountId, 'url']));
   const isAccount = useAppSelector((state) => !!(state.getIn(['accounts', accountId])));
-  const featuredItems = useAppSelector((state) => state.getIn(['user_lists', showTags ? 'featured_tags' : 'featured_accounts', accountId, 'items'], ImmutableList()));
-  const isLoading = useAppSelector((state) => !accountId || state.getIn(['user_lists', showTags ? 'featured_tags' : 'featured_accounts', accountId, 'isLoading'], true));
-  const hasMore = useAppSelector((state) => !accountId || state.getIn(['user_lists', showTags ? 'featured_tags' : 'featured_accounts', accountId, 'next'], false));
   const suspended = useAppSelector((state) => state.getIn(['accounts', accountId, 'suspended'], false));
   const hidden = useAppSelector((state) => getAccountHidden(state, accountId));
+  // Featured tags are still returned for limited accounts, preventing the limited account hint from showing, so explicitely set an empty list
+  const featuredItems = useAppSelector((state) => !hidden ? state.getIn(['user_lists', showTags ? 'featured_tags' : 'featured_accounts', accountId, 'items'], ImmutableList()) : ImmutableList());
+  const isLoading = useAppSelector((state) => !accountId || state.getIn(['user_lists', showTags ? 'featured_tags' : 'featured_accounts', accountId, 'isLoading'], true));
+  const hasMore = useAppSelector((state) => !accountId || !!state.getIn(['user_lists', showTags ? 'featured_tags' : 'featured_accounts', accountId, 'next']));
 
   const handleHeaderClick = useCallback(() => columnRef.current?.scrollTop(), []);
 
@@ -78,9 +79,6 @@ const Featured = ({ params, multiColumn, type }) => {
 
   let emptyMessage;
 
-  /*NOTE: Limited account hint will never show, most likely because featured tags are still returned for limited accounts,
-     *      while other requests return empty data.
-     */
   if (suspended) {
     emptyMessage = <FormattedMessage id='empty_column.account_suspended' defaultMessage='Account suspended' />;
   } else if (hidden) {

--- a/app/javascript/flavours/glitch/features/featured/index.jsx
+++ b/app/javascript/flavours/glitch/features/featured/index.jsx
@@ -58,7 +58,7 @@ const Featured = ({ params, multiColumn, type }) => {
     } else {
       if (!isAccount) dispatch(fetchAccount(accountId));
       dispatch(fetchFeaturedTags(accountId));
-      dispatch(fetchPinnedAccounts(accountId, 10));
+      dispatch(fetchPinnedAccounts(accountId, undefined));
     }
 
   }, [dispatch, showTags, isAccount, accountId, params]);

--- a/app/javascript/flavours/glitch/features/pinned_accounts_editor/containers/account_container.js
+++ b/app/javascript/flavours/glitch/features/pinned_accounts_editor/containers/account_container.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { pinAccount, unpinAccount } from 'flavours/glitch/actions/accounts';
 import Account from 'flavours/glitch/features/list_editor/components/account';
+import { me } from 'flavours/glitch/initial_state';
 import { makeGetAccount } from 'flavours/glitch/selectors';
 
 const makeMapStateToProps = () => {
@@ -11,7 +12,7 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state, { accountId, added }) => ({
     account: getAccount(state, accountId),
-    added: typeof added === 'undefined' ? state.getIn(['pinnedAccountsEditor', 'accounts', 'items']).includes(accountId) : added,
+    added: typeof added === 'undefined' ? state.getIn(['user_lists', 'featured_accounts', me, 'items']).includes(accountId) : added,
   });
 
   return mapStateToProps;

--- a/app/javascript/flavours/glitch/features/pinned_accounts_editor/index.jsx
+++ b/app/javascript/flavours/glitch/features/pinned_accounts_editor/index.jsx
@@ -11,16 +11,25 @@ import spring from 'react-motion/lib/spring';
 import { fetchPinnedAccounts, clearPinnedAccountsSuggestions, resetPinnedAccountsEditor } from 'flavours/glitch/actions/accounts';
 import Motion from 'flavours/glitch/features/ui/util/optional_motion';
 
+import { LoadingIndicator } from '../../components/loading_indicator';
+import { me } from '../../initial_state';
+
 import AccountContainer from './containers/account_container';
 import SearchContainer from './containers/search_container';
 
-const mapStateToProps = state => ({
-  accountIds: state.getIn(['pinnedAccountsEditor', 'accounts', 'items']),
-  searchAccountIds: state.getIn(['pinnedAccountsEditor', 'suggestions', 'items']),
-});
+
+const mapStateToProps = state => {
+  const myAccount = state.getIn(['accounts', me]);
+
+  return {
+    myAccount,
+    accountIds: state.getIn(['user_lists', 'featured_accounts', myAccount.get('id'), 'items']),
+    searchAccountIds: state.getIn(['pinnedAccountsEditor', 'suggestions', 'items']),
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
-  onInitialize: () => dispatch(fetchPinnedAccounts()),
+  onInitialize: (myAccount) => dispatch(fetchPinnedAccounts(myAccount.get('id'))),
   onClear: () => dispatch(clearPinnedAccountsSuggestions()),
   onReset: () => dispatch(resetPinnedAccountsEditor()),
 });
@@ -34,13 +43,14 @@ class PinnedAccountsEditor extends ImmutablePureComponent {
     onClear: PropTypes.func.isRequired,
     onReset: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
+    myAccount: ImmutablePropTypes.map.isRequired,
     accountIds: ImmutablePropTypes.list.isRequired,
     searchAccountIds: ImmutablePropTypes.list.isRequired,
   };
 
   componentDidMount () {
-    const { onInitialize } = this.props;
-    onInitialize();
+    const { onInitialize, myAccount } = this.props;
+    onInitialize(myAccount);
   }
 
   componentWillUnmount () {
@@ -51,6 +61,12 @@ class PinnedAccountsEditor extends ImmutablePureComponent {
   render () {
     const { accountIds, searchAccountIds, onClear } = this.props;
     const showSearch = searchAccountIds.size > 0;
+
+    if (!accountIds) {
+      return (
+        <LoadingIndicator />
+      );
+    }
 
     return (
       <div className='modal-root__modal list-editor'>

--- a/app/javascript/flavours/glitch/features/ui/index.jsx
+++ b/app/javascript/flavours/glitch/features/ui/index.jsx
@@ -231,7 +231,8 @@ class SwitchingColumnsArea extends PureComponent {
           <WrappedRoute path={['/accounts/:id/followers', '/users/:acct/followers', '/@:acct/followers']} component={Followers} content={children} />
           <WrappedRoute path={['/accounts/:id/following', '/users/:acct/following', '/@:acct/following']} component={Following} content={children} />
           <WrappedRoute path={['/@:acct/media', '/accounts/:id/media']} component={AccountGallery} content={children} />
-          <WrappedRoute path={['/@:acct/featured', '/accounts/:id/featured']} component={Featured} content={children} />
+          <WrappedRoute path={['/@:acct/featured', '/accounts/:id/featured', '/@:acct/featured/tags', '/accounts/:id/featured/tags']} exact component={Featured} componentParams={{ type: 'tags' }} content={children} />
+          <WrappedRoute path={['/@:acct/featured/accounts', '/accounts/:id/featured/accounts']} exact component={Featured} componentParams={{ type: 'accounts' }} content={children} />
           <WrappedRoute path='/@:acct/:statusId' exact component={Status} content={children} />
           <WrappedRoute path='/@:acct/:statusId/reblogs' component={Reblogs} content={children} />
           <WrappedRoute path='/@:acct/:statusId/favourites' component={Favourites} content={children} />

--- a/app/javascript/flavours/glitch/reducers/pinned_accounts_editor.js
+++ b/app/javascript/flavours/glitch/reducers/pinned_accounts_editor.js
@@ -2,23 +2,12 @@ import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 
 import {
   PINNED_ACCOUNTS_EDITOR_RESET,
-  PINNED_ACCOUNTS_FETCH_REQUEST,
-  PINNED_ACCOUNTS_FETCH_SUCCESS,
-  PINNED_ACCOUNTS_FETCH_FAIL,
   PINNED_ACCOUNTS_SUGGESTIONS_FETCH_SUCCESS,
   PINNED_ACCOUNTS_EDITOR_SUGGESTIONS_CLEAR,
   PINNED_ACCOUNTS_EDITOR_SUGGESTIONS_CHANGE,
-  ACCOUNT_PIN_SUCCESS,
-  ACCOUNT_UNPIN_SUCCESS,
 } from '../actions/accounts';
 
 const initialState = ImmutableMap({
-  accounts: ImmutableMap({
-    items: ImmutableList(),
-    loaded: false,
-    isLoading: false,
-  }),
-
   suggestions: ImmutableMap({
     value: '',
     items: ImmutableList(),
@@ -29,16 +18,6 @@ export default function listEditorReducer(state = initialState, action) {
   switch(action.type) {
   case PINNED_ACCOUNTS_EDITOR_RESET:
     return initialState;
-  case PINNED_ACCOUNTS_FETCH_REQUEST:
-    return state.setIn(['accounts', 'isLoading'], true);
-  case PINNED_ACCOUNTS_FETCH_FAIL:
-    return state.setIn(['accounts', 'isLoading'], false);
-  case PINNED_ACCOUNTS_FETCH_SUCCESS:
-    return state.update('accounts', accounts => accounts.withMutations(map => {
-      map.set('isLoading', false);
-      map.set('loaded', true);
-      map.set('items', ImmutableList(action.accounts.map(item => item.id)));
-    }));
   case PINNED_ACCOUNTS_SUGGESTIONS_FETCH_SUCCESS:
     return state.setIn(['suggestions', 'items'], ImmutableList(action.accounts.map(item => item.id)));
   case PINNED_ACCOUNTS_EDITOR_SUGGESTIONS_CHANGE:
@@ -48,10 +27,6 @@ export default function listEditorReducer(state = initialState, action) {
       map.set('items', ImmutableList());
       map.set('value', '');
     }));
-  case ACCOUNT_PIN_SUCCESS:
-    return state.updateIn(['accounts', 'items'], list => list.unshift(action.relationship.id));
-  case ACCOUNT_UNPIN_SUCCESS:
-    return state.updateIn(['accounts', 'items'], list => list.filterNot(item => item === action.relationship.id));
   default:
     return state;
   }

--- a/app/javascript/flavours/glitch/reducers/user_lists.js
+++ b/app/javascript/flavours/glitch/reducers/user_lists.js
@@ -35,6 +35,12 @@ import {
   FOLLOW_REQUESTS_EXPAND_FAIL,
   FOLLOW_REQUEST_AUTHORIZE_SUCCESS,
   FOLLOW_REQUEST_REJECT_SUCCESS,
+  PINNED_ACCOUNTS_FETCH_REQUEST,
+  PINNED_ACCOUNTS_FETCH_SUCCESS,
+  PINNED_ACCOUNTS_FETCH_FAIL,
+  PINNED_ACCOUNTS_EXPAND_REQUEST,
+  PINNED_ACCOUNTS_EXPAND_SUCCESS,
+  PINNED_ACCOUNTS_EXPAND_FAIL,
 } from '../actions/accounts';
 import {
   BLOCKS_FETCH_REQUEST,
@@ -230,6 +236,16 @@ export default function userLists(state = initialState, action) {
     return state.setIn(['featured_tags', action.id, 'isLoading'], true);
   case FEATURED_TAGS_FETCH_FAIL:
     return state.setIn(['featured_tags', action.id, 'isLoading'], false);
+  case PINNED_ACCOUNTS_FETCH_REQUEST:
+  case PINNED_ACCOUNTS_EXPAND_REQUEST:
+    return state.setIn(['featured_accounts', action.id, 'isLoading'], true);
+  case PINNED_ACCOUNTS_FETCH_FAIL:
+  case PINNED_ACCOUNTS_EXPAND_FAIL:
+    return state.setIn(['featured_accounts', action.id, 'isLoading'], false);
+  case PINNED_ACCOUNTS_FETCH_SUCCESS:
+    return normalizeList(state, ['featured_accounts', action.id], action.accounts, action.next);
+  case PINNED_ACCOUNTS_EXPAND_SUCCESS:
+    return appendToList(state, ['featured_accounts', action.id], action.accounts, action.next);
   default:
     return state;
   }

--- a/app/javascript/flavours/polyam/locales/en.json
+++ b/app/javascript/flavours/polyam/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "account.featured": "Featured",
+  "account.featured_accounts.empty": "This user doesn't feature any accounts yet.",
   "account.featured_tags.empty": "This user doesn't feature any hashtags yet.",
   "account.request_follow": "Request follow",
   "column.reacted_by": "Reacted by",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,8 @@ Rails.application.routes.draw do
     get '/@:username', to: 'accounts#show', as: :short_account
     get '/@:username/with_replies', to: 'accounts#show', as: :short_account_with_replies
     get '/@:username/featured', to: 'accounts#show', as: :short_account_featured
+    get '/@:username/featured/tags', to: 'accounts#show', as: :short_account_featured_tags
+    get '/@:username/featured/accounts', to: 'accounts#show', as: :short_account_featured_accounts
     get '/@:username/media', to: 'accounts#show', as: :short_account_media
     get '/@:username/tagged/:tag', to: 'accounts#show', as: :short_account_tag
   end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -190,6 +190,7 @@ namespace :api, format: false do
       end
 
       resource :pin, only: :create, controller: 'accounts/pins'
+      resources :pinned, only: :index, controller: 'accounts/pins'
       post :unpin, to: 'accounts/pins#destroy'
       resource :note, only: :create, controller: 'accounts/notes'
     end

--- a/spec/controllers/api/v1/accounts/pins_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/pins_controller_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Accounts::PinsController do
+  # What's this for?
+  render_views
+
+  let(:account) { Fabricate(:account) }
   let(:john)  { Fabricate(:user) }
   let(:kevin) { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: john.id, scopes: 'write:accounts') }
@@ -10,6 +14,34 @@ RSpec.describe Api::V1::Accounts::PinsController do
   before do
     kevin.account.followers << john.account
     allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    before do
+      account.follow!(kevin.account)
+      Fabricate(:account_pin, account: account, target_account: kevin.account)
+    end
+
+    it 'returns accounts pinned by the given account', :aggregate_failures do
+      get :index, params: { account_id: account.id, limit: 1 }
+
+      expect(response).to have_http_status(200)
+      expect(body_as_json.size).to eq 1
+      expect(body_as_json[0][:id]).to eq kevin.account.id.to_s
+    end
+
+    context 'when requesting user is blocked' do
+      before do
+        account.block!(john.account)
+      end
+
+      it 'hides results' do
+        get :index, params: { account_id: account.id, limit: 1 }
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json.size).to eq 0
+      end
+    end
   end
 
   describe 'POST #create' do

--- a/spec/routing/accounts_routing_spec.rb
+++ b/spec/routing/accounts_routing_spec.rb
@@ -44,6 +44,8 @@ describe 'Routes under accounts/' do
 
     it 'routes /@:username/featured' do
       expect(get("/@#{username}/featured")).to route_to('accounts#show', username: username)
+      expect(get("/@#{username}/featured/tags")).to route_to('accounts#show', username: username)
+      expect(get("/@#{username}/featured/accounts")).to route_to('accounts#show', username: username)
     end
 
     it 'routes /@:username/tagged/:tag' do
@@ -84,6 +86,8 @@ describe 'Routes under accounts/' do
 
     it 'routes /@:username/featured' do
       expect(get("/@#{username}/featured")).to route_to('home#index', username_with_domain: username, any: 'featured')
+      expect(get("/@#{username}/featured/tags")).to route_to('home#index', username_with_domain: username, any: 'featured/tags')
+      expect(get("/@#{username}/featured/accounts")).to route_to('home#index', username_with_domain: username, any: 'featured/accounts')
     end
 
     it 'routes /@:username/tagged/:tag' do


### PR DESCRIPTION
Fixes #204 

Adds `api/v1/accounts/{id}/pinned` endpoint returning the endorsed accounts of `{id}`
Kept `api/v1/endorsements` endpoint just in case apps use these.

TODO:
- [x] Keep pinned accounts editor functional
- [x] Allow expanding pinned accounts
- [x] Display featured accounts on profiles (I have to rewrite the whole component... D:)
- [x] Adjust routing spec