### PR TITLE
Fix policy display for domain blocks with none severity

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -41,7 +41,7 @@ class DomainBlock < ApplicationRecord
     if suspend?
       [:suspend]
     else
-      [severity.to_sym, reject_media? ? :reject_media : nil, reject_reports? ? :reject_reports : nil].reject { |policy| policy == :noop || policy.nil? }
+      [severity.to_sym, reject_media? ? :reject_media : nil, reject_reports? ? :reject_reports : nil].compact
     end
   end
 

--- a/app/views/admin/export_domain_blocks/_domain_block.html.haml
+++ b/app/views/admin/export_domain_blocks/_domain_block.html.haml
@@ -17,7 +17,7 @@
 
       %br/
 
-      = f.object.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
+      = f.object.policies.filter_map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') if policy != :noop }.join(' · ')
       - if f.object.public_comment.present?
         ·
         = f.object.public_comment

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -59,7 +59,7 @@
             %td= @instance.domain_block.public_comment
           %tr
             %th= t('admin.instances.content_policies.policy')
-            %td= @instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
+            %td= @instance.domain_block.policies.filter_map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') if policy != :noop }.join(' · ')
 
     = link_to t('admin.domain_blocks.edit'), edit_admin_domain_block_path(@instance.domain_block), class: 'button'
     = link_to t('admin.domain_blocks.undo'), admin_domain_block_path(@instance.domain_block), class: 'button', data: { confirm: t('admin.accounts.are_you_sure'), method: :delete }

--- a/config/locales-polyam/en.yml
+++ b/config/locales-polyam/en.yml
@@ -14,6 +14,10 @@ en:
       category_hint: Optional. Assign the emoji to a category.
       visible_in_picker: Show in emoji picker
       visible_in_picker_hint: Makes this emoji available in the emoji picker and API.
+    instances:
+      content_policies:
+        policies:
+          noop: None
     registration_filters:
       add_new: Add new filter
       created_msg: Registration text filter successfully created!


### PR DESCRIPTION
`noop` is filtered from policies, so instead of showing policies in the admin interface it is non-existent for domain blocks with the "None" severity.

This displays "None" instead