### PR TITLE
Replace locale strings containing "applies to Glitch flavour only"

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -34,7 +34,7 @@
       = ff.input :'web.reduce_motion', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_reduce_motion')
       = ff.input :'web.disable_swiping', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_disable_swiping')
       = ff.input :'web.use_system_font', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_system_font_ui')
-      = ff.input :'web.use_system_emoji_font', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_system_emoji_font'), glitch_only: true
+      = ff.input :'web.use_system_emoji_font', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_polyam_system_emoji_font'), glitch_only: true
 
     %h4= t 'appearance.toot_layout'
 
@@ -51,7 +51,7 @@
     .fields-group
       = ff.input :'web.unfollow_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_unfollow_modal')
       = ff.input :'web.reblog_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
-      = ff.input :'web.favourite_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_favourite_modal'), glitch_only: true
+      = ff.input :'web.favourite_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_polyam_favourite_modal'), glitch_only: true
       = ff.input :'web.delete_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_delete_modal')
 
     %h4= t 'appearance.sensitive_content'

--- a/config/locales-polyam/simple_form.en.yml
+++ b/config/locales-polyam/simple_form.en.yml
@@ -12,7 +12,9 @@ en:
     labels:
       defaults:
         setting_enable_rss: Enable RSS feed for your public toots
+        setting_polyam_favourite_modal: Show confirmation dialog before favouriting
         setting_notification_sound: Notification Sound
+        setting_polyam_system_emoji_font: Use system's default font for emojis
         setting_visible_reactions: Number of visible emoji reactions
       form_admin_settings:
         publish_button_text: Publish button text


### PR DESCRIPTION
Fixes #338 

This has been misleading as these settings also apply to the polyam flavour.

I don't really have the confidence this would be changed upstream right now :/

Thinking about adding another string with the parentheses content, which is shown conditionally when the vanilla flavour is enabled, but this would likely just push the issue downstream should someone decide to fork this project.