### PR TITLE
Add removed `nowrap` to account moderation interface

### DIFF
--- a/app/javascript/flavours/polyam/styles/admin.scss
+++ b/app/javascript/flavours/polyam/styles/admin.scss
@@ -983,6 +983,15 @@ a.name-tag,
       border-radius: 0 4px 0 0;
     }
 
+    // Polyam: This was removed in component
+    dt,
+    dd {
+      max-height: 48px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
     .verified a {
       color: $valid-value-color;
     }


### PR DESCRIPTION
Follow-up to #495 

The elements display as horizontal instead of vertical columns without it.

Preview:
![Screenshot of account moderation page showing elements aligned vertical instead of horizontal](https://github.com/polyamspace/mastodon/assets/117664621/e0944f03-5958-4f23-90cc-8eb56a20ae9e)
