### PR TITLE
Show profile fields above bio again

### DIFF
--- a/app/javascript/flavours/polyam/features/account/components/header.jsx
+++ b/app/javascript/flavours/polyam/features/account/components/header.jsx
@@ -381,8 +381,6 @@ class Header extends ImmutablePureComponent {
               <div className='account__header__bio'>
                 {(account.get('id') !== me && signedIn) && <AccountNoteContainer account={account} />}
 
-                {account.get('note').length > 0 && account.get('note') !== '<p></p>' && <div className='account__header__content translate' dangerouslySetInnerHTML={content} />}
-
                 {fields.size > 0 && (
                   <div className='account__header__fields'>
                     {fields.map((pair, i) => (
@@ -396,6 +394,9 @@ class Header extends ImmutablePureComponent {
                     ))}
                   </div>
                 )}
+
+                {/* Polyam: Show note after fields as fields are visually distracting */}
+                {account.get('note').length > 0 && account.get('note') !== '<p></p>' && <div className='account__header__content translate' dangerouslySetInnerHTML={content} />}
 
                 <div className='account__header__joined'><FormattedMessage id='account.joined' defaultMessage='Joined {date}' values={{ date: intl.formatDate(account.get('created_at'), { year: 'numeric', month: 'short', day: '2-digit' }) }} /></div>
               </div>

--- a/app/javascript/flavours/polyam/styles/components/accounts.scss
+++ b/app/javascript/flavours/polyam/styles/components/accounts.scss
@@ -435,6 +435,7 @@ a .account__avatar {
   overflow: hidden;
   word-break: normal;
   word-wrap: break-word;
+  margin-top: 16px; // Polyam: Note is shown after fields
 
   p {
     margin-bottom: 20px;
@@ -614,7 +615,8 @@ a .account__avatar {
 
     .account__header__fields {
       margin: 0;
-      margin-top: 16px;
+
+      // Polyam: margin-top: 16px; removed as margin to note was too large
       border-radius: 4px;
       background: darken($ui-base-color, 4%);
       border: 0;


### PR DESCRIPTION
Fixes #431 

Profile fields are visually appealing, which results in the text being skipped.

Shows them above bio again as was the case before.