### PR TITLE
Fix search icon position

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/search.scss
+++ b/app/javascript/flavours/polyam/styles/components/search.scss
@@ -160,10 +160,6 @@
       pointer-events: auto;
       opacity: 1;
     }
-
-    @media screen and (min-width: $no-gap-breakpoint) {
-      inset-inline-start: 16px - 2px;
-    }
   }
 
   .icon-search {


### PR DESCRIPTION
Follow up to #456 

This removal was somehow not displayed in the diff.

Fixes:
![Search icon overlapses with placeholder text](https://github.com/polyamspace/mastodon/assets/117664621/5b871a51-9f29-4194-ba1f-55989343978a)
