### PR TITLE
Fix background of disabled vote button in polls in homogay theme

### DIFF
--- a/app/javascript/flavours/glitch/styles/homogay/diff.scss
+++ b/app/javascript/flavours/glitch/styles/homogay/diff.scss
@@ -19,6 +19,15 @@ body {
   color: $highlight-text-color;
 }
 
+// Fix background of disabled vote button
+.poll__footer {
+  button {
+    &:disabled {
+      background-color: transparent;
+    }
+  }
+}
+
 // compose panel
 .compose-panel .autosuggest-textarea label .autosuggest-textarea__textarea,
 .compose-form .autosuggest-input label .autosuggest-textarea__textarea,

--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -19,6 +19,15 @@ body {
   color: $highlight-text-color;
 }
 
+// Fix background of disabled vote button
+.poll__footer {
+  button {
+    &:disabled {
+      background-color: transparent;
+    }
+  }
+}
+
 // compose panel
 .compose-panel .autosuggest-textarea label .autosuggest-textarea__textarea,
 .compose-form .autosuggest-input label .autosuggest-textarea__textarea,


### PR DESCRIPTION
Sets the background to transparent, like default.

Not the best design, but better than current.

Before:
![Background color makes text unreadable](https://github.com/polyamspace/mastodon/assets/117664621/30fab4c3-5a14-4c5b-b2da-5bab36f7ead2)

After:
![Background is transparent, therefore text more readable](https://github.com/polyamspace/mastodon/assets/117664621/f45a5320-5632-45f8-9a63-0d8d106cb8aa)

