### PR TITLE
Explicitly ignore disabling of required skins

### DIFF
--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -6,7 +6,7 @@ require 'yaml'
 class Themes
   include Singleton
 
-  DISABLED_THEMES = ENV.fetch('DISABLED_SKINS', '').split(/\s*,\s*/)
+  DISABLED_THEMES = ENV.fetch('DISABLED_SKINS', '').split(/\s*,\s*/).delete_if { |s| %w(system default mastodon-light).include?(s) }
 
   THEME_COLORS = {
     dark: '#191b22',
@@ -58,7 +58,7 @@ class Themes
       name = pathname.dirname.basename.to_s
       next unless result[name]
 
-      next if skin != 'default' && skin != 'system' && DISABLED_THEMES.include?(skin)
+      next if DISABLED_THEMES.include?(skin)
 
       if pathname.directory?
         pack = []

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -13,7 +13,7 @@ const flavourFiles = glob.sync('app/javascript/flavours/*/theme.yml');
 const skinFiles = glob.sync('app/javascript/skins/*/*');
 const flavours = {};
 
-const disabled_skins = (env.DISABLED_SKINS || '').split(/\s*,\s*/);
+const disabled_skins = (env.DISABLED_SKINS || '').split(/\s*,\s*/).filter(s => !['default', 'mastodon-light'].includes(s));
 
 const core = function () {
   const coreFile = resolve('app', 'javascript', 'core', 'theme.yml');
@@ -45,7 +45,7 @@ skinFiles.forEach((skinFile) => {
   let skin = basename(skinFile);
   const name = basename(dirname(skinFile));
   // Skip skin if disabled
-  if (disabled_skins && skin !== 'default' && skin !== 'system' && disabled_skins.includes(skin)) {
+  if (disabled_skins.includes(skin)) {
     return;
   }
   if (!flavours[name]) {


### PR DESCRIPTION
Follow-up to #345 

The new system theme requires the default and mastodon-light skin so explicitly delete them from `DISABLED_SKINS` if set.