### PR TITLE
Fix `reactions_count` not being updated on unreact

### DIFF
--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -94,6 +94,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
     relationships&.attributes_map&.dig(object.id, :favourites_count) || object.favourites_count
   end
 
+  def reactions_count
+    relationships&.attributes_map&.dig(object.id, :reactions_count) || object.reactions_count
+  end
+
   def favourited
     if relationships
       relationships.favourites_map[object.id] || false


### PR DESCRIPTION
Applies the count in response fix of 4c18928a931c8dc149fa3e0bd7de8ce4f6242715 to reactions