### PR TITLE
Fix missing param in `followAccountFail`

### DIFF
--- a/app/javascript/flavours/polyam/actions/accounts.js
+++ b/app/javascript/flavours/polyam/actions/accounts.js
@@ -166,7 +166,7 @@ export function followAccount(id, options = { reblogs: true }) {
     api().post(`/api/v1/accounts/${id}/follow`, options).then(response => {
       dispatch(followAccountSuccess({ relationship: response.data, alreadyFollowing }));
     }).catch(error => {
-      dispatch(followAccountFail({ error, locked }));
+      dispatch(followAccountFail({ id, error, locked }));
     });
   };
 }


### PR DESCRIPTION
Follow-up to #316 

Fixes missed change in f6476d7196165143ee81cbd4eec6ef626f84a607