### PR TITLE
Add env var to disable skins

### DIFF
--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -6,6 +6,8 @@ require 'yaml'
 class Themes
   include Singleton
 
+  DISABLED_THEMES = ENV.fetch('DISABLED_SKINS', '').split(/\s*,\s*/)
+
   def initialize
     core = YAML.load_file(Rails.root.join('app', 'javascript', 'core', 'theme.yml'))
     core['pack'] = {} unless core['pack']
@@ -50,6 +52,8 @@ class Themes
       skin = pathname.basename.to_s
       name = pathname.dirname.basename.to_s
       next unless result[name]
+
+      next if skin != 'default' && DISABLED_THEMES.include?(skin)
 
       if pathname.directory?
         pack = []

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -13,6 +13,8 @@ const flavourFiles = glob.sync('app/javascript/flavours/*/theme.yml');
 const skinFiles = glob.sync('app/javascript/skins/*/*');
 const flavours = {};
 
+const disabled_skins = (env.DISABLED_SKINS || '').split(/\s*,\s*/);
+
 const core = function () {
   const coreFile = resolve('app', 'javascript', 'core', 'theme.yml');
   const data = load(readFileSync(coreFile), 'utf8');
@@ -42,6 +44,10 @@ flavourFiles.forEach((flavourFile) => {
 skinFiles.forEach((skinFile) => {
   let skin = basename(skinFile);
   const name = basename(dirname(skinFile));
+  // Skip skin if disabled
+  if (disabled_skins && skin !== 'default' && disabled_skins.includes(skin)) {
+    return;
+  }
   if (!flavours[name]) {
     return;
   }


### PR DESCRIPTION
Fixes #340 

This, like `ENABLE_VANILLA` and `RAILS_ENV` is used before loading `.env` file
Though it can be used in an env file, it would still compile assets of disabled skins needlessly.
Default skin cannot be disabled as it is used as a fallback.

Example:
`DISABLED_SKINS="oatstodon,fairy-floss"`