### PR TITLE
Fix autosuggest colors in Oatstodon theme

### DIFF
--- a/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
+++ b/app/javascript/flavours/glitch/styles/oatstodon/diff.scss
@@ -219,6 +219,21 @@ hr {
   }
 }
 
+.autosuggest-textarea {
+  &__suggestions {
+    background-color: $simple-background-color;
+
+    &__item {
+      &:hover,
+      &:focus,
+      &:active,
+      &.selected {
+        background-color: lighten($simple-background-color, 8%);
+      }
+    }
+  }
+}
+
 .reply-indicator {
   max-height: 38px;
   overflow-y: hidden;


### PR DESCRIPTION
Follow-up to #296 

Forgot to test this.
Changes the background to a dark one and hover background to match.