### PR TITLE
Remove size property in account note

### DIFF
--- a/app/javascript/flavours/polyam/features/account/components/account_note.tsx
+++ b/app/javascript/flavours/polyam/features/account/components/account_note.tsx
@@ -100,7 +100,6 @@ export const AccountNote: React.FC<{ account: Account }> = ({ account }) => {
         <IconButton
           icon='times'
           iconComponent={faTimes}
-          size={15}
           title=''
           label={intl.formatMessage(messages.cancel)}
           onClick={handleCancel}
@@ -110,7 +109,6 @@ export const AccountNote: React.FC<{ account: Account }> = ({ account }) => {
         <IconButton
           icon='check'
           iconComponent={faCheck}
-          size={15}
           title=''
           label={intl.formatMessage(messages.save)}
           onClick={handleSave}
@@ -124,7 +122,6 @@ export const AccountNote: React.FC<{ account: Account }> = ({ account }) => {
         <IconButton
           icon='pencil'
           iconComponent={faPencil}
-          size={15}
           title=''
           label={intl.formatMessage(messages.edit)}
           onClick={handleInitEdit}


### PR DESCRIPTION
Follow-up to #332 

I think this will also be the direction upstream is going, so remove instead of restore in IconButton