### PR TITLE
Add missing `-` to chomp in `material_to_awesome`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,7 +132,7 @@ module ApplicationHelper
   end
 
   def material_to_awesome(icon)
-    icon = icon.chomp('fill')
+    icon = icon.chomp('-fill')
 
     case icon
     when 'add'


### PR DESCRIPTION
Follow-up to #521 

Some material icon files have `-fill` in their name, which is pointless for font awesome as it is equivalent to "solid".

The `-` was missing which would result in icons like `bell-` being returned.