### PR TITLE
Increase score half-life for trending toots

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -298,6 +298,12 @@ MAX_REACTIONS=1
 # Customize the number of hashtags shown in 'Explore'
 # MAX_TRENDING_TAGS=10
 
+# Score half-life for trending toots in hours
+# Influences how long toots trend for
+# Higher values recommended for small instances, lower for larger ones
+# Upstream uses 1
+# TRENDS_TOOT_HALFLIFE=4
+
 # Maximum custom emoji file sizes
 # If undefined or smaller than MAX_EMOJI_SIZE, the value
 # of MAX_EMOJI_SIZE will be used for MAX_REMOTE_EMOJI_SIZE

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -5,10 +5,12 @@ class Trends::Statuses < Trends::Base
 
   BATCH_SIZE = 100
 
+  STATUS_HALFLIFE = (ENV['TRENDS_TOOT_HALFLIFE'] || 4).to_i
+
   self.default_options = {
     threshold: 5,
     review_threshold: 3,
-    score_halflife: 1.hour.freeze,
+    score_halflife: STATUS_HALFLIFE.hours.freeze,
     decay_threshold: 0.3,
   }
 


### PR DESCRIPTION
Adds a new env var: `TRENDS_TOOT_HALFLIFE`

4 is just a random number that seems to make sense.