### PR TITLE
Add user setting to customize light/dark skins in system skin

### DIFF
--- a/app/controllers/concerns/theming_concern.rb
+++ b/app/controllers/concerns/theming_concern.rb
@@ -19,8 +19,8 @@ module ThemingConcern
   def system_skins
     @system_skins ||= begin
       skins = Themes.instance.skins_for(current_flavour)
-      system_dark = [Setting.system_dark, 'default'].find { |skin| skins.include?(skin) }
-      system_light = [Setting.system_light, 'mastodon-light'].find { |skin| skins.include?(skin) }
+      system_dark = [current_user&.setting_system_dark, Setting.system_dark, 'default'].find { |skin| skins.include?(skin) }
+      system_light = [current_user&.setting_system_light, Setting.system_light, 'mastodon-light'].find { |skin| skins.include?(skin) }
       [system_dark, system_light]
     end
   end

--- a/app/controllers/settings/flavours_controller.rb
+++ b/app/controllers/settings/flavours_controller.rb
@@ -19,7 +19,7 @@ class Settings::FlavoursController < Settings::BaseController
   end
 
   def update
-    current_user.settings.update(flavour: params.require(:flavour), skin: params.dig(:user, :setting_skin))
+    current_user.settings.update(flavour: params.require(:flavour), skin: params.dig(:user, :setting_skin), system_dark: params.dig(:user, :setting_system_dark), system_light: params.dig(:user, :setting_system_light))
     current_user.save
     redirect_to action: 'show', flavour: params[:flavour]
   end

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -67,6 +67,14 @@ module User::HasSettings
     settings['skin']
   end
 
+  def setting_system_dark
+    settings['system_dark']
+  end
+
+  def setting_system_light
+    settings['system_light']
+  end
+
   def setting_display_media
     settings['web.display_media']
   end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -19,6 +19,8 @@ class UserSettings
   setting :default_privacy, default: nil, in: %w(public unlisted private)
   setting :default_content_type, default: -> { ::Setting.default_content_type }
   setting :hide_followers_count, default: false
+  setting :system_dark, default: -> { ::Setting.system_dark }
+  setting :system_light, default: -> { ::Setting.system_light }
 
   setting_inverse_alias :indexable, :noindex
   setting_inverse_alias :show_followers_count, :hide_followers_count

--- a/app/views/settings/flavours/show.html.haml
+++ b/app/views/settings/flavours/show.html.haml
@@ -16,5 +16,25 @@
     .fields-group
       = f.input :setting_skin, collection: Themes.instance.skins_for(@selected), label_method: ->(skin) { I18n.t("skins.#{@selected}.#{skin}", default: skin) }, wrapper: :with_label, include_blank: false
 
+    - if Themes.instance.skins_for(@selected).include?('system')
+      .fields-row
+        .fields-row__column.fields-row__column-6.fields-group
+          = f.input :setting_system_dark,
+                    selected: Themes.instance.skins_for(@selected).include?(f.object.setting_system_dark) ? f.object.setting_system_dark : 'default',
+                    collection: Themes.instance.skins_for(@selected).delete_if { |s| s == 'system' },
+                    label_method: ->(skin) { I18n.t("skins.#{@selected}.#{skin}", default: skin) },
+                    wrapper: :with_label,
+                    include_blank: false,
+                    polyam_only: true
+
+        .fields-row__column.fields-row__column-6.fields-group
+          = f.input :setting_system_light,
+                    selected: Themes.instance.skins_for(@selected).include?(f.object.setting_system_light) ? f.object.setting_system_light : 'mastodon-light',
+                    collection: Themes.instance.skins_for(@selected).delete_if { |s| s == 'system' },
+                    label_method: ->(skin) { I18n.t("skins.#{@selected}.#{skin}", default: skin) },
+                    wrapper: :with_label,
+                    include_blank: false,
+                    polyam_only: true
+
   .actions
     = f.button :button, t('generic.use_this'), type: :submit

--- a/config/locales-polyam/simple_form.en.yml
+++ b/config/locales-polyam/simple_form.en.yml
@@ -4,6 +4,8 @@ en:
     hints:
       defaults:
         setting_enable_rss: Mastodon offers an RSS feed of all public toots by default.
