### PR TITLE
[WIP] Make default skin a skin

### DIFF
--- a/app/controllers/concerns/theming_concern.rb
+++ b/app/controllers/concerns/theming_concern.rb
@@ -53,10 +53,10 @@ module ThemingConcern
     pack_data[:preload] = [preloads] if preloads.is_a?(String)
     pack_data[:preload] = preloads if preloads.is_a?(Array)
 
-    if skin != 'default' && data['skin'][skin]
+    if skin != 'system' && data['skin'][skin]
       pack_data[:skin] = skin if data['skin'][skin].include?(pack_name)
     elsif data['pack'][pack_name]['stylesheet']
-      pack_data[:skin] = 'default'
+      pack_data[:skin] = 'system'
     end
 
     pack_data
@@ -81,7 +81,7 @@ module ThemingConcern
     nil
   end
 
-  def resolve_pack_with_common(data, pack_name, skin = 'default')
+  def resolve_pack_with_common(data, pack_name, skin = 'system')
     result = resolve_pack(data, pack_name, skin) || nil_pack(data)
     result[:common] = resolve_pack(data, 'common', skin) if result.delete(:use_common)
     result

--- a/app/javascript/skins/glitch/default/common.scss
+++ b/app/javascript/skins/glitch/default/common.scss
@@ -1,0 +1,1 @@
+@import 'flavours/glitch/styles/index';

--- a/app/javascript/skins/glitch/default/names.yml
+++ b/app/javascript/skins/glitch/default/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    glitch:
+      default: Default

--- a/app/javascript/skins/polyam/default/common.scss
+++ b/app/javascript/skins/polyam/default/common.scss
@@ -1,0 +1,1 @@
+@import 'flavours/polyam/styles/index';

--- a/app/javascript/skins/polyam/default/names.yml
+++ b/app/javascript/skins/polyam/default/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    polyam:
+      default: Default

--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -43,7 +43,7 @@ class Themes
       data['name'] = name
       data['locales'] = locales
       data['screenshot'] = screenshots
-      data['skin'] = { 'default' => [] }
+      data['skin'] = { 'system' => [] }
       result[name] = data
     end
 
@@ -53,7 +53,7 @@ class Themes
       name = pathname.dirname.basename.to_s
       next unless result[name]
 
-      next if skin != 'default' && DISABLED_THEMES.include?(skin)
+      next if skin != 'system' && DISABLED_THEMES.include?(skin)
 
       if pathname.directory?
         pack = []
@@ -65,7 +65,7 @@ class Themes
         pack = ['common']
       end
 
-      result[name]['skin'][skin] = pack if !pack.empty? && skin != 'default'
+      result[name]['skin'][skin] = pack if !pack.empty? && skin != 'system'
     end
 
     @core = core

--- a/app/views/layouts/_theme.html.haml
+++ b/app/views/layouts/_theme.html.haml
@@ -4,7 +4,7 @@
     - pack_path = theme[:flavour] ? "flavours/#{theme[:flavour]}/#{theme[:pack]}" : "core/#{theme[:pack]}"
     = javascript_pack_tag pack_path, crossorigin: 'anonymous'
     - if theme[:skin]
-      - if !theme[:flavour] || theme[:skin] == 'default'
+      - if !theme[:flavour] || theme[:skin] == 'system'
         = stylesheet_pack_tag pack_path, media: 'all', crossorigin: 'anonymous'
       - else
         = stylesheet_pack_tag "skins/#{theme[:flavour]}/#{theme[:skin]}/#{theme[:pack]}", media: 'all', crossorigin: 'anonymous'

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -45,7 +45,7 @@ skinFiles.forEach((skinFile) => {
   let skin = basename(skinFile);
   const name = basename(dirname(skinFile));
   // Skip skin if disabled
-  if (disabled_skins && skin !== 'default' && disabled_skins.includes(skin)) {
+  if (disabled_skins && skin !== 'system' && disabled_skins.includes(skin)) {
     return;
   }
   if (!flavours[name]) {


### PR DESCRIPTION
This is in preparation to vanilla's new system theme.

Makes the default theme an actual theme instead of relying on loading core assets.

Changes some checks for "default" to "system"

This is also more of a proof of concept.
I'm not sure how upstream intends to deal with it.
Another alternative would be to refactor the theming system to support multiple pseudo-skins.
This is however simpler, though I'm not convinced by this.