### PR TITLE
Remove border-radius from spoiler-input

### DIFF
--- a/app/javascript/flavours/glitch/styles/homogay/diff.scss
+++ b/app/javascript/flavours/glitch/styles/homogay/diff.scss
@@ -237,7 +237,6 @@ body {
 .dropdown-menu,
 .account__avatar,
 .search__input,
-.spoiler-input input,
 .status-card,
 .language-dropdown__dropdown,
 .privacy-dropdown__dropdown,

--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -237,7 +237,6 @@ body {
 .dropdown-menu,
 .account__avatar,
 .search__input,
-.spoiler-input input,
 .status-card,
 .language-dropdown__dropdown,
 .privacy-dropdown__dropdown,


### PR DESCRIPTION
This was a leftover from the old compose design.