### PR TITLE
Add FontAwesome icons to admin/settings views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,11 +114,46 @@ module ApplicationHelper
   end
 
   def material_symbol(icon, attributes = {})
+    return awesome_icon(material_to_awesome(icon), attributes) if current_flavour == 'polyam'
+
     inline_svg_tag(
       "400-24px/#{icon}.svg",
       class: %w(icon).concat(attributes[:class].to_s.split),
       role: :img
     )
+  end
+
+  def awesome_icon(icon, attributes = {})
+    inline_svg_tag(
+      "#{attributes[:variant] || 'solid'}/#{icon}.svg",
+      class: %w(icon).concat(attributes[:class].to_s.split),
+      role: :img
+    )
+  end
+
+  def material_to_awesome(icon)
+    icon = icon.chomp('fill')
+
+    case icon
+    when 'add'
+      'plus'
+    when 'content_copy'
+      'copy'
+    when 'close'
+      'xmark'
+    when 'group'
+      'users'
+    when 'person'
+      'user'
+    when 'tag'
+      'hashtag'
+    when 'visibility'
+      'eye'
+    when 'visibility_off'
+      'eye-slash'
+    else
+      icon.tr('_', '-')
+    end
   end
 
   def check_icon

--- a/app/javascript/flavours/polyam/styles/admin.scss
+++ b/app/javascript/flavours/polyam/styles/admin.scss
@@ -10,9 +10,10 @@ $content-width: 840px;
   width: 100%;
   min-height: 100vh;
 
+  // Polyam: smaller icon size compared to upstream
   .icon {
-    width: 16px;
-    height: 16px;
+    width: 13px;
+    height: 13px;
     vertical-align: middle;
     margin: 0 2px;
   }

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -55,9 +55,9 @@
         - if params[:local] == '1'
           = f.button safe_join([fa_icon('save'), t('generic.save_changes')]), name: :update, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([material_symbol('visibility'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([material_symbol('visibility', variant: 'regular'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([material_symbol('visibility_off'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([material_symbol('visibility_off', variant: 'regular'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
         = f.button safe_join([fa_icon('power-off'), t('admin.custom_emojis.enable')]), name: :enable, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -37,5 +37,5 @@
         = t("statuses.visibilities.#{status.visibility}")
       - if status.proper.sensitive?
         ·
-        = material_symbol('visibility_off')
+        = material_symbol('visibility_off', variant: 'regular')
         = t('stream_entries.sensitive_content')

--- a/app/views/admin/status_edits/_status_edit.html.haml
+++ b/app/views/admin/status_edits/_status_edit.html.haml
@@ -26,5 +26,5 @@
 
         - if status_edit.sensitive?
           ·
-          = material_symbol('visibility_off')
+          = material_symbol('visibility_off', variant: 'regular')
           = t('stream_entries.sensitive_content')

--- a/config/initializers/propshaft.rb
+++ b/config/initializers/propshaft.rb
@@ -5,3 +5,6 @@ Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'i
 
 # Material Design icons
 Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'material-icons')
+
+# Font Awesome icons
+Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'awesome-icons')


### PR DESCRIPTION
Lets `material_symbol` return an awesome icon instead of material.

Add helper to replace material names with awesome names.

Adds propshaft config to load Font Awesome icons.

Adds `variant` to some icons