### PR TITLE
Merge upstream changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
       rdoc
       reline (>= 0.3.8)
     jmespath (1.6.2)
-    json (2.6.3)
+    json (2.7.0)
     json-canonicalization (1.0.0)
     json-jwt (1.15.3)
       activesupport (>= 4.2)


### PR DESCRIPTION
aka fix polyam-glitch being uninstallable because of yanked gem
Thought this was already included in latest vanilla merge :/

Conflicts:
- `Gemfile.lock`
Upstream updated a dependency, but others were ahead.
Updated dependencies upstream did

Additional changes:
- b6ee987ea799b4da4e955a04b900492e6c1c4817