### PR TITLE
Add name for system theme

### DIFF
--- a/app/javascript/flavours/polyam/names.yml
+++ b/app/javascript/flavours/polyam/names.yml
@@ -6,3 +6,4 @@ en:
   skins:
     polyam:
       default: Default
+      system: Automatic (use system theme)


### PR DESCRIPTION
![Screenshot of skin selector showing name as "Automatic (use system theme)"](https://github.com/polyamspace/mastodon/assets/117664621/3d0b22f0-2aa7-4b24-a4ec-0ad7e658b0d4)

Not sure why upstream didn't do this, but I guess how locales for themes are handled is about to change.