### PR TITLE
Fix classname for light theme in variables

### DIFF
--- a/app/javascript/flavours/polyam/styles/mastodon-light/variables.scss
+++ b/app/javascript/flavours/polyam/styles/mastodon-light/variables.scss
@@ -56,7 +56,8 @@ $account-background-color: $white !default;
 
 $emojis-requiring-inversion: 'chains';
 
-.theme-mastodon-light {
+.skin-mastodon-light,
+.skin-system {
   --dropdown-border-color: #d9e1e8;
   --dropdown-background-color: #fff;
   --background-border-color: #d9e1e8;


### PR DESCRIPTION
Glitch-soc's themeing system uses `skin-` instead of `theme-` so the overrides in the light theme didn't apply.