### PR TITLE
Fix overrides for emoji picker in homogay

### DIFF
--- a/app/javascript/flavours/glitch/styles/homogay/diff.scss
+++ b/app/javascript/flavours/glitch/styles/homogay/diff.scss
@@ -60,20 +60,13 @@
   width: 286px;
 }
 
-// Polyam: Remove transparency while selecting skin tone
-.emoji-picker-dropdown__menu.selecting .emoji-mart-scroll {
-  opacity: 1;
+// Polyam: Restore background of category label
+.emoji-mart-category-label span {
+  background: var(--dropdown-background-color);
 }
 
 .emoji-mart-anchor {
   padding: 12px 0;
-}
-
-.emoji-mart-bar:first-child {
-  // background: $ui-base-extra-light-color;
-  border-bottom-color: #fff0;
-  border-top-left-radius: $border-radius;
-  border-top-right-radius: $border-radius;
 }
 
 .drawer__inner__mastodon {

--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -60,20 +60,13 @@
   width: 286px;
 }
 
-// Polyam: Remove transparency while selecting skin tone
-.emoji-picker-dropdown__menu.selecting .emoji-mart-scroll {
-  opacity: 1;
+// Polyam: Restore background of category label
+.emoji-mart-category-label span {
+  background: var(--dropdown-background-color);
 }
 
 .emoji-mart-anchor {
   padding: 12px 0;
-}
-
-.emoji-mart-bar:first-child {
-  // background: $ui-base-extra-light-color;
-  border-bottom-color: #fff0;
-  border-top-left-radius: $border-radius;
-  border-top-right-radius: $border-radius;
 }
 
 .drawer__inner__mastodon {


### PR DESCRIPTION
Removing transparency is no longer needed as upstream fixed the background.

Overriding borders is no longer necessary as upstream removed them.

Added background override for category label as transparent label looks wrong.