### PR TITLE
Disable vanilla flavour by default

### DIFF
--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -21,7 +21,7 @@ class Themes
       screenshots = []
 
       # Skip vanilla flavour
-      next if name == 'vanilla'
+      next if name == 'vanilla' && ENV['ENABLE_VANILLA'] != 'true'
 
       if data['locales']
         Dir.glob(File.join(dir, data['locales'], '*.{js,json}')) do |locale|

--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -20,6 +20,9 @@ class Themes
       locales = []
       screenshots = []
 
+      # Skip vanilla flavour
+      next if name == 'vanilla'
+
       if data['locales']
         Dir.glob(File.join(dir, data['locales'], '*.{js,json}')) do |locale|
           locale_name = File.basename(locale, File.extname(locale))

--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -1,8 +1,15 @@
 - content_for :header_tags do
   - if user_signed_in?
-    = preload_pack_asset 'features/compose.js'
-    = preload_pack_asset 'features/home_timeline.js'
-    = preload_pack_asset 'features/notifications.js'
+    - if current_user.setting_flavour == 'vanilla'
+      = preload_pack_asset 'features/compose.js'
+      = preload_pack_asset 'features/home_timeline.js'
+      = preload_pack_asset 'features/notifications.js'
+    - else
+      -# haml-lint:disable InstanceVariables
+      = preload_pack_asset "flavours/#{@theme[:flavour]}/async/compose.js"
+      = preload_pack_asset "flavours/#{@theme[:flavour]}/async/home_timeline.js"
+      = preload_pack_asset "flavours/#{@theme[:flavour]}/async/notifications.js"
+      -# haml-lint:enable InstanceVariables
     %meta{ name: 'initialPath', content: request.path }
 
   %meta{ name: 'applicationServerKey', content: Rails.configuration.x.vapid_public_key }

--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -1,6 +1,6 @@
 - content_for :header_tags do
   - if user_signed_in?
-    - if current_user.setting_flavour == 'vanilla'
+    - if current_user.setting_flavour == 'vanilla' && Themes.instance.flavours.include?('vanilla')
       = preload_pack_asset 'features/compose.js'
       = preload_pack_asset 'features/home_timeline.js'
       = preload_pack_asset 'features/notifications.js'

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -27,7 +27,7 @@ flavourFiles.forEach((flavourFile) => {
   data.name = basename(dirname(flavourFile));
   data.skin = {};
   // Skip vanilla flavour
-  if (data.name === 'vanilla') return;
+  if (data.name === 'vanilla' && env.ENABLE_VANILLA !== 'true') return;
   if (!data.pack_directory) {
     data.pack_directory = dirname(flavourFile);
   }

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -26,6 +26,8 @@ flavourFiles.forEach((flavourFile) => {
   const data = load(readFileSync(flavourFile), 'utf8');
   data.name = basename(dirname(flavourFile));
   data.skin = {};
+  // Skip vanilla flavour
+  if (data.name === 'vanilla') return;
   if (!data.pack_directory) {
     data.pack_directory = dirname(flavourFile);
   }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -85,7 +85,7 @@ describe ApplicationController do
       allow(Setting).to receive(:[]).with('skin').and_return 'default'
       allow(Setting).to receive(:[]).with('flavour').and_return 'vanilla'
 
-      expect(controller.view_context.current_flavour).to eq 'vanilla'
+      expect(controller.view_context.current_flavour).to eq 'glitch'
     end
 
     it 'returns instances\'s default flavour when user didn\'t set theme' do
@@ -98,7 +98,7 @@ describe ApplicationController do
       allow(Setting).to receive(:[]).with('show_application').and_return false
       allow(Setting).to receive(:[]).with('norss').and_return false
 
-      expect(controller.view_context.current_flavour).to eq 'vanilla'
+      expect(controller.view_context.current_flavour).to eq 'glitch'
     end
 
     it 'returns user\'s flavour when it is set' do


### PR DESCRIPTION
Somewhat related to #306 

This change keeps the files, but disables the vanilla flavour and also skips precompiling vanilla files.

Keeping files is necessary as otherwise git gets confused and tries to apply changes to wrong files on upstream merges.