### PR TITLE
Remove `max-height` `overflow` and `white-space` from account fields

### DIFF
--- a/app/javascript/flavours/polyam/styles/accounts.scss
+++ b/app/javascript/flavours/polyam/styles/accounts.scss
@@ -298,9 +298,11 @@
     box-sizing: border-box;
     padding: 14px;
     text-align: center;
-    max-height: 48px;
-    overflow: hidden;
-    white-space: nowrap;
+
+    // Polyam: Disable these as they make long field text unreadable
+    // max-height: 48px;
+    // overflow: hidden;
+    // white-space: nowrap;
     text-overflow: ellipsis;
   }
 


### PR DESCRIPTION
Upstream has this really annoying tendency to make long texts unreadable. And while fields are intended to be short information, some designs allow for more, so display them properly.