+        setting_system_dark: Skin used as dark skin in system skin
+        setting_system_light: Skin used as light skin in system skin
       form_admin_settings:
         publish_button_text: Overrides the text of the publish button.
         search_preview: Logged out visitors will be able to use the search bar.
@@ -15,6 +17,8 @@ en:
         setting_notification_sound: Notification Sound
         setting_polyam_favourite_modal: Show confirmation dialog before favouriting
         setting_polyam_system_emoji_font: Use system's default font for emojis
+        setting_system_dark: Dark skin
+        setting_system_light: Light skin
         setting_visible_reactions: Number of visible emoji reactions
       form_admin_settings:
         publish_button_text: Publish button text

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -118,6 +118,44 @@ describe ApplicationController do
 
       expect(controller.view_context.system_skins).to eq ['default', 'mastodon-light']
     end
+
+    it 'returns instances\'s default system skins when user is not signed in' do
+      allow(Setting).to receive(:[]).with('skin').and_return 'default'
+      allow(Setting).to receive(:[]).with('flavour').and_return 'vanilla'
+      allow(Setting).to receive(:[]).with('system_dark').and_return 'default'
+      allow(Setting).to receive(:[]).with('system_light').and_return 'mastodon-light'
+
+      expect(controller.view_context.system_skins).to eq ['default', 'mastodon-light']
+    end
+
+    it 'returns instances\'s default system skins when user didn\'t set them' do
+      current_user = Fabricate(:user)
+      sign_in current_user
+
+      allow(Setting).to receive(:[]).with('skin').and_return 'default'
+      allow(Setting).to receive(:[]).with('flavour').and_return 'vanilla'
+      allow(Setting).to receive(:[]).with('system_dark').and_return 'default'
+      allow(Setting).to receive(:[]).with('system_light').and_return 'mastodon-light'
+      allow(Setting).to receive(:[]).with('noindex').and_return false
+      allow(Setting).to receive(:[]).with('show_application').and_return false
+      allow(Setting).to receive(:[]).with('norss').and_return false
+
+      expect(controller.view_context.system_skins).to eq ['default', 'mastodon-light']
+    end
+
+    it 'returns user\'s system skins when set' do
+      current_user = Fabricate(:user)
+      current_user.settings.update(system_dark: 'contrast')
+      current_user.save
+      sign_in current_user
+
+      allow(Setting).to receive(:[]).with('skin').and_return 'default'
+      allow(Setting).to receive(:[]).with('flavour').and_return 'vanilla'
+      allow(Setting).to receive(:[]).with('system_dark').and_return 'default'
+      allow(Setting).to receive(:[]).with('system_light').and_return 'mastodon-light'
+
+      expect(controller.view_context.system_skins).to eq ['contrast', 'mastodon-light']
+    end
   end
 
   context 'with ActionController::RoutingError' do

--- a/spec/controllers/settings/flavours_controller_spec.rb
+++ b/spec/controllers/settings/flavours_controller_spec.rb
@@ -35,5 +35,29 @@ RSpec.describe Settings::FlavoursController do
         expect(user.setting_skin).to eq 'wallpaper'
       end
     end
+
+    describe 'with a user[system_dark] parameter' do
+      before do
+        put :update, params: { flavour: 'schnozzberry', user: { setting_system_dark: 'wallpaper' } }
+
+        user.reload
+      end
+
+      it 'sets the selected system dark skin' do
+        expect(user.setting_system_dark).to eq 'wallpaper'
+      end
+    end
+
+    describe 'with a user[system_light] parameter' do
+      before do
+        put :update, params: { flavour: 'schnozzberry', user: { setting_system_light: 'wallpaper' } }
+
+        user.reload
+      end
+
+      it 'sets the selected system light skin' do
+        expect(user.setting_system_light).to eq 'wallpaper'
+      end
+    end
   end
 end


### PR DESCRIPTION
Allows users to override the admin setting.

Adds new settings to flavour settings.

Settings default to admin setting or default skins if not available in selected flavour.

Preview:
![Screensho flavour and skin settings showing the new settings below the skin selection](https://github.com/polyamspace/mastodon/assets/117664621/821f804d-e818-43cc-b39c-3df356d3685c)
