### PR TITLE
Fix hashtag bar background in homogay

### DIFF
--- a/app/javascript/flavours/glitch/styles/homogay/diff.scss
+++ b/app/javascript/flavours/glitch/styles/homogay/diff.scss
@@ -93,6 +93,19 @@
   color: $highlight-text-color;
 }
 
+// Polyam: Hashtag bar
+.hashtag-bar {
+  a {
+    background-color: lighten($ui-base-color, 4%);
+
+    &:hover,
+    &:focus,
+    &:active {
+      background-color: lighten($ui-base-color, 8%);
+    }
+  }
+}
+
 // Polyam: Keep collapse button in higthlight color
 .status__collapse-button {
   color: $highlight-text-color;

--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -93,6 +93,19 @@
   color: $highlight-text-color;
 }
 
+// Polyam: Hashtag bar
+.hashtag-bar {
+  a {
+    background-color: lighten($ui-base-color, 4%);
+
+    &:hover,
+    &:focus,
+    &:active {
+      background-color: lighten($ui-base-color, 8%);
+    }
+  }
+}
+
 // Polyam: Keep collapse button in higthlight color
 .status__collapse-button {
   color: $highlight-text-color;


### PR DESCRIPTION
Upstream uses a darkened background, so using the base color makes the background the same.