### PR TITLE
Use `current_theme` for `theme_color_tags`

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,7 +22,7 @@
 
     %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/
-    = theme_color_tags current_skin
+    = theme_color_tags current_theme
     %meta{ name: 'apple-mobile-web-app-capable', content: 'yes' }/
 
     %title= html_title


### PR DESCRIPTION
This should've been overridden in an upstream merge, but wasn't.

Fixes giving `theme_color_tags` unexpected values, so color tags are set correctly for system skin.