### PR TITLE
Fix specs adding media to `public/system`

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -80,6 +80,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 end
 
+# Polyam: This is ignored by specs
 Paperclip::Attachment.default_options[:path] = Rails.root.join('spec', 'test_files', ':class', ':id_partition', ':style.:extension')
 
 # Enable fake_data for PAM

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -156,7 +156,7 @@ module Mastodon::CLI
       when :filesystem
         require 'find'
 
-        root_path = ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system')).gsub(':rails_root', Rails.root.to_s)
+        root_path = (ENV['RAILS_ENV'] == 'test' ? File.join('spec', 'test_files') : ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system'))).gsub(':rails_root', Rails.root.to_s)
 
         Find.find(File.join(*[root_path, prefix].compact)) do |path|
           next if File.directory?(path)

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -199,7 +199,7 @@ describe Mastodon::CLI::Media do
     let(:action) { :remove_orphans }
 
     before do
-      FileUtils.mkdir_p Rails.public_path.join('system')
+      FileUtils.mkdir_p Rails.root.join('spec', 'test_files')
     end
 
     context 'without any options' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ RUN_SYSTEM_SPECS = ENV.fetch('RUN_SYSTEM_SPECS', false)
 if RUN_SYSTEM_SPECS
   STREAMING_PORT = ENV.fetch('TEST_STREAMING_PORT', '4020')
   ENV['STREAMING_API_BASE_URL'] = "http://localhost:#{STREAMING_PORT}"
+else
+  # Fix specs writing to public/system
+  ENV['PAPERCLIP_ROOT_PATH'] ||= File.join('spec', 'test_files')
 end
 
 require File.expand_path('../config/environment', __dir__)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,9 +8,6 @@ RUN_SYSTEM_SPECS = ENV.fetch('RUN_SYSTEM_SPECS', false)
 if RUN_SYSTEM_SPECS
   STREAMING_PORT = ENV.fetch('TEST_STREAMING_PORT', '4020')
   ENV['STREAMING_API_BASE_URL'] = "http://localhost:#{STREAMING_PORT}"
-else
-  # Fix specs writing to public/system
-  ENV['PAPERCLIP_ROOT_PATH'] ||= File.join('spec', 'test_files')
 end
 
 require File.expand_path('../config/environment', __dir__)
@@ -107,6 +104,10 @@ RSpec.configure do |config|
     else
       Sidekiq::Testing.fake!
     end
+
+    # Polyam: Fix specs writing to public/system
+    Paperclip::Attachment.default_options[:path] = File.join(ENV.fetch('PAPERCLIP_ROOT_PATH', File.join('spec', 'test_files')), ':prefix_path:class', ':attachment', ':id_partition', ':style', ':filename') unless example.metadata[:type] == :system
+
     example.run
   end
 


### PR DESCRIPTION
`config/environment/test.rb` already defines `spec/test_files` as root path, but this seems to be overridden by `config/initializers/paperclip.rb`

This caused media uploads from specs being left in `public/system` after ran locally.