### PR TITLE
Fix white corners in simple UI textarea in FairyFloss

### DIFF
--- a/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
+++ b/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
@@ -262,6 +262,13 @@ button.icon-button {
 
 // Compose
 
+// Fix white corners in compose textarea in simple UI
+.compose-panel {
+  .compose-form__autosuggest-wrapper {
+    background-color: transparent;
+  }
+}
+
 .compose-form {
   // Bar below textarea
   &__buttons-wrapper {

--- a/app/javascript/flavours/polyam/styles/fairy-floss/diff.scss
+++ b/app/javascript/flavours/polyam/styles/fairy-floss/diff.scss
@@ -262,6 +262,13 @@ button.icon-button {
 
 // Compose
 
+// Fix white corners in compose textarea in simple UI
+.compose-panel {
+  .compose-form__autosuggest-wrapper {
+    background-color: transparent;
+  }
+}
+
 .compose-form {
   // Bar below textarea
   &__buttons-wrapper {


### PR DESCRIPTION
Fixes white corners in textarea of compose panel by making the background of the wrapper transparent