### PR TITLE
Fix spoiler button background in report modal in homogay

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -219,6 +219,14 @@ body {
   }
 }
 
+.report-dialog-modal .status__content__spoiler-link {
+  background-color: lighten($ui-base-color, 30%);
+
+  &:hover {
+    background: lighten($ui-base-color, 33%);
+  }
+}
+
 // app settings modal
 .glitch.local-settings {
   background: $ui-base-color;


### PR DESCRIPTION
It was "light themed" which doesn't work.