### PR TITLE
Create mixins for component SCSS

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/_mixins.scss
+++ b/app/javascript/flavours/polyam/styles/components/_mixins.scss
@@ -119,3 +119,9 @@
     text-decoration: underline;
   }
 }
+
+// Mixin for upstream's .column, .drawer class
+@mixin column-drawer() {
+  flex: 1 1 100%;
+  overflow: hidden;
+}

--- a/app/javascript/flavours/polyam/styles/components/_mixins.scss
+++ b/app/javascript/flavours/polyam/styles/components/_mixins.scss
@@ -131,3 +131,66 @@
   flex: 1 1 auto;
   text-align: center;
 }
+
+// Mixin for upstream's .notification__filter-bar, .account__section-headline
+@mixin filter-bar() {
+  // deliberate glitch-soc choice for now
+  background: darken($ui-base-color, 4%);
+  border-bottom: 1px solid lighten($ui-base-color, 8%);
+  cursor: default;
+  display: flex;
+  flex-shrink: 0;
+
+  button {
+    background: transparent;
+    border: 0;
+    margin: 0;
+  }
+
+  button,
+  a {
+    display: block;
+    flex: 1 1 auto;
+    color: $darker-text-color;
+    padding: 15px 0;
+    font-size: 14px;
+    font-weight: 500;
+    text-align: center;
+    text-decoration: none;
+    position: relative;
+
+    &.active {
+      color: $primary-text-color;
+
+      &::before {
+        display: block;
+        content: '';
+        position: absolute;
+        bottom: -1px;
+        left: 0;
+        width: 100%;
+        height: 3px;
+        border-radius: 4px;
+        background: $highlight-text-color;
+      }
+    }
+  }
+}
+
+// Mixin for upstream's .notification, .status__wrapper
+@mixin notification-status-wrapper {
+  position: relative;
+
+  &.unread {
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      inset-inline-start: 0;
+      width: 100%;
+      height: 100%;
+      border-inline-start: 4px solid $highlight-text-color;
+      pointer-events: none;
+    }
+  }
+}

--- a/app/javascript/flavours/polyam/styles/components/_mixins.scss
+++ b/app/javascript/flavours/polyam/styles/components/_mixins.scss
@@ -94,3 +94,28 @@
     }
   }
 }
+
+// Mixin for upstream's .status__display-name,
+// .status__relative-time,
+// .detailed-status__display-name,
+// .detailed-status__datetime,
+// .detailed-status__application,
+// .account__display-name
+// class
+@mixin no-text-decoration() {
+  text-decoration: none;
+}
+
+// Mixin for upstream's .status__display-name, .account__display-name class
+@mixin display-name-primary-color() {
+  .display-name strong {
+    color: $primary-text-color;
+  }
+}
+
+// Mixin for upstream's .status__display-name, .detailed-status__display-name. a.account__display-name class
+@mixin underline-display-name-on-hover() {
+  &:hover .display-name strong {
+    text-decoration: underline;
+  }
+}

--- a/app/javascript/flavours/polyam/styles/components/_mixins.scss
+++ b/app/javascript/flavours/polyam/styles/components/_mixins.scss
@@ -125,3 +125,9 @@
   flex: 1 1 100%;
   overflow: hidden;
 }
+
+// Mixin for upstream's .account--panel__button, .detailed-status__button
+@mixin panel-button() {
+  flex: 1 1 auto;
+  text-align: center;
+}

--- a/app/javascript/flavours/polyam/styles/components/_mixins.scss
+++ b/app/javascript/flavours/polyam/styles/components/_mixins.scss
@@ -1,0 +1,96 @@
+// Upstream has a nasty habit to override its own style.
+// Due to different structure and load order of CSS,
+// this sometimes causes overrides to not apply correctly
+// and makes it necessary to put overrides in files where they don't belong
+// or split classes anyway and apply changes to all of them.
+
+// Mixin for upstream's .status__content, .edit-indicator__content, .reply-indicator__content class
+@mixin status-content() {
+  position: relative;
+  word-wrap: break-word;
+  font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 15px;
+  line-height: 20px;
+  padding-top: 2px;
+  color: $primary-text-color;
+
+  &:focus {
+    outline: 0;
+  }
+
+  .emojione {
+    width: 20px;
+    height: 20px;
+    margin: -3px 0 0;
+  }
+
+  p,
+  pre {
+    margin-bottom: 20px;
+    white-space: pre-wrap;
+    unicode-bidi: plaintext;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  a {
+    color: $secondary-text-color;
+    text-decoration: none;
+    unicode-bidi: isolate;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &.mention {
+      &:hover {
+        text-decoration: none;
+
+        span {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+
+  a.unhandled-link {
+    color: $highlight-text-color;
+
+    .link-origin-tag {
+      color: $gold-star;
+      font-size: 0.8em;
+    }
+  }
+
+  .status__content__spoiler-link {
+    background: $action-button-color;
+
+    &:hover,
+    &:focus {
+      background: lighten($action-button-color, 7%);
+      text-decoration: none;
+    }
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
+
+    &::-moz-focus-inner,
+    &:focus,
+    &:active {
+      outline: 0 !important;
+    }
+  }
+
+  .status__content__spoiler {
+    display: none;
+
+    &.status__content__spoiler--visible {
+      display: block;
+    }
+  }
+}

--- a/app/javascript/flavours/polyam/styles/components/accounts.scss
+++ b/app/javascript/flavours/polyam/styles/components/accounts.scss
@@ -356,49 +356,9 @@ a.account__display-name {
   }
 }
 
-.notification__filter-bar,
+// Polyam: Split from .notification__filter-bar, .account__section-headline
 .account__section-headline {
-  // deliberate glitch-soc choice for now
-  background: darken($ui-base-color, 4%);
-  border-bottom: 1px solid lighten($ui-base-color, 8%);
-  cursor: default;
-  display: flex;
-  flex-shrink: 0;
-
-  button {
-    background: transparent;
-    border: 0;
-    margin: 0;
-  }
-
-  button,
-  a {
-    display: block;
-    flex: 1 1 auto;
-    color: $darker-text-color;
-    padding: 15px 0;
-    font-size: 14px;
-    font-weight: 500;
-    text-align: center;
-    text-decoration: none;
-    position: relative;
-
-    &.active {
-      color: $primary-text-color;
-
-      &::before {
-        display: block;
-        content: '';
-        position: absolute;
-        bottom: -1px;
-        left: 0;
-        width: 100%;
-        height: 3px;
-        border-radius: 4px;
-        background: $highlight-text-color;
-      }
-    }
-  }
+  @include filter-bar;
 }
 
 .moved-account-banner,

--- a/app/javascript/flavours/polyam/styles/components/accounts.scss
+++ b/app/javascript/flavours/polyam/styles/components/accounts.scss
@@ -229,10 +229,9 @@ a.account__display-name {
   padding: 10px 0;
 }
 
-.account--panel__button,
-.detailed-status__button {
-  flex: 1 1 auto;
-  text-align: center;
+// Polyam: Split from .account--panel__button, .detailed-status__button
+.account--panel__button {
+  @include panel-button;
 }
 
 .relationship-tag {

--- a/app/javascript/flavours/polyam/styles/components/accounts.scss
+++ b/app/javascript/flavours/polyam/styles/components/accounts.scss
@@ -184,6 +184,21 @@ a .account__avatar {
   margin-inline-end: 10px;
 }
 
+// Polyam: Split from .status__display-name, .status__relative-time, .detailed-statuse__display-name etc. class
+.account__display-name {
+  @include no-text-decoration;
+}
+
+// Polyam: Split from .status__display-name, .acocunt__display-name class
+.account__display-name {
+  @include display-name-primary-color;
+}
+
+// Polyam: Split from .status__display-name, .detailed-status__display-name, a.account__display-name
+a.account__display-name {
+  @include underline-display-name-on-hover;
+}
+
 .account__display-name .display-name strong {
   display: block;
   overflow: hidden;

--- a/app/javascript/flavours/polyam/styles/components/columns.scss
+++ b/app/javascript/flavours/polyam/styles/components/columns.scss
@@ -161,10 +161,9 @@ $ui-header-height: 55px;
   height: 100%;
 }
 
-.column,
-.drawer {
-  flex: 1 1 100%;
-  overflow: hidden;
+// Polyam: Split from .column, .drawer
+.column {
+  @include column-drawer;
 }
 
 @media screen and (width >= 631px) {

--- a/app/javascript/flavours/polyam/styles/components/compose_form.scss
+++ b/app/javascript/flavours/polyam/styles/components/compose_form.scss
@@ -547,98 +547,10 @@
     opacity 0.4s ease;
 }
 
-// TODO: create mixin?
-// Polyam: Split out from .status__content, .reply-indicator__content upstream
-// Polyam: Changes here also need to be applied to status.scss
+// Polyam: Split out from .status__content, .edit-indicator__content, .reply-indicator__content upstream
 .edit-indicator__content,
 .reply-indicator__content {
-  position: relative;
-  word-wrap: break-word;
-  font-weight: 400;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 15px;
-  line-height: 20px;
-  padding-top: 2px;
-  color: $primary-text-color;
-
-  &:focus {
-    outline: 0;
-  }
-
-  .emojione {
-    width: 20px;
-    height: 20px;
-    margin: -3px 0 0;
-  }
-
-  p,
-  pre {
-    margin-bottom: 20px;
-    white-space: pre-wrap;
-    unicode-bidi: plaintext;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  a {
-    color: $secondary-text-color;
-    text-decoration: none;
-    unicode-bidi: isolate;
-
-    &:hover {
-      text-decoration: underline;
-    }
-
-    &.mention {
-      &:hover {
-        text-decoration: none;
-
-        span {
-          text-decoration: underline;
-        }
-      }
-    }
-  }
-
-  a.unhandled-link {
-    color: $highlight-text-color;
-
-    .link-origin-tag {
-      color: $gold-star;
-      font-size: 0.8em;
-    }
-  }
-
-  .status__content__spoiler-link {
-    background: $action-button-color;
-
-    &:hover,
-    &:focus {
-      background: lighten($action-button-color, 7%);
-      text-decoration: none;
-    }
-
-    &::-moz-focus-inner {
-      border: 0;
-    }
-
-    &::-moz-focus-inner,
-    &:focus,
-    &:active {
-      outline: 0 !important;
-    }
-  }
-
-  .status__content__spoiler {
-    display: none;
-
-    &.status__content__spoiler--visible {
-      display: block;
-    }
-  }
+  @include status-content;
 }
 
 .reply-indicator {

--- a/app/javascript/flavours/polyam/styles/components/drawer.scss
+++ b/app/javascript/flavours/polyam/styles/components/drawer.scss
@@ -64,6 +64,11 @@
   border-bottom: 2px solid transparent;
 }
 
+// Polyam: Split from .columns, .drawer
+.drawer {
+  @include column-drawer;
+}
+
 .drawer__pager {
   box-sizing: border-box;
   padding: 0;

--- a/app/javascript/flavours/polyam/styles/components/index.scss
+++ b/app/javascript/flavours/polyam/styles/components/index.scss
@@ -1,4 +1,5 @@
 @import 'animations';
+@import 'mixins';
 @import 'misc';
 @import 'buttons';
 @import 'dropdown';

--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -149,8 +149,14 @@
   }
 }
 
-// .notification__filter-bar, .account__section-headline (Moved to account.scss)
+// Polyam: Split from .notification__filter-bar, .account__section-headline
+.notification__filter-bar {
+  @include filter-bar;
+}
 
-// .notification, status (duplicate upstream, Merged with same class in status.scss)
+// Polyam: Split from .notification, .status__wrapper
+.notification {
+  @include notification-status-wrapper;
+}
 
 // .notifications-permission-banner (Moved to columns.scss)

--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -1035,22 +1035,9 @@ a.status-card {
   }
 }
 
-.notification,
+// Polyam: Split from .notifaction, .status__wrapper
 .status__wrapper {
-  position: relative;
-
-  &.unread {
-    &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      inset-inline-start: 0;
-      width: 100%;
-      height: 100%;
-      border-inline-start: 4px solid $highlight-text-color;
-      pointer-events: none;
-    }
-  }
+  @include notification-status-wrapper;
 }
 
 .picture-in-picture {

--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -619,20 +619,18 @@
   line-height: 18px;
 }
 
+// Polyam: Split from class also containing .account__display-name
 .status__display-name,
 .status__relative-time,
 .detailed-status__display-name,
 .detailed-status__datetime,
-.detailed-status__application,
-.account__display-name {
-  text-decoration: none;
+.detailed-status__application {
+  @include no-text-decoration;
 }
 
-.status__display-name,
-.account__display-name {
-  .display-name strong {
-    color: $primary-text-color;
-  }
+// Polyam: Split from class also containing .account__display-name
+.status__display-name {
+  @include display-name-primary-color;
 }
 
 .muted {
@@ -641,12 +639,10 @@
   }
 }
 
+// Polyam: Split from class also containing a.account__display-name
 .status__display-name,
-.detailed-status__display-name,
-a.account__display-name {
-  &:hover .display-name strong {
-    text-decoration: underline;
-  }
+.detailed-status__display-name {
+  @include underline-display-name-on-hover;
 }
 
 .detailed-status__application,

--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -6,96 +6,9 @@
   clear: both;
 }
 
-// Polyam: Split out from .status__content, .reply-indicator__content upstream
-// Polyam: Changes here also need to be applied to compose-form.scss
+// Polyam: Split out from .status__content, .edit-indicator__content, .reply-indicator__content upstream
 .status__content {
-  position: relative;
-  word-wrap: break-word;
-  font-weight: 400;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 15px;
-  line-height: 20px;
-  padding-top: 2px;
-  color: $primary-text-color;
-
-  &:focus {
-    outline: 0;
-  }
-
-  .emojione {
-    width: 20px;
-    height: 20px;
-    margin: -3px 0 0;
-  }
-
-  p,
-  pre {
-    margin-bottom: 20px;
-    white-space: pre-wrap;
-    unicode-bidi: plaintext;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  a {
-    color: $secondary-text-color;
-    text-decoration: none;
-    unicode-bidi: isolate;
-
-    &:hover {
-      text-decoration: underline;
-    }
-
-    &.mention {
-      &:hover {
-        text-decoration: none;
-
-        span {
-          text-decoration: underline;
-        }
-      }
-    }
-  }
-
-  a.unhandled-link {
-    color: $highlight-text-color;
-
-    .link-origin-tag {
-      color: $gold-star;
-      font-size: 0.8em;
-    }
-  }
-
-  .status__content__spoiler-link {
-    background: $action-button-color;
-
-    &:hover,
-    &:focus {
-      background: lighten($action-button-color, 7%);
-      text-decoration: none;
-    }
-
-    &::-moz-focus-inner {
-      border: 0;
-    }
-
-    &::-moz-focus-inner,
-    &:focus,
-    &:active {
-      outline: 0 !important;
-    }
-  }
-
-  .status__content__spoiler {
-    display: none;
-
-    &.status__content__spoiler--visible {
-      display: block;
-    }
-  }
+  @include status-content;
 }
 
 .status__content {

--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -962,6 +962,11 @@ a.status-card {
   width: 100%;
 }
 
+// Polyam: Split from .account--panel__button, .detailed-status__button
+.detailed-status__button {
+  @include panel-button;
+}
+
 .status__relative-time,
 .detailed-status__datetime {
   &:hover {


### PR DESCRIPTION
Upstream has a nasty habit of overriding its own style. Due to different structure and therefore load order, this sometimes causes overrides to not apply correctly and makes it necessary to put overrides in files where they don't belong or split classes and apply changes to all of them.

This creates a mixin file for component CSS to avoid duplication.