### PR TITLE
Use constant for instance filter instead of magic number

### DIFF
--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -35,7 +35,7 @@ class Api::V2::FiltersController < Api::BaseController
   private
 
   def set_filters
-    @filters = CustomFilter.includes(:keywords, :statuses).where(account_id: [current_account.id, CustomFilter.instance_filter.account_id])
+    @filters = CustomFilter.includes(:keywords, :statuses).where(account_id: [current_account.id, Account::INSTANCE_ACTOR_ID])
   end
 
   def set_filter

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -28,6 +28,8 @@ class CustomFilter < ApplicationRecord
     account
   ).freeze
 
+  INSTANCE_FILTER_ID = -99
+
   include Expireable
   include Redisable
 
@@ -63,9 +65,9 @@ class CustomFilter < ApplicationRecord
   end
 
   def self.instance_filter
-    CustomFilter.find(-99)
+    CustomFilter.find(INSTANCE_FILTER_ID)
   rescue ActiveRecord::RecordNotFound
-    CustomFilter.create!(id: -99, account_id: Account.representative.id, context: VALID_CONTEXTS, phrase: 'Hidden by moderators')
+    CustomFilter.create!(id: INSTANCE_FILTER_ID, account_id: Account.representative.id, context: VALID_CONTEXTS, phrase: 'Hidden by moderators')
   end
 
   def self.cached_filters_for(account_id)

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -67,7 +67,7 @@ class CustomFilter < ApplicationRecord
   def self.instance_filter
     CustomFilter.find(INSTANCE_FILTER_ID)
   rescue ActiveRecord::RecordNotFound
-    CustomFilter.create!(id: INSTANCE_FILTER_ID, account_id: Account.representative.id, context: VALID_CONTEXTS, phrase: 'Hidden by moderators')
+    CustomFilter.create!(id: INSTANCE_FILTER_ID, account_id: Account::INSTANCE_ACTOR_ID, context: VALID_CONTEXTS, phrase: 'Hidden by moderators')
   end
 
   def self.cached_filters_for(account_id)

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -81,7 +81,7 @@ class CustomFilter < ApplicationRecord
         filters_hash[filter.id] = { keywords: Regexp.union(keywords), filter: filter }
       end.to_h
 
-      with_instance_filter = [account_id, CustomFilter.instance_filter.account_id]
+      with_instance_filter = [account_id, Account::INSTANCE_ACTOR_ID]
       scope = CustomFilterStatus.includes(:custom_filter).where(custom_filter: { account_id: with_instance_filter }).where(Arel.sql('expires_at IS NULL OR expires_at > NOW()'))
       scope.to_a.group_by(&:custom_filter).each do |filter, statuses|
         filters_hash[filter.id] ||= { filter: filter }

--- a/app/serializers/rest/filter_serializer.rb
+++ b/app/serializers/rest/filter_serializer.rb
@@ -10,7 +10,7 @@ class REST::FilterSerializer < ActiveModel::Serializer
   end
 
   def title
-    object.id == CustomFilter.instance_filter.id ? I18n.t('filters.instance_filter.title') : object.title
+    object.id == CustomFilter::INSTANCE_FILTER_ID ? I18n.t('filters.instance_filter.title') : object.title
   end
 
   def rules_requested?

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Filters' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.pluck(:id)).to match_array(filters.map { |filter| filter.id.to_s }.push(CustomFilter.instance_filter.id.to_s))
+      expect(body_as_json.pluck(:id)).to match_array(filters.map { |filter| filter.id.to_s })
     end
   end
 


### PR DESCRIPTION
Follow-up to #228 

Add a constant for the instance filter id and use instead actor id constant to create the filter.
This has the benefit of not having to look up the id unnecessarily in the db.

Also uses the new constant in some places as the filter doesn't need to exist in them.

Fixes system specs.