### PR TITLE
Fix empty directories count as selectable themes

### DIFF
--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -65,7 +65,7 @@ class Themes
         pack = ['common']
       end
 
-      result[name]['skin'][skin] = pack if skin != 'default'
+      result[name]['skin'][skin] = pack if !pack.empty? && skin != 'default'
     end
 
     @core = core


### PR DESCRIPTION
When adding a directory in one of the skins directories, it is immediately selectable as a skin even when there are no files.

When creating a theme at least one (S)CSS is required though.

This skips the skin if there is no file.