### PR TITLE
Add integrity to theming system

### DIFF
--- a/app/views/layouts/_theme.html.haml
+++ b/app/views/layouts/_theme.html.haml
@@ -9,4 +9,4 @@
       - else
         = stylesheet_pack_tag "skins/#{theme[:flavour]}/#{theme[:skin]}/#{theme[:pack]}", media: 'all', crossorigin: 'anonymous'
     - theme[:preload]&.each do |link|
-      %link{ href: asset_pack_path("#{link}.js"), crossorigin: 'anonymous', rel: 'preload', as: 'script' }/
+      = preload_pack_asset "#{link}.js"


### PR DESCRIPTION
I'm not sure why this hasn't been done, but this now uses `preload_pack_asset` to add an integrity check for packs loaded by the theming system.