### PR TITLE
Remove warning stripes around CW input

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/compose_form.scss
+++ b/app/javascript/flavours/polyam/styles/components/compose_form.scss
@@ -183,7 +183,8 @@
     align-items: stretch;
 
     &__border {
-      background: url('~images/warning-stripes.svg') repeat-y;
+      // Polyam: Don't show stripes. Keep same as input
+      background: mix($ui-base-color, $ui-highlight-color, 85%);
       width: 5px;
       flex: 0 0 auto;
 


### PR DESCRIPTION
It looks better without these and quite frankly, I think they were a bad idea and discourage usage of CWs.

Before:
![Screenshot of spoiler input with stripes left and right](https://github.com/polyamspace/mastodon/assets/117664621/cc8638a2-bd6c-4eec-863c-772037408646)

After:
![Screenshot of spoiler input without stripes](https://github.com/polyamspace/mastodon/assets/117664621/889d1336-c8aa-4223-a015-b697b5e4675f)
