### PR TITLE
Fix typo in `notificationsUpdate` call and setting wrong meta

### DIFF
--- a/app/javascript/flavours/polyam/actions/notifications.js
+++ b/app/javascript/flavours/polyam/actions/notifications.js
@@ -109,7 +109,7 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
         dispatch(importFetchedAccount(notification.report.target_account));
       }
 
-      dispatch(notificationsUpdate({ notification, preferPendingItems, playsound: playSound && !filtered }));
+      dispatch(notificationsUpdate({ notification, preferPendingItems, playSound: playSound && !filtered }));
 
       fetchRelatedRelationships(dispatch, [notification]);
     } else if (playSound && !filtered) {

--- a/app/javascript/flavours/polyam/actions/notifications_typed.ts
+++ b/app/javascript/flavours/polyam/actions/notifications_typed.ts
@@ -18,6 +18,6 @@ export const notificationsUpdate = createAction(
     playSound: boolean;
   }) => ({
     payload: args,
-    meta: { playSound: playSound ? { sound: 'notificationSound' } : undefined },
+    meta: playSound ? { sound: 'notificationSound' } : undefined,
   }),
 );


### PR DESCRIPTION
Follow-up to #319 

The first one seems to be on me, the second was an upstream issue.

This fixes custom notification sounds not playing.