### PR TITLE
Fix showing fediversary banner on registration day

### DIFF
--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -146,7 +146,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   def anniversary
     now = Time.now.utc
-    object.created_at.month == now.month && object.created_at.day == now.day
+    object.created_at.month == now.month && object.created_at.day == now.day && object.created_at.year != now.year
   end
 
   def roles


### PR DESCRIPTION
The previous check returned true for newly created accounts resulting in the banner showing "it's usernames 0th fediversary".

This adds an additional condition to not show the banner if the current year matches the creation year.