### PR TITLE
Fix background color of modifier wrapper

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -25,7 +25,6 @@ body {
 .compose-form__buttons-wrapper,
 .compose-form__warning,
 .spoiler-input input,
-.compose-form__modifiers,
 .reply-indicator {
   background: $ui-base-semi-lighter-color;
   color: $primary-text-color;


### PR DESCRIPTION
The refactor of the compose form doesn't hide this element anymore and it had a different color, which made it look like the buttons area was bigger than it is.

Before:
![Too big](https://github.com/polyamspace/mastodon/assets/117664621/6b3fee3b-13e5-43e2-990d-1f0106a5b4e5)

After:
![More reasonable](https://github.com/polyamspace/mastodon/assets/117664621/b90b6441-8b86-4c36-98b1-bf395694d55c)
