### PR TITLE
[PoC] awesome icons in admin/moderation interface

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -113,6 +113,14 @@ module ApplicationHelper
     content_tag(:i, nil, attributes.merge(class: class_names.join(' ')))
   end
 
+  def material_symbol(icon, attributes = {})
+    inline_svg_tag(
+      "400-24px/#{icon}.svg",
+      class: %w(icon).concat(attributes[:class].to_s.split),
+      role: :img
+    )
+  end
+
   def check_icon
     inline_svg_tag 'check.svg'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,8 +114,18 @@ module ApplicationHelper
   end
 
   def material_symbol(icon, attributes = {})
+    return awesome_icon(icon.tr('_', '-'), attributes) if current_flavour == 'polyam'
+
     inline_svg_tag(
       "400-24px/#{icon}.svg",
+      class: %w(icon).concat(attributes[:class].to_s.split),
+      role: :img
+    )
+  end
+
+  def awesome_icon(icon, attributes = {})
+    inline_svg_tag(
+      "solid/#{icon}.svg",
       class: %w(icon).concat(attributes[:class].to_s.split),
       role: :img
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,7 +114,7 @@ module ApplicationHelper
   end
 
   def material_symbol(icon, attributes = {})
-    return awesome_icon(icon.tr('_', '-'), attributes) if current_flavour == 'polyam'
+    return awesome_icon(material_to_awesome(icon), attributes) if current_flavour == 'polyam'
 
     inline_svg_tag(
       "400-24px/#{icon}.svg",
@@ -129,6 +129,19 @@ module ApplicationHelper
       class: %w(icon).concat(attributes[:class].to_s.split),
       role: :img
     )
+  end
+
+  def material_to_awesome(icon)
+    case icon
+    when 'visibility'
+      'eye'
+    when 'visibility_off'
+      'eye-slash'
+    when 'close'
+      'xmark'
+    else
+      icon.tr('_', '-').tr('-fill', '')
+    end
   end
 
   def check_icon

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -125,7 +125,7 @@ module ApplicationHelper
 
   def awesome_icon(icon, attributes = {})
     inline_svg_tag(
-      "solid/#{icon}.svg",
+      "#{attributes[:variant] || 'solid'}/#{icon}.svg",
       class: %w(icon).concat(attributes[:class].to_s.split),
       role: :img
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,7 +132,7 @@ module ApplicationHelper
   end
 
   def material_to_awesome(icon)
-    icon = icon.tr('-fill', '')
+    icon = icon.chomp('-fill')
 
     case icon
     when 'visibility'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,6 +132,8 @@ module ApplicationHelper
   end
 
   def material_to_awesome(icon)
+    icon = icon.tr('-fill', '')
+
     case icon
     when 'visibility'
       'eye'
@@ -140,7 +142,7 @@ module ApplicationHelper
     when 'close'
       'xmark'
     else
-      icon.tr('_', '-').tr('-fill', '')
+      icon.tr('_', '-')
     end
   end
 

--- a/app/javascript/flavours/glitch/styles/admin.scss
+++ b/app/javascript/flavours/glitch/styles/admin.scss
@@ -10,6 +10,13 @@ $content-width: 840px;
   width: 100%;
   min-height: 100vh;
 
+  .icon {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+    margin: 0 2px;
+  }
+
   .sidebar-wrapper {
     min-height: 100vh;
     overflow: hidden;

--- a/app/javascript/flavours/polyam/styles/admin.scss
+++ b/app/javascript/flavours/polyam/styles/admin.scss
@@ -10,6 +10,13 @@ $content-width: 840px;
   width: 100%;
   min-height: 100vh;
 
+  .icon {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+    margin: 0 2px;
+  }
+
   .sidebar-wrapper {
     min-height: 100vh;
     overflow: hidden;

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -55,9 +55,9 @@
         - if params[:local] == '1'
           = f.button safe_join([fa_icon('save'), t('generic.save_changes')]), name: :update, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([awesome_icon('eye', variant: 'regular'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([material_symbol('visibility', variant: 'regular'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([awesome_icon('eye-slash', variant: 'regular'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([material_symbol('visibility_off', variant: 'regular'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
         = f.button safe_join([fa_icon('power-off'), t('admin.custom_emojis.enable')]), name: :enable, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -55,9 +55,9 @@
         - if params[:local] == '1'
           = f.button safe_join([fa_icon('save'), t('generic.save_changes')]), name: :update, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([fa_icon('eye'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([awesome_icon('eye', variant: 'regular'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([fa_icon('eye-slash'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([awesome_icon('eye-slash', variant: 'regular'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
         = f.button safe_join([fa_icon('power-off'), t('admin.custom_emojis.enable')]), name: :enable, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -57,7 +57,7 @@
   .dashboard__item
     = link_to admin_reports_path, class: 'dashboard__quick-access' do
       %span= t('admin.dashboard.pending_reports_html', count: @pending_reports_count)
-      = fa_icon 'chevron-right fw'
+      = material_symbol 'chevron_right'
 
     = link_to admin_accounts_path(status: 'pending'), class: 'dashboard__quick-access' do
       %span= t('admin.dashboard.pending_users_html', count: @pending_users_count)

--- a/config/initializers/propshaft.rb
+++ b/config/initializers/propshaft.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'images')
+
+# Material Design icons
+Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'material-icons')

--- a/config/initializers/propshaft.rb
+++ b/config/initializers/propshaft.rb
@@ -4,3 +4,6 @@ Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'i
 
 # Material Design icons
 Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'material-icons')
+
+# Font Awesome icons
+Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'awesome-icons')


### PR DESCRIPTION
Proof of concept to deal with upstreams upcoming change of backend icons to material, so I don't forget.

I'm not exactly set on anything yet.
hijacking `material_symbol` to return an awesome icon instead seems like the best solution without merge conflicts and having to override every use of it, but comes with its own set of issues like the different icon names.
I think an additional helper method to "translate" material icon names to awesome icons would help here and keep the code clean enough.