### PR TITLE
Move notification sound setting to "Other"

### DIFF
--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -42,9 +42,3 @@
                      label_method: ->(setting) { I18n.t("simple_form.labels.notification_emails.software_updates.#{setting}") },
                      label: I18n.t('simple_form.labels.notification_emails.software_updates.label'),
                      wrapper: :with_label
-
-  %h4= t 'notifications.other_settings'
-
-  = f.simple_fields_for :settings, current_user.settings do |ff|
-    .fields-group
-      = ff.input :'web.notification_sound', collection: NotificationSounds.instance.names, label_method: ->(sound) { I18n.t("sounds.#{sound}", default: sound) }, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_notification_sound'), include_blank: false, polyam_only: true

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -57,6 +57,12 @@
                  item_wrapper_tag: 'li',
                  glitch_only: true
 
+  %h4= t 'notifications.other_settings'
+
+  = f.simple_fields_for :settings, current_user.settings do |ff|
+    .fields-group
+      = ff.input :'web.notification_sound', collection: NotificationSounds.instance.names, label_method: ->(sound) { I18n.t("sounds.#{sound}", default: sound) }, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_notification_sound'), include_blank: false, polyam_only: true
+
   %h4= t 'preferences.public_timelines'
 
   .fields-group

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -57,7 +57,7 @@
                  item_wrapper_tag: 'li',
                  glitch_only: true
 
-  %h4= t 'notifications.other_settings'
+  %h4= t 'preferences.notifications'
 
   = f.simple_fields_for :settings, current_user.settings do |ff|
     .fields-group

--- a/config/locales-polyam/en.yml
+++ b/config/locales-polyam/en.yml
@@ -94,8 +94,8 @@ en:
       body: "%{name} reacted to your toot:"
       subject: "%{name} reacted to your toot"
       title: New reaction
-  notifications:
-    other_settings: Other settings
+  preferences:
+    notifications: Notifications
   regex_validator:
     invalid_regexp: 'error parsing regular expression: %{error}'
   sounds:


### PR DESCRIPTION
Notification setting has been renamed to e-mail notifications and other settings have been removed in favour of notification requests, so it makes more sense there.

![Screenshot of Preferences > Other page showing the notification sound setting](https://github.com/polyamspace/mastodon/assets/117664621/3e42fb4e-5764-4a83-a810-3127a70b4da3)
