### PR TITLE
Add `nowrap` to table-action-link

### DIFF
--- a/app/javascript/flavours/polyam/styles/tables.scss
+++ b/app/javascript/flavours/polyam/styles/tables.scss
@@ -134,6 +134,7 @@ a.table-action-link {
   padding: 0 10px;
   color: $darker-text-color;
   font-weight: 500;
+  white-space: nowrap; // Polyam: Fix display with long text
 
   &:hover {
     color: $primary-text-color;


### PR DESCRIPTION
This prevents the icon and text from wrapping when part of element with long text. Specifically the rule page when the rule text or upcoming hint is very long.

This is probably the first `nowrap` that has an actual good reason to be there.

Before:
![Screenshot of rules overview showing icon wrapped above text](https://github.com/polyamspace/mastodon/assets/117664621/18cd2d35-2b4f-4ecb-864e-b429b93dd9cd)

After:
![Screenshot of rules overview showing icon stays left of text](https://github.com/polyamspace/mastodon/assets/117664621/4eae3c0a-81a8-44e1-9955-111cc093e779)

