### PR TITLE
Change design of icon buttons in account relationships

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/accounts.scss
+++ b/app/javascript/flavours/polyam/styles/components/accounts.scss
@@ -277,6 +277,29 @@ a .account__avatar {
     width: 23px;
     height: 23px;
   }
+
+  // Polyam: Make buttons more visible
+  .icon-button {
+    border: 1px solid $action-button-color;
+    padding: 5px;
+
+    &:hover,
+    &:active,
+    &:focus {
+      border-color: lighten($action-button-color, 7%);
+    }
+
+    &.active {
+      border-color: $highlight-text-color;
+
+      // Polyam: Change background on hover
+      &:hover,
+      &:focus,
+      &:active {
+        background-color: rgba($highlight-text-color, 0.15);
+      }
+    }
+  }
 }
 
 .account-authorize {


### PR DESCRIPTION
Fixes #502 

Before:
![Screenshot of two follow notifications. Only icon for follow back](https://github.com/polyamspace/mastodon/assets/117664621/6671840c-3606-4f91-b975-837493368838)

![Screenshot of a search result for a muted user.](https://github.com/polyamspace/mastodon/assets/117664621/65f62182-34f5-4a34-915c-893eeddf73fc)

After:
![Screenshot of a follow notification. Icon has a border and the button has additional padding](https://github.com/polyamspace/mastodon/assets/117664621/b50aaf65-f841-4241-967a-22a6c10def35)

![Screenshot of a search result for a muted user. Buttons for unmuting have a border and additional padding](https://github.com/polyamspace/mastodon/assets/117664621/99992258-55ca-49b4-9dac-f3cb4aac072d)


TODO:
- [x] Hover style for active variant
