### PR TITLE
Fix size of media spoiler button

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/misc.scss
+++ b/app/javascript/flavours/polyam/styles/components/misc.scss
@@ -252,6 +252,7 @@
     }
   }
 
+  // Polyam: Added width/height to match button size with upstream
   &.overlayed {
     box-sizing: content-box;
     background: rgba($black, 0.65);
@@ -259,6 +260,8 @@
     color: rgba($white, 0.7);
     border-radius: 4px;
     padding: 2px;
+    width: 24px;
+    height: 24px;
 
     &:hover {
       background: rgba($black, 0.9);


### PR DESCRIPTION
Match size with upstream while not making icon comically large.
The icon itself still appears smaller than before the icon change, but that's because the eye was shrunk down.