### PR TITLE
Remove admin override for show application

### DIFF
--- a/app/lib/settings/scoped_settings.rb
+++ b/app/lib/settings/scoped_settings.rb
@@ -6,7 +6,6 @@ module Settings
       flavour
       skin
       noindex
-      show_application
       norss
     ).freeze
 

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -35,7 +35,6 @@ class Form::AdminSettings
     trendable_by_default
     trending_status_cw
     trending_status_sensitive
-    show_application
     show_domain_blocks
     show_domain_blocks_rationale
     noindex
@@ -67,7 +66,6 @@ class Form::AdminSettings
     preview_sensitive_media
     profile_directory
     hide_followers_count
-    show_application
     show_reblogs_in_public_timelines
     show_replies_in_public_timelines
     trends

--- a/app/views/admin/settings/other/show.html.haml
+++ b/app/views/admin/settings/other/show.html.haml
@@ -20,9 +20,6 @@
     = f.input :show_replies_in_public_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_replies_in_public_timelines.title'), hint: t('admin.settings.show_replies_in_public_timelines.desc_html'), glitch_only: true
 
   .fields-group
-    = f.input :show_application, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_show_application.title'), hint: t('admin.settings.default_show_application.desc_html'), polyam_only: true
-
-  .fields-group
     = f.input :outgoing_spoilers, wrapper: :with_label, label: t('admin.settings.outgoing_spoilers.title'), hint: t('admin.settings.outgoing_spoilers.desc_html'), glitch_only: true
 
   .actions

--- a/config/locales-glitch/de.yml
+++ b/config/locales-glitch/de.yml
@@ -8,9 +8,6 @@ de:
       captcha_enabled:
         desc_html: Dies beruht auf externen Skripts von hCaptcha, was Sicherheits- und Datenschutz-Bedenken auslösen kann. Zusätzlich <strong>kann das den Registrierungsprozess für manche (besonders behinderte) Leute signifikant weniger zugänglich machen</strong>. Ziehe aus diesen Gründen bittte alternative Maßnahmen, wie Zulassungs- oder Einladungs-basierte Registrierung, in Erwägung.
         title: Neue Nutzer sollen ein CAPTCHA lösen müssen, um ihr Konto zu bestätigen
-      default_show_application:
-        desc_html: Beeinflusst alle Nutzer*innen, die diese Einstellung nicht selbst geändert haben.
-        title: Anwendung, die zum erstellen von Beiträgen genutzt wird, anzeigen
       flavour_and_skin:
         title: Variante und Skin
       hide_followers_count:

--- a/config/locales-polyam/en.yml
+++ b/config/locales-polyam/en.yml
@@ -55,9 +55,6 @@ en:
       default_norss:
         desc_html: Affects all users who have not changed this setting themselves
         title: Opt users out of having an RSS feed of their public toots by default
-      default_show_application:
-        desc_html: Affects all users who have not changed this setting themselves
-        title: Disclose application used to send toots
       discovery:
         rss: RSS
         search: Search


### PR DESCRIPTION
Partially reverts #9 

I thought I already removed it. Oops.

When I implemented this, I thought upstream forgot about this setting.
I have since seen some people argue it should be up to users to decide whether they show their application and I agree.