### PR TITLE
Also disable role badge preview for glitch flavour

### DIFF
--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -21,7 +21,7 @@
                      input_html: { placeholder: '#000000', type: 'color' },
                      wrapper: :with_label
 
-    - unless current_user.setting_flavour == 'vanilla'
+    - unless ['vanilla', 'glitch'].include? current_user.setting_flavour
       .fields-row__column.fields-row__column-6
         .user-role__preview
           .item.dark


### PR DESCRIPTION
There is currently no point in showing it in glitch flavour as glitch now also doesn't support role badge colors.