### PR TITLE
Revert "[Polyam] Feature - Prevents multiple audio/video attachments from being played at the same time"

### DIFF
--- a/app/javascript/flavours/polyam/features/audio/index.jsx
+++ b/app/javascript/flavours/polyam/features/audio/index.jsx
@@ -16,7 +16,6 @@ import { formatTime, getPointerPosition, fileNameFromURL } from 'flavours/polyam
 
 import { Blurhash } from '../../components/blurhash';
 import { displayMedia, useBlurhash } from '../../initial_state';
-import { currentMedia, setCurrentMedia } from '../../reducers/media_attachments';
 
 import Visualizer from './visualizer';
 
@@ -170,32 +169,15 @@ class Audio extends PureComponent {
   }
 
   togglePlay = () => {
-    const audios = document.querySelectorAll('audio');
-
-    audios.forEach((audio) => {
-      const button = audio.previousElementSibling;
-      button.addEventListener('click', () => {
-        if(audio.paused) {
-          audios.forEach((e) => {
-            if (e !== audio) {
-              e.pause();
-            }
-          });
-          audio.play();
-          this.setState({ paused: false });
-        } else {
-          audio.pause();
-          this.setState({ paused: true });
-        }
-      });
-    });
-
-    if (currentMedia !== null) {
-      currentMedia.pause();
+    if (!this.audioContext) {
+      this._initAudioContext();
     }
 
-    this.audio.play();
-    setCurrentMedia(this.audio);
+    if (this.state.paused) {
+      this.setState({ paused: false }, () => this.audio.play());
+    } else {
+      this.setState({ paused: true }, () => this.audio.pause());
+    }
   };
 
   handleResize = debounce(() => {
@@ -217,7 +199,6 @@ class Audio extends PureComponent {
   };
 
   handlePause = () => {
-    this.audio.pause();
     this.setState({ paused: true });
 
     if (this.audioContext) {

--- a/app/javascript/flavours/polyam/features/video/index.jsx
+++ b/app/javascript/flavours/polyam/features/video/index.jsx
@@ -16,7 +16,6 @@ import { Icon }  from 'flavours/polyam/components/icon';
 import { playerSettings } from 'flavours/polyam/settings';
 
 import { displayMedia, useBlurhash } from '../../initial_state';
-import { currentMedia, setCurrentMedia } from '../../reducers/media_attachments';
 import { isFullscreen, requestFullscreen, exitFullscreen } from '../ui/util/fullscreen';
 
 const messages = defineMessages({
@@ -182,7 +181,6 @@ class Video extends PureComponent {
   };
 
   handlePause = () => {
-    this.video.pause();
     this.setState({ paused: true });
   };
 
@@ -346,32 +344,11 @@ class Video extends PureComponent {
   };
 
   togglePlay = () => {
-    const videos = document.querySelectorAll('video');
-
-    videos.forEach((video) => {
-      const button = video.nextElementSibling;
-      button.addEventListener('click', () => {
-        if (video.paused) {
-          videos.forEach((e) => {
-            if (e !== video) {
-              e.pause();
-            }
-          });
-          video.play();
-          this.setState({ paused: false });
-        } else {
-          video.pause();
-          this.setState({ paused: true });
-        }
-      });
-    });
-
-    if (currentMedia !== null) {
-      currentMedia.pause();
+    if (this.state.paused) {
+      this.setState({ paused: false }, () => this.video.play());
+    } else {
+      this.setState({ paused: true }, () => this.video.pause());
     }
-
-    this.video.play();
-    setCurrentMedia(this.video);
   };
 
   toggleFullscreen = () => {

--- a/app/javascript/flavours/polyam/reducers/media_attachments.js
+++ b/app/javascript/flavours/polyam/reducers/media_attachments.js
@@ -2,12 +2,6 @@ import { Map as ImmutableMap } from 'immutable';
 
 import { STORE_HYDRATE } from '../actions/store';
 
-export let currentMedia = null;
-
-export function setCurrentMedia(value) {
-  currentMedia = value;
-}
-
 const initialState = ImmutableMap({
   accept_content_types: [],
 });


### PR DESCRIPTION
This reverts commit 885fd9b7ef6984d726724d55265557997d0e9d92.

This prevented volume change from working on audio attachments.
I could probably fix that or wait for upstream to fix, but not worth it for a change I was reluctant to port anyway.
This might be added back once the issue is fixed upstream.