### PR TITLE
Remove unnecessary return in `UnreactService`

### DIFF
--- a/app/services/unreact_service.rb
+++ b/app/services/unreact_service.rb
@@ -6,9 +6,7 @@ class UnreactService < BaseService
   def call(account, status, emoji)
     name, domain = emoji.split('@')
     custom_emoji = CustomEmoji.find_by(shortcode: name, domain: domain)
-    reaction = StatusReaction.find_by(account: account, status: status, name: name, custom_emoji: custom_emoji)
-    return if reaction.nil?
-
+    reaction = StatusReaction.find_by!(account: account, status: status, name: name, custom_emoji: custom_emoji)
     reaction.destroy!
     create_notification(reaction) if !status.account.local? && status.account.activitypub?
     reaction


### PR DESCRIPTION
A non-existent reaction should already be covered by rescuing RecordNotFound.