### PR TITLE
Fix ffmpeg version check

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -98,7 +98,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ffmpeg_version
-    version = `ffmpeg -version`.match(/ffmpeg version ([\d\.]+)/)[1]
+    version = `ffmpeg -version`.match(/ffmpeg version ([\w\d\.-]+) (?=Copyright)/)[1]
 
     {
       key: 'ffmpeg',


### PR DESCRIPTION
Follow-up to #588 (4a5442edaa5d598eea969ac023dc394761f38d7b)

`ffmpeg -version` can output versions that differ from a simple number version, which throws a NoMethodError and results in the component not loading.

Instead match any version string that could be returned.