### PR TITLE
Fix domain export when only rejecting reports

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -30,7 +30,7 @@ class DomainBlock < ApplicationRecord
 
   scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
   scope :with_user_facing_limitations, -> { where(severity: [:silence, :suspend]) }
-  scope :with_limitations, -> { where(severity: [:silence, :suspend]).or(where(reject_media: true)) }
+  scope :with_limitations, -> { where(severity: [:silence, :suspend]).or(where(reject_media: true)).or(where(reject_reports: true)) }
   scope :by_severity, -> { order(Arel.sql('(CASE severity WHEN 0 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 0 END), domain')) }
 
   def to_log_human_identifier


### PR DESCRIPTION
Domain blocks are exported when severity is silence or suspend, or when rejecting media.

This also exports domain blocks with noop when reject_reports policy is enabled.

I'm not sure why this was fixed for rejecting media, but not rejecting reports. 