### PR TITLE
Remove apps from new welcome email

### DIFF
--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -29,7 +29,6 @@
       = render 'application/mailer/checklist', key: 'follow_step', title: t('user_mailer.welcome.follow_title'), text: t('user_mailer.welcome.follow_step'), checked: @has_active_relationships, button_text: t('user_mailer.welcome.follow_action'), button_url: web_url('start/follows')
       = render 'application/mailer/checklist', key: 'post_step', title: t('user_mailer.welcome.post_title'), text: t('user_mailer.welcome.post_step'), checked: @has_statuses, button_text: t('user_mailer.welcome.post_action'), button_url: web_url
       = render 'application/mailer/checklist', key: 'share_step', title: t('user_mailer.welcome.share_title'), text: t('user_mailer.welcome.share_step'), checked: false, button_text: t('user_mailer.welcome.share_action'), button_url: web_url('start/share')
-      = render 'application/mailer/checklist', key: 'apps_step', title: t('user_mailer.welcome.apps_title'), text: t('user_mailer.welcome.apps_step'), checked: false, show_apps_buttons: true
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-columns-td

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -28,11 +28,6 @@
    <%= t('user_mailer.welcome.share_step') %>
    * <%= web_url('start/share') %>
 
-5. <%= t('user_mailer.welcome.apps_title') %>
-   <%= t('user_mailer.welcome.apps_step') %>
-   * iOS: https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974
-   * Android: https://play.google.com/store/apps/details?id=org.joinmastodon.android
-
 ---
 
 <%= t('user_mailer.welcome.follows_title') %>


### PR DESCRIPTION
Follow-up to #460 

The "official" apps should be considered bootleg and no-one should use them.

I wish upstream would stop shoving them into people's faces.

I would rather replace the recommendation to include Tusky and Megalodon for Android apps, but I'm not sure which ones are currently recommended for iOS