### PR TITLE
Fix media icons in CWs

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -139,8 +139,9 @@
   color: $dark-text-color;
 }
 
+// Extra attributes: align-items and width, height in spoiler-icon
 .status__content__spoiler-link {
-  display: inline-block;
+  display: inline-flex;
   border-radius: 2px;
   background: lighten($ui-base-color, 30%);
   border: 0;
@@ -152,6 +153,7 @@
   line-height: inherit;
   cursor: pointer;
   vertical-align: top;
+  align-items: center;
 
   &:hover {
     background: lighten($ui-base-color, 33%);
@@ -164,7 +166,6 @@
     border-inline-start: 1px solid currentColor;
     padding: 0;
     padding-inline-start: 4px;
-    vertical-align: text-top;
     width: 16px;
     height: 16px;
   }


### PR DESCRIPTION
Fixes alignment of media icons in CW button by adding `align-items` attribute.