### PR TITLE
Fix propType of myAccount in getting_started

### DIFF
--- a/app/javascript/flavours/polyam/features/getting_started/index.jsx
+++ b/app/javascript/flavours/polyam/features/getting_started/index.jsx
@@ -106,7 +106,7 @@ class GettingStarted extends ImmutablePureComponent {
 
   static propTypes = {
     intl: PropTypes.object.isRequired,
-    myAccount: ImmutablePropTypes.map,
+    myAccount: ImmutablePropTypes.record,
     columns: ImmutablePropTypes.list,
     multiColumn: PropTypes.bool,
     fetchFollowRequests: PropTypes.func.isRequired,


### PR DESCRIPTION
Upstream changed type from map to record a while ago. This got never updated apparently.