### PR TITLE
Add missing Font Awesome replacements to `material_to_awesome`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,6 +143,8 @@ module ApplicationHelper
       'xmark'
     when 'group'
       'users'
+    when 'info'
+      'circle-info'
     when 'person'
       'user'
     when 'tag'
@@ -151,6 +153,8 @@ module ApplicationHelper
       'eye'
     when 'visibility_off'
       'eye-slash'
+    when 'warning'
+      'triangle-exclamation'
     else
       icon.tr('_', '-')
     end


### PR DESCRIPTION
Follow-up to #521

Some icons were missed.

Also some icons use the same name, but are an alias not actual file name for FA.