### PR TITLE
Forbid import of Material icons in polyam flavour

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -285,6 +285,12 @@ module.exports = defineConfig({
           from: ['app/javascript/mastodon/', 'app/javascript/flavours/glitch/'],
           except: ['./api_types'],
           message: 'Import from flavours/polyam/ instead'
+        },
+        // Forbid imports from material-icons in polyam flavour
+        {
+          target: 'app/javascript/flavours/polyam/',
+          from: 'app/javascript/material-icons',
+          message: 'Use awesome-icons instead'
         }]
       }
     ],


### PR DESCRIPTION
Add additional rule to no-restricted-paths to disallow imports from material-icons