### PR TITLE
Fix background color of modifier wrapper (again)

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -25,6 +25,7 @@ body {
 .compose-form__buttons-wrapper,
 .compose-form__warning,
 .spoiler-input input,
+.compose-panel .compose-form__modifiers,
 .reply-indicator {
   background: $ui-base-semi-lighter-color;
   color: $primary-text-color;


### PR DESCRIPTION
Follow-up to #363 

The background color of the element was wrong in simple UI instead of advanced UI.

This fixes the wrong color for both.