### PR TITLE
Fix misaligned account bio in moderation interface

### DIFF
--- a/app/javascript/flavours/polyam/styles/admin.scss
+++ b/app/javascript/flavours/polyam/styles/admin.scss
@@ -992,6 +992,7 @@ a.name-tag,
     box-sizing: border-box;
     padding: 20px;
     color: $primary-text-color;
+    margin: 0; // Polyam: Added margin to component
   }
 }
 


### PR DESCRIPTION
Caused by adding margin to the component version and it's reused in moderation interface.

Before:
![Screenshot of account moderation interface showing misaligned elements](https://github.com/polyamspace/mastodon/assets/117664621/2717d522-013e-4d1e-b7e1-3a1f4e2d8444)

After:
![Screenshot of account moderation interface showing elements aligned](https://github.com/polyamspace/mastodon/assets/117664621/ec18583f-6524-4d51-aa4f-a6e1abbb7f24)
