### PR TITLE
Remove server favicon setting

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,18 +83,6 @@ module ApplicationHelper
     end
   end
 
-  def favicon_path
-    instance_presenter.favicon ? instance_presenter.favicon&.file&.url : '/favicon.ico'
-  end
-
-  def favicon_type
-    instance_presenter.favicon ? instance_presenter.favicon.file.content_type : 'image/x-icon'
-  end
-
-  def favicon?
-    instance_presenter.favicon.present?
-  end
-
   def html_title
     safe_join(
       [content_for(:page_title).to_s.chomp, title]

--- a/app/javascript/flavours/glitch/styles/forms.scss
+++ b/app/javascript/flavours/glitch/styles/forms.scss
@@ -327,19 +327,6 @@ code {
         object-fit: cover;
       }
     }
-
-    &__favicon {
-      display: block;
-      margin: 0;
-      margin-bottom: 10px;
-      max-width: 64px;
-      height: auto;
-      border-radius: 4px;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
-    }
   }
 
   .fields-row {

--- a/app/javascript/flavours/polyam/styles/forms.scss
+++ b/app/javascript/flavours/polyam/styles/forms.scss
@@ -327,19 +327,6 @@ code {
         object-fit: cover;
       }
     }
-
-    &__favicon {
-      display: block;
-      margin: 0;
-      margin-bottom: 10px;
-      max-width: 64px;
-      height: auto;
-      border-radius: 4px;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
-    }
   }
 
   .fields-row {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -327,19 +327,6 @@ code {
         object-fit: cover;
       }
     }
-
-    &__favicon {
-      display: block;
-      margin: 0;
-      margin-bottom: 10px;
-      max-width: 64px;
-      height: auto;
-      border-radius: 4px;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
-    }
   }
 
   .fields-row {

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -25,7 +25,6 @@ class Form::AdminSettings
     profile_directory
     hide_followers_count
     flavour_and_skin
-    favicon
     thumbnail
     mascot
     show_reblogs_in_public_timelines
@@ -81,7 +80,6 @@ class Form::AdminSettings
   ).freeze
 
   UPLOAD_KEYS = %i(
-    favicon
     thumbnail
     mascot
   ).freeze

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -39,21 +39,9 @@ class SiteUpload < ApplicationRecord
     }.freeze,
 
     mascot: {}.freeze,
-    favicon: {},
   }.freeze
 
-  # Feels a bit hacky, but adds required sizes to favicon and then freezes it.
-  %w(16 32 48 57 60 72 76 114 120 144 152 167 180 1024).each do |size|
-    STYLES[:favicon][:"#{size}"] = {
-      format: 'png',
-      geometry: "#{size}x#{size}#",
-      file_geometry_parser: FastGeometryParser,
-    }.freeze
-  end
-
-  STYLES[:favicon].freeze
-
-  has_attached_file :file, source_file_options: { all: '-background transparent' }, styles: ->(file) { STYLES[file.instance.var.to_sym] }, convert_options: { all: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' }, processors: [:lazy_thumbnail, :blurhash_transcoder, :type_corrector]
+  has_attached_file :file, styles: ->(file) { STYLES[file.instance.var.to_sym] }, convert_options: { all: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' }, processors: [:lazy_thumbnail, :blurhash_transcoder, :type_corrector]
 
   validates_attachment_content_type :file, content_type: %r{\Aimage/.*\z}
   validates :file, presence: true

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -81,8 +81,4 @@ class InstancePresenter < ActiveModelSerializers::Model
   def mascot
     @mascot ||= Rails.cache.fetch('site_uploads/mascot') { SiteUpload.find_by(var: 'mascot') }
   end
-
-  def favicon
-    @favicon ||= Rails.cache.fetch('site_uploads/favicon') { SiteUpload.find_by(var: 'favicon') }
-  end
 end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -123,7 +123,6 @@ class InitialStateSerializer < ActiveModel::Serializer
       version: instance_presenter.version,
       limited_federation_mode: Rails.configuration.x.limited_federation_mode,
       mascot: instance_presenter.mascot&.file&.url,
-      favicon: instance_presenter.favicon&.file&.url,
       profile_directory: Setting.profile_directory,
       trends_enabled: Setting.trends,
       registrations_open: Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode,

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -40,15 +40,5 @@
           = fa_icon 'trash fw'
           = t('admin.site_uploads.delete')
 
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :favicon, as: :file, wrapper: :with_block_label, polyam_only: true
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.favicon.persisted?
-        = image_tag @admin_settings.favicon.file.url(:original), class: 'fields-group__favicon'
-        = link_to admin_site_upload_path(@admin_settings.favicon), data: { method: :delete }, class: 'link-button link-button--destructive' do
-          = fa_icon 'trash fw'
-          = t('admin.site_uploads.delete')
-
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,19 +12,13 @@
     - if storage_host?
       %link{ rel: 'dns-prefetch', href: storage_host }/
 
-    %link{ rel: 'icon', href: favicon_path, type: favicon_type }/
+    %link{ rel: 'icon', href: '/favicon.ico', type: 'image/x-icon' }/
 
     - %w(16 32 48).each do |size|
-      - if favicon?
-        %link{ rel: 'icon', sizes: "#{size}x#{size}", href: instance_presenter.favicon&.file&.url(:"#{size}"), type: 'image/png' }/
-      - else
-        %link{ rel: 'icon', sizes: "#{size}x#{size}", href: frontend_asset_path("icons/favicon-#{size}x#{size}.png"), type: 'image/png' }/
+      %link{ rel: 'icon', sizes: "#{size}x#{size}", href: frontend_asset_path("icons/favicon-#{size}x#{size}.png"), type: 'image/png' }/
 
     - %w(57 60 72 76 114 120 144 152 167 180 1024).each do |size|
-      - if favicon?
-        %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: instance_presenter.favicon&.file&.url(:"#{size}") }/
-      - else
-        %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: frontend_asset_path("icons/apple-touch-icon-#{size}x#{size}.png") }/
+      %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: frontend_asset_path("icons/apple-touch-icon-#{size}x#{size}.png") }/
 
     %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -82,7 +82,6 @@ en:
         closed_registrations_message: Displayed when sign-ups are closed
         content_cache_retention_period: All toots and boosts from other servers will be deleted after the specified number of days. Some toots may not be recoverable. All related bookmarks, favourites and boosts will also be lost and impossible to undo.
         custom_css: You can apply custom styles on the web version of Mastodon.
-        favicon: An image to use as favicon.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         peers_api_enabled: A list of domain names this server has encountered in the fediverse. No data is included here about whether you federate with a given server, just that your server knows about it. This is used by services that collect statistics on federation in a general sense.
@@ -246,7 +245,6 @@ en:
         closed_registrations_message: Custom message when sign-ups are not available
         content_cache_retention_period: Content cache retention period
         custom_css: Custom CSS
-        favicon: Server favicon
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
         peers_api_enabled: Publish list of discovered servers in the API


### PR DESCRIPTION
Closes #206
Closes #241
Ref #7 

This setting has been semi-broken for a while and I don't feel confident in fixing this without making major changes.
If there is enough interest I might look back into it, but for now it's not really worth fixing.

Using the `branding:generate_app_icons` task instead is recommended.
Just replace `app/javascript/images/logo.svg` and `app/javascript/images/app-icon.svg` with the svg of the icon you want to use and then run `RAILS_ENV=production bundle exec rake branding:generate_app_icons` \
(Or better in a local dev environment and commit the result to your repo to avoid issues when pulling updates)