### PR TITLE
Fix wrong class being used for alt-button in gallery

### DIFF
--- a/app/javascript/flavours/glitch/features/account_gallery/components/media_item.jsx
+++ b/app/javascript/flavours/glitch/features/account_gallery/components/media_item.jsx
@@ -82,7 +82,7 @@ export default class MediaItem extends ImmutablePureComponent {
     const title  = status.get('spoiler_text') || attachment.get('description');
 
     let thumbnail, label, icon, content;
-    let altButton = (<button type='button' className='media-gallery__alt__button' onClick={this.handleAltClick}><span>ALT</span></button>);
+    let altButton = (<button type='button' className='media-gallery__alt__label' onClick={this.handleAltClick}><span>ALT</span></button>);
 
     if (!visible) {
       icon = (

--- a/app/javascript/flavours/polyam/features/account_gallery/components/media_item.jsx
+++ b/app/javascript/flavours/polyam/features/account_gallery/components/media_item.jsx
@@ -81,7 +81,7 @@ export default class MediaItem extends ImmutablePureComponent {
     const title  = status.get('spoiler_text') || attachment.get('description');
 
     let thumbnail, label, icon, content;
-    let altButton = (<button type='button' className='media-gallery__alt__button' onClick={this.handleAltClick}><span>ALT</span></button>);
+    let altButton = (<button type='button' className='media-gallery__alt__label' onClick={this.handleAltClick}><span>ALT</span></button>);
 
     if (!visible) {
       icon = (


### PR DESCRIPTION
The class changed from `media-gallery__alt__button` to `media-gallery__alt__label` since upstream implemented an alt label.