### PR TITLE
Add account bio, display name and profile fields limits to instance s…

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -55,6 +55,9 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       accounts: {
         max_featured_tags: FeaturedTag::LIMIT,
         max_pinned_statuses: StatusPinValidator::PIN_LIMIT,
+        max_bio_chars: Account::MAX_NOTE_LENGTH,
+        max_display_name_chars: Account::MAX_DISPLAY_NAME_LENGTH,
+        max_profile_fields: Account::DEFAULT_FIELDS_SIZE,
       },
 
       statuses: {

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -41,7 +41,10 @@ describe 'Instances' do
         configuration: include(
           accounts: include(
             max_featured_tags: FeaturedTag::LIMIT,
-            max_pinned_statuses: StatusPinValidator::PIN_LIMIT
+            max_pinned_statuses: StatusPinValidator::PIN_LIMIT,
+            max_bio_chars: Account::MAX_NOTE_LENGTH,
+            max_display_name_chars: Account::MAX_DISPLAY_NAME_LENGTH,
+            max_profile_fields: Account::DEFAULT_FIELDS_SIZE
           ),
           statuses: include(
             max_characters: StatusLengthValidator::MAX_CHARS,

--- a/spec/serializers/rest/instance_serializer_spec.rb
+++ b/spec/serializers/rest/instance_serializer_spec.rb
@@ -27,5 +27,32 @@ describe REST::InstanceSerializer do
           )
         )
     end
+
+    it 'returns the max profile bio length limit' do
+      expect(serialization.deep_symbolize_keys)
+        .to include(
+          configuration: include(
+            accounts: include(max_bio_chars: Account::MAX_NOTE_LENGTH)
+          )
+        )
+    end
+
+    it 'return the max display name length limit' do
+      expect(serialization.deep_symbolize_keys)
+        .to include(
+          configuration: include(
+            accounts: include(max_display_name_chars: Account::MAX_DISPLAY_NAME_LENGTH)
+          )
+        )
+    end
+
+    it 'returns the profile fields limit' do
+      expect(serialization.deep_symbolize_keys)
+        .to include(
+          configuration: include(
+            accounts: include(max_profile_fields: Account::DEFAULT_FIELDS_SIZE)
+          )
+        )
+    end
   end
 end


### PR DESCRIPTION
…erializer

Requirement for #528 

Exposes `max_bio_chars`, `max_display_name_chars` and `max_profile_fields` to `configuration.accounts`

Vanilla has these hardcoded, but glitch-soc allows these to be configurable, so exposing these to clients makes sense.
Also vanilla has the bad habit of hardcoding these in the frontend (see onboarding)