### PR TITLE
Remove redundant asset preload

### DIFF
--- a/app/javascript/flavours/glitch/theme.yml
+++ b/app/javascript/flavours/glitch/theme.yml
@@ -13,7 +13,6 @@ pack:
     filename: packs/home.js
     preload:
       - flavours/glitch/async/compose
-      - flavours/glitch/async/getting_started
       - flavours/glitch/async/home_timeline
       - flavours/glitch/async/notifications
   mailer:

--- a/app/javascript/flavours/vanilla/theme.yml
+++ b/app/javascript/flavours/vanilla/theme.yml
@@ -12,7 +12,6 @@ pack:
   home:
     filename: application.js
     preload:
-      - features/getting_started
       - features/compose
       - features/home_timeline
       - features/notifications

--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -1,15 +1,5 @@
 - content_for :header_tags do
   - if user_signed_in?
-    - if current_user.setting_flavour == 'vanilla' && Themes.instance.flavours.include?('vanilla')
-      = preload_pack_asset 'features/compose.js'
-      = preload_pack_asset 'features/home_timeline.js'
-      = preload_pack_asset 'features/notifications.js'
-    - else
-      -# haml-lint:disable InstanceVariables
-      = preload_pack_asset "flavours/#{@theme[:flavour]}/async/compose.js"
-      = preload_pack_asset "flavours/#{@theme[:flavour]}/async/home_timeline.js"
-      = preload_pack_asset "flavours/#{@theme[:flavour]}/async/notifications.js"
-      -# haml-lint:enable InstanceVariables
     %meta{ name: 'initialPath', content: request.path }
 
   %meta{ name: 'applicationServerKey', content: Rails.configuration.x.vapid_public_key }


### PR DESCRIPTION
Follow-up to #307

This preload is actually already handled by glitch-soc's theming system.

Basically the theming system preloads these and the view preloads them a second time conditionally.

Also this hardcoded paths, which isn't ideal.