### PR TITLE
Update FairyFloss to new monocolor design

### DIFF
--- a/app/javascript/flavours/glitch/styles/fairy-floss.scss
+++ b/app/javascript/flavours/glitch/styles/fairy-floss.scss
@@ -1,4 +1,3 @@
 @import 'fairy-floss/variables';
 @import 'index';
-@import 'backgrounds';
 @import 'fairy-floss/diff';

--- a/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
+++ b/app/javascript/flavours/glitch/styles/fairy-floss/diff.scss
@@ -21,80 +21,53 @@ html {
   background-color: $mint;
 }
 
-body,
 body.admin {
   background-color: $purple1;
 }
 
-// Small space above column headers in simple UI
-.tabs-bar__wrapper {
-  background-color: $purple1;
+// Polyam: Make background of badge darker
+.column-link__badge {
+  background: $purple1;
 }
 
-.column-header {
-  color: $purple4;
-  background-color: $purple5;
+// Polyam: Restore background of category label
+.emoji-mart-category-label span {
+  background: var(--dropdown-background-color);
+}
 
-  &__button,
-  &__back-button {
-    background-color: $purple5;
+.drawer__inner__mastodon {
+  // Polyam: var() can't be used in in url()
+  background: var(--background-color)
+    url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 234.80078 31.757813" width="234.80078" height="31.757812"><path d="M19.599609 0c-1.05 0-2.10039.375-2.90039 1.125L0 16.925781v14.832031h234.80078V17.025391l-16.5-15.900391c-1.6-1.5-4.20078-1.5-5.80078 0l-13.80078 13.099609c-1.6 1.5-4.19883 1.5-5.79883 0L179.09961 1.125c-1.6-1.5-4.19883-1.5-5.79883 0L159.5 14.224609c-1.6 1.5-4.20078 1.5-5.80078 0L139.90039 1.125c-1.6-1.5-4.20078-1.5-5.80078 0l-13.79883 13.099609c-1.6 1.5-4.20078 1.5-5.80078 0L100.69922 1.125c-1.600001-1.5-4.198829-1.5-5.798829 0l-13.59961 13.099609c-1.6 1.5-4.200781 1.5-5.800781 0L61.699219 1.125c-1.6-1.5-4.198828-1.5-5.798828 0L42.099609 14.224609c-1.6 1.5-4.198828 1.5-5.798828 0L22.5 1.125C21.7.375 20.649609 0 19.599609 0z" fill="#{hex-color($ui-base-color)}"/></svg>')
+    no-repeat bottom / 100% auto;
+}
+
+// Boost Icon
+
+button.icon-button.active {
+  .icon-retweet {
+    color: $mint;
+
+    &:hover {
+      color: $mint;
+    }
   }
 
-  &__back-button {
+  &:not(.star-icon, .bookmark-icon)::after {
     color: $mint;
   }
+}
 
-  &__button {
-    &.active {
-      background-color: $purple3;
-
-      &:hover {
-        background-color: $purple3;
-      }
-    }
-  }
-
-  &__collapsible-inner {
-    background-color: $purple3;
+.status__prepend {
+  .icon-retweet {
+    color: $mint;
   }
 }
 
-// slim button
-.column-back-button {
-  color: $mint;
-  background-color: $purple5;
-}
-
-.announcements {
-  background-color: $purple3;
-}
-
-.column-link {
-  background-color: $purple3;
-
-  // Fix wrong hover color
-  &:hover,
-  &:focus,
-  &:active {
-    background-color: lighten($purple3, 11%);
+.notification__message {
+  .icon-retweet {
+    color: $mint;
   }
-
-  // Keep transparent background in simple UI
-  &--transparent {
-    background-color: transparent;
-
-    // Add hover color
-    &:hover,
-    &:focus,
-    &:active {
-      background-color: $purpleborder;
-    }
-  }
-}
-
-// "Toots are not end-to-end encrypted..."
-.follow_requests-unlocked_explanation {
-  background-color: darken($purple1, 4%);
 }
 
 // Toots
@@ -102,21 +75,32 @@ body.admin {
 // Technically also announcements
 .reactions-bar {
   &__item {
-    background-color: lighten($purple1, 12%);
+    background-color: lighten($purple2, 4%);
 
     &:hover,
     &:focus,
     &:active {
-      background-color: lighten($purple1, 16%);
+      background-color: lighten($purple2, 8%);
     }
 
     &.active {
-      background-color: mix(lighten($purple1, 12%), $ui-highlight-color, 80%);
+      background-color: mix(lighten($purple2, 4%), $ui-highlight-color, 80%);
 
       .reactions-bar__item__count {
         color: lighten($highlight-text-color, 16%);
       }
     }
+  }
+}
+
+// Polyam: Keep collapse button colored
+.status__collapse-button {
+  color: $highlight-text-color;
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: $highlight-text-color;
   }
 }
 
@@ -134,342 +118,46 @@ body.admin {
       }
     }
 
+    // Polyam: Make darker than background
+    code,
+    pre {
+      background-color: darken($ui-base-color, 8%);
+    }
+
     &__spoiler-link {
       color: $purple1;
     }
   }
-
-  // Used in modals
-  &.light {
-    // Style the same as default
-    .status__content {
-      a.status__content__spoiler-link {
-        color: $purple1;
-        background-color: lighten($ui-base-color, 30%);
-
-        &:hover,
-        &:focus {
-          background-color: lighten($ui-base-color, 33%);
-        }
-      }
-    }
-  }
-
-  // Private mentions
-  &.status-direct {
-    background-color: $purple1;
-    border-right: 1px solid $ui-base-color;
-    border-left: 1px solid $ui-base-color;
-
-    // Collapsed toots
-    &.collapsed {
-      .status__content {
-        &::after {
-          background-color: linear-gradient(
-            rgba($purple1, 0),
-            rgba($purple1, 1)
-          );
-        }
-      }
-
-      &:focus > .status__content::after {
-        background-color: linear-gradient(
-          rgba(lighten($purple1, 4%), 0),
-          rgba(lighten($purple1, 4%), 1)
-        );
-      }
-    }
-  }
 }
 
-.focusable {
-  &:focus {
-    // Private mentions
-    &.status.status-direct {
-      background-color: lighten($purple1, 4%);
-    }
-  }
-}
-
-// Grouped private messages
-.conversation {
-  &--unread {
-    background-color: lighten($purple1, 2%);
-
-    &:focus {
-      background-color: lighten($purple1, 4%);
-    }
-  }
-}
-
-// Reverts colors for conversations and some notifications
-.muted {
-  .status {
-    &__content a {
-      color: $dark-text-color;
-    }
-  }
-}
-
-.reply-indicator {
-  background-color: $purple5;
-}
-
-// Buttons
-
-.icon-button.active {
-  color: $pink;
-}
-
-.text-icon-button.active {
-  color: darken($pink, 12%);
-}
-
-// Icons
-
-// Boost icon
-button.icon-button {
-  i.fa-retweet {
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='209'><path d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ADA6BF' stroke-width='0'/><path d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23c2ffdf' stroke-width='0'/></svg>");
-  }
-
-  &:hover i.fa-retweet {
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='209'><path d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23C0BBCE' stroke-width='0'/><path d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23c2ffdf' stroke-width='0'/></svg>");
-  }
-
-  &.active:not(.star-icon, .bookmark-icon)::after {
-    color: $mint;
-  }
-}
-
-// Icons in notifications
-.notification__message .fa {
-  color: $pink;
-}
-
-// Notification category and account page
-.notification__filter-bar,
-.account__section-headline {
-  background-color: $purple1;
-
-  a,
-  button {
-    &.active {
-      color: $mint;
-    }
-  }
-}
-
-// Compose
-
-// Fix white corners in compose textarea in simple UI
-.compose-panel {
-  .compose-form__autosuggest-wrapper {
-    background-color: transparent;
-  }
-}
-
-.compose-form {
-  // Bar below textarea
-  &__buttons-wrapper {
-    background-color: darken($simple-background-color, 4%);
-  }
-
-  &__poll-wrapper {
-    // Arrows in select
-    select {
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='%23c2ffdf'/></svg>");
-    }
-  }
-
-  &__warning {
-    background-color: darken($purple2, 4%);
-  }
-
-  // Hashtags and users suggestions
-  .autosuggest-textarea {
-    &__suggestions {
-      background-color: darken($purple2, 4%);
-
-      &__item {
-        &:hover,
-        &:focus,
-        &:active,
-        &.selected {
-          background-color: darken($purple2, 10%);
-        }
-      }
-    }
-  }
-}
-
-.drawer {
-  // Navigation on top
-  &__header {
-    background-color: $purple3;
-
-    a {
-      &:hover,
-      &:focus {
-        background-color: darken($purple3, 8%);
-      }
-    }
-  }
-
-  // Compose area
-  &__inner {
-    background-color: $purple3;
-
-    &__mastodon {
-      background-color: $purple3;
-    }
-  }
-}
-
-// Emoji picker
-
-.emoji-mart-bar {
-  &:first-child {
-    background-color: darken($simple-background-color, 4%);
-  }
-}
-
-.emoji-mart-anchors {
-  color: $darker-text-color;
-}
-
-.emoji-mart-anchor {
-  color: $purple4;
-
-  &:hover {
-    color: darken($purple4, 8%);
-  }
-}
-
-// Restore default color for selected, since color added to emoji-mart-anchor
-.emoji-mart-anchor-selected {
-  color: $highlight-text-color;
-
-  &:hover {
-    color: darken($highlight-text-color, 4%);
-  }
-}
-
-// Also used in filter-modal
-.emoji-mart-search {
-  background-color: $ui-base-color;
-
-  input {
-    background-color: rgba($ui-base-color, 0.3);
-    color: $primary-text-color;
-  }
-}
-
-.emoji-mart-search-icon {
-  svg {
-    fill: $primary-text-color;
-  }
-}
-
-.emoji-mart-category .emoji-mart-emoji {
-  &:hover::before {
-    background-color: rgba(lighten($ui-base-color, 8%), 0.7);
-  }
-}
-
-// Language dropdown
-
-.language-dropdown {
-  &__dropdown {
-    background-color: $ui-base-color;
-
-    // Also used by filter-modal
-    &__results {
-      &__item {
-        color: $primary-text-color;
-
-        &:focus,
-        &:active,
-        &:hover {
-          background-color: lighten($ui-base-color, 8%);
-        }
-      }
-    }
-  }
-}
-
-// Privacy dropdown
-
-.privacy-dropdown {
-  &__dropdown {
-    background-color: $purple3;
-  }
-
-  &__option {
-    color: $primary-text-color;
-
-    .privacy-dropdown__option__content {
-      color: $darker-text-color;
-
-      strong {
-        color: $primary-text-color;
-      }
-    }
-  }
-}
-
-// Account page
-
-.account {
-  &__header {
-    background-color: $purple5;
-
-    &__image {
-      background-color: $purple1;
-    }
-
-    &__fields {
-      border-color: lighten($purple1, 12%);
-
-      dl {
-        border-color: lighten($purple1, 12%);
-      }
-
-      dt {
-        background-color: rgba(darken($purple1, 8%), 0.5);
-      }
-    }
-
-    &__bio {
-      .account__header__fields {
-        border-color: lighten($purple1, 12%);
-      }
-    }
-
-    // Polyam: Keep same background as header
-    &__account-note {
-      textarea {
-        &:focus {
-          background-color: $purple5;
-        }
-      }
-    }
+// Polyam: Use same color as hashtags in toot
+.hashtag-bar {
+  a {
+    color: $lemon;
   }
 }
 
 // Modals
+
+// Polyam: Apply background to modals,
+// but new mute and block modals need to be exempt
+// as otherwise it conflicts with border-radius
+.modal-root__modal:not(.safety-action-modal) {
+  background-color: lighten($purple2, 8%);
+}
+
+.safety-action-modal__top,
+.safety-action-modal__bottom {
+  background: lighten($purple2, 8%);
+}
 
 .doodle-modal,
 .boost-modal,
 .confirmation-modal,
 .report-modal,
 .actions-modal,
-.mute-modal,
-.block-modal,
 .compare-history-modal,
 .report-dialog-modal {
-  background-color: lighten($purple2, 8%);
-
   &__action-bar {
     background-color: $purple2;
   }
@@ -478,12 +166,6 @@ button.icon-button {
   &__comment {
     .setting-text {
       background-color: $simple-background-color;
-    }
-  }
-
-  &__container {
-    select {
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color($mint)}'/></svg>");
     }
   }
 
@@ -521,11 +203,6 @@ button.icon-button {
 // Uses simple-background and should be white
 .qr-code {
   background-color: $white;
-}
-
-// Uses simple-background and should be white
-.react-toggle-thumb {
-  background-color: darken($white, 2%);
 }
 
 .admin-wrapper {

--- a/app/javascript/flavours/glitch/styles/fairy-floss/variables.scss
+++ b/app/javascript/flavours/glitch/styles/fairy-floss/variables.scss
@@ -108,3 +108,14 @@ $no-gap-breakpoint: 415px;
 $font-sans-serif: 'mastodon-font-sans-serif' !default;
 $font-display: 'mastodon-font-display' !default;
 $font-monospace: 'mastodon-font-monospace' !default;
+
+:root {
+  --dropdown-border-color: #{lighten($purple3, 4%)} !important;
+  --dropdown-background-color: #{$purple3} !important;
+  --modal-background-color: #{lighten($ui-base-color, 8%)} !important;
+  --modal-background-variant-color: #{$ui-base-color} !important;
+  --background-border-color: #{lighten($ui-base-color, 8%)} !important;
+  --background-color: #{darken($ui-base-color, 4%)} !important;
+  --background-color-tint: #{darken($ui-base-color, 4%)} !important;
+  --surface-background-color: #{$purple1} !important;
+}

--- a/app/javascript/flavours/polyam/styles/fairy-floss.scss
+++ b/app/javascript/flavours/polyam/styles/fairy-floss.scss
@@ -1,4 +1,3 @@
 @import 'fairy-floss/variables';
 @import 'index';
-@import 'backgrounds';
 @import 'fairy-floss/diff';

--- a/app/javascript/flavours/polyam/styles/fairy-floss/diff.scss
+++ b/app/javascript/flavours/polyam/styles/fairy-floss/diff.scss
@@ -21,80 +21,53 @@ html {
   background-color: $mint;
 }
 
-body,
 body.admin {
   background-color: $purple1;
 }
 
-// Small space above column headers in simple UI
-.tabs-bar__wrapper {
-  background-color: $purple1;
+// Polyam: Make background of badge darker
+.column-link__badge {
+  background: $purple1;
 }
 
-.column-header {
-  color: $purple4;
-  background-color: $purple5;
+// Polyam: Restore background of category label
+.emoji-mart-category-label span {
+  background: var(--dropdown-background-color);
+}
 
-  &__button,
-  &__back-button {
-    background-color: $purple5;
+.drawer__inner__mastodon {
+  // Polyam: var() can't be used in in url()
+  background: var(--background-color)
+    url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 234.80078 31.757813" width="234.80078" height="31.757812"><path d="M19.599609 0c-1.05 0-2.10039.375-2.90039 1.125L0 16.925781v14.832031h234.80078V17.025391l-16.5-15.900391c-1.6-1.5-4.20078-1.5-5.80078 0l-13.80078 13.099609c-1.6 1.5-4.19883 1.5-5.79883 0L179.09961 1.125c-1.6-1.5-4.19883-1.5-5.79883 0L159.5 14.224609c-1.6 1.5-4.20078 1.5-5.80078 0L139.90039 1.125c-1.6-1.5-4.20078-1.5-5.80078 0l-13.79883 13.099609c-1.6 1.5-4.20078 1.5-5.80078 0L100.69922 1.125c-1.600001-1.5-4.198829-1.5-5.798829 0l-13.59961 13.099609c-1.6 1.5-4.200781 1.5-5.800781 0L61.699219 1.125c-1.6-1.5-4.198828-1.5-5.798828 0L42.099609 14.224609c-1.6 1.5-4.198828 1.5-5.798828 0L22.5 1.125C21.7.375 20.649609 0 19.599609 0z" fill="#{hex-color($ui-base-color)}"/></svg>')
+    no-repeat bottom / 100% auto;
+}
+
+// Boost Icon
+
+button.icon-button.active {
+  .icon-retweet {
+    color: $mint;
+
+    &:hover {
+      color: $mint;
+    }
   }
 
-  &__back-button {
+  &:not(.star-icon, .bookmark-icon)::after {
     color: $mint;
   }
+}
 
-  &__button {
-    &.active {
-      background-color: $purple3;
-
-      &:hover {
-        background-color: $purple3;
-      }
-    }
-  }
-
-  &__collapsible-inner {
-    background-color: $purple3;
+.status__prepend {
+  .icon-retweet {
+    color: $mint;
   }
 }
 
-// slim button
-.column-back-button {
-  color: $mint;
-  background-color: $purple5;
-}
-
-.announcements {
-  background-color: $purple3;
-}
-
-.column-link {
-  background-color: $purple3;
-
-  // Fix wrong hover color
-  &:hover,
-  &:focus,
-  &:active {
-    background-color: lighten($purple3, 11%);
+.notification__message {
+  .icon-retweet {
+    color: $mint;
   }
-
-  // Keep transparent background in simple UI
-  &--transparent {
-    background-color: transparent;
-
-    // Add hover color
-    &:hover,
-    &:focus,
-    &:active {
-      background-color: $purpleborder;
-    }
-  }
-}
-
-// "Toots are not end-to-end encrypted..."
-.follow_requests-unlocked_explanation {
-  background-color: darken($purple1, 4%);
 }
 
 // Toots
@@ -102,21 +75,32 @@ body.admin {
 // Technically also announcements
 .reactions-bar {
   &__item {
-    background-color: lighten($purple1, 12%);
+    background-color: lighten($purple2, 4%);
 
     &:hover,
     &:focus,
     &:active {
-      background-color: lighten($purple1, 16%);
+      background-color: lighten($purple2, 8%);
     }
 
     &.active {
-      background-color: mix(lighten($purple1, 12%), $ui-highlight-color, 80%);
+      background-color: mix(lighten($purple2, 4%), $ui-highlight-color, 80%);
 
       .reactions-bar__item__count {
         color: lighten($highlight-text-color, 16%);
       }
     }
+  }
+}
+
+// Polyam: Keep collapse button colored
+.status__collapse-button {
+  color: $highlight-text-color;
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: $highlight-text-color;
   }
 }
 
@@ -134,342 +118,46 @@ body.admin {
       }
     }
 
+    // Polyam: Make darker than background
+    code,
+    pre {
+      background-color: darken($ui-base-color, 8%);
+    }
+
     &__spoiler-link {
       color: $purple1;
     }
   }
-
-  // Used in modals
-  &.light {
-    // Style the same as default
-    .status__content {
-      a.status__content__spoiler-link {
-        color: $purple1;
-        background-color: lighten($ui-base-color, 30%);
-
-        &:hover,
-        &:focus {
-          background-color: lighten($ui-base-color, 33%);
-        }
-      }
-    }
-  }
-
-  // Private mentions
-  &.status-direct {
-    background-color: $purple1;
-    border-right: 1px solid $ui-base-color;
-    border-left: 1px solid $ui-base-color;
-
-    // Collapsed toots
-    &.collapsed {
-      .status__content {
-        &::after {
-          background-color: linear-gradient(
-            rgba($purple1, 0),
-            rgba($purple1, 1)
-          );
-        }
-      }
-
-      &:focus > .status__content::after {
-        background-color: linear-gradient(
-          rgba(lighten($purple1, 4%), 0),
-          rgba(lighten($purple1, 4%), 1)
-        );
-      }
-    }
-  }
 }
 
-.focusable {
-  &:focus {
-    // Private mentions
-    &.status.status-direct {
-      background-color: lighten($purple1, 4%);
-    }
-  }
-}
-
-// Grouped private messages
-.conversation {
-  &--unread {
-    background-color: lighten($purple1, 2%);
-
-    &:focus {
-      background-color: lighten($purple1, 4%);
-    }
-  }
-}
-
-// Reverts colors for conversations and some notifications
-.muted {
-  .status {
-    &__content a {
-      color: $dark-text-color;
-    }
-  }
-}
-
-.reply-indicator {
-  background-color: $purple5;
-}
-
-// Buttons
-
-.icon-button.active {
-  color: $pink;
-}
-
-.text-icon-button.active {
-  color: darken($pink, 12%);
-}
-
-// Icons
-
-// Boost icon
-button.icon-button {
-  i.fa-retweet {
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='209'><path d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ADA6BF' stroke-width='0'/><path d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23c2ffdf' stroke-width='0'/></svg>");
-  }
-
-  &:hover i.fa-retweet {
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='209'><path d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23C0BBCE' stroke-width='0'/><path d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23c2ffdf' stroke-width='0'/></svg>");
-  }
-
-  &.active:not(.star-icon, .bookmark-icon)::after {
-    color: $mint;
-  }
-}
-
-// Icons in notifications
-.notification__message .fa {
-  color: $pink;
-}
-
-// Notification category and account page
-.notification__filter-bar,
-.account__section-headline {
-  background-color: $purple1;
-
-  a,
-  button {
-    &.active {
-      color: $mint;
-    }
-  }
-}
-
-// Compose
-
-// Fix white corners in compose textarea in simple UI
-.compose-panel {
-  .compose-form__autosuggest-wrapper {
-    background-color: transparent;
-  }
-}
-
-.compose-form {
-  // Bar below textarea
-  &__buttons-wrapper {
-    background-color: darken($simple-background-color, 4%);
-  }
-
-  &__poll-wrapper {
-    // Arrows in select
-    select {
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='%23c2ffdf'/></svg>");
-    }
-  }
-
-  &__warning {
-    background-color: darken($purple2, 4%);
-  }
-
-  // Hashtags and users suggestions
-  .autosuggest-textarea {
-    &__suggestions {
-      background-color: darken($purple2, 4%);
-
-      &__item {
-        &:hover,
-        &:focus,
-        &:active,
-        &.selected {
-          background-color: darken($purple2, 10%);
-        }
-      }
-    }
-  }
-}
-
-.drawer {
-  // Navigation on top
-  &__header {
-    background-color: $purple3;
-
-    a {
-      &:hover,
-      &:focus {
-        background-color: darken($purple3, 8%);
-      }
-    }
-  }
-
-  // Compose area
-  &__inner {
-    background-color: $purple3;
-
-    &__mastodon {
-      background-color: $purple3;
-    }
-  }
-}
-
-// Emoji picker
-
-.emoji-mart-bar {
-  &:first-child {
-    background-color: darken($simple-background-color, 4%);
-  }
-}
-
-.emoji-mart-anchors {
-  color: $darker-text-color;
-}
-
-.emoji-mart-anchor {
-  color: $purple4;
-
-  &:hover {
-    color: darken($purple4, 8%);
-  }
-}
-
-// Restore default color for selected, since color added to emoji-mart-anchor
-.emoji-mart-anchor-selected {
-  color: $highlight-text-color;
-
-  &:hover {
-    color: darken($highlight-text-color, 4%);
-  }
-}
-
-// Also used in filter-modal
-.emoji-mart-search {
-  background-color: $ui-base-color;
-
-  input {
-    background-color: rgba($ui-base-color, 0.3);
-    color: $primary-text-color;
-  }
-}
-
-.emoji-mart-search-icon {
-  svg {
-    fill: $primary-text-color;
-  }
-}
-
-.emoji-mart-category .emoji-mart-emoji {
-  &:hover::before {
-    background-color: rgba(lighten($ui-base-color, 8%), 0.7);
-  }
-}
-
-// Language dropdown
-
-.language-dropdown {
-  &__dropdown {
-    background-color: $ui-base-color;
-
-    // Also used by filter-modal
-    &__results {
-      &__item {
-        color: $primary-text-color;
-
-        &:focus,
-        &:active,
-        &:hover {
-          background-color: lighten($ui-base-color, 8%);
-        }
-      }
-    }
-  }
-}
-
-// Privacy dropdown
-
-.privacy-dropdown {
-  &__dropdown {
-    background-color: $purple3;
-  }
-
-  &__option {
-    color: $primary-text-color;
-
-    .privacy-dropdown__option__content {
-      color: $darker-text-color;
-
-      strong {
-        color: $primary-text-color;
-      }
-    }
-  }
-}
-
-// Account page
-
-.account {
-  &__header {
-    background-color: $purple5;
-
-    &__image {
-      background-color: $purple1;
-    }
-
-    &__fields {
-      border-color: lighten($purple1, 12%);
-
-      dl {
-        border-color: lighten($purple1, 12%);
-      }
-
-      dt {
-        background-color: rgba(darken($purple1, 8%), 0.5);
-      }
-    }
-
-    &__bio {
-      .account__header__fields {
-        border-color: lighten($purple1, 12%);
-      }
-    }
-
-    // Polyam: Keep same background as header
-    &__account-note {
-      textarea {
-        &:focus {
-          background-color: $purple5;
-        }
-      }
-    }
+// Polyam: Use same color as hashtags in toot
+.hashtag-bar {
+  a {
+    color: $lemon;
   }
 }
 
 // Modals
+
+// Polyam: Apply background to modals,
+// but new mute and block modals need to be exempt
+// as otherwise it conflicts with border-radius
+.modal-root__modal:not(.safety-action-modal) {
+  background-color: lighten($purple2, 8%);
+}
+
+.safety-action-modal__top,
+.safety-action-modal__bottom {
+  background: lighten($purple2, 8%);
+}
 
 .doodle-modal,
 .boost-modal,
 .confirmation-modal,
 .report-modal,
 .actions-modal,
-.mute-modal,
-.block-modal,
 .compare-history-modal,
 .report-dialog-modal {
-  background-color: lighten($purple2, 8%);
-
   &__action-bar {
     background-color: $purple2;
   }
@@ -478,12 +166,6 @@ button.icon-button {
   &__comment {
     .setting-text {
       background-color: $simple-background-color;
-    }
-  }
-
-  &__container {
-    select {
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color($mint)}'/></svg>");
     }
   }
 
@@ -521,11 +203,6 @@ button.icon-button {
 // Uses simple-background and should be white
 .qr-code {
   background-color: $white;
-}
-
-// Uses simple-background and should be white
-.react-toggle-thumb {
-  background-color: darken($white, 2%);
 }
 
 .admin-wrapper {

--- a/app/javascript/flavours/polyam/styles/fairy-floss/variables.scss
+++ b/app/javascript/flavours/polyam/styles/fairy-floss/variables.scss
@@ -108,3 +108,14 @@ $no-gap-breakpoint: 415px;
 $font-sans-serif: 'mastodon-font-sans-serif' !default;
 $font-display: 'mastodon-font-display' !default;
 $font-monospace: 'mastodon-font-monospace' !default;
+
+:root {
+  --dropdown-border-color: #{lighten($purple3, 4%)} !important;
+  --dropdown-background-color: #{$purple3} !important;
+  --modal-background-color: #{lighten($ui-base-color, 8%)} !important;
+  --modal-background-variant-color: #{$ui-base-color} !important;
+  --background-border-color: #{lighten($ui-base-color, 8%)} !important;
+  --background-color: #{darken($ui-base-color, 4%)} !important;
+  --background-color-tint: #{darken($ui-base-color, 4%)} !important;
+  --surface-background-color: #{$purple1} !important;
+}


### PR DESCRIPTION
This greatly reduces the diff and should make maintaining it less painful

Not sure `mint` as boost icon color still makes sense, but I kept it, because it was there before.

Changed background to a darker variant to make it easier on the eyes.

Adjusted reaction-bar colors for new background.

Simplified modal background overrides.

Color hashtags in hashtag bar same as in toots.

Before:
![Screenshot of the old design with some broken overrides](https://github.com/polyamspace/mastodon/assets/117664621/7d9add46-bbdf-4644-b23d-61d9e621fb76)

After:
![Screenshot of the new design with broken overrides fixed](https://github.com/polyamspace/mastodon/assets/117664621/8634c43e-8c9a-4b1f-abd3-a90da977e4a5)

