### PR TITLE
Fix typo of `identity` in poll component

### DIFF
--- a/app/javascript/flavours/polyam/components/poll.jsx
+++ b/app/javascript/flavours/polyam/components/poll.jsx
@@ -40,7 +40,7 @@ const makeEmojiMap = record => record.get('emojis').reduce((obj, emoji) => {
 
 class Poll extends ImmutablePureComponent {
   static propTypes = {
-    identitiy: identityContextPropShape,
+    identity: identityContextPropShape,
     poll: ImmutablePropTypes.map,
     lang: PropTypes.string,
     intl: PropTypes.object.isRequired,


### PR DESCRIPTION
Follow-up to #558

Fixes typo in bd8b508c31e9ce7ed7b570acb13fc75b150c9521