### PR TITLE
Don't rely on capture group in version check regex

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -85,7 +85,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   def imagemagick_version
     return if Rails.configuration.x.use_vips
 
-    version = `convert -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
+    version = `convert -version`.match(/(?<=Version: ImageMagick) [\d\.]+/).to_s
 
     {
       key: 'imagemagick',
@@ -98,7 +98,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ffmpeg_version
-    version = `ffmpeg -version`.match(/ffmpeg version ([\w\d\.-]+) (?=Copyright)/)[1]
+    version = `ffmpeg -version`.match(/(?<=ffmpeg version) [\w\d\.-]+/).to_s
 
     {
       key: 'ffmpeg',


### PR DESCRIPTION
Follow-up to #590

When the version strings are in an unexpected format, the match is nil, which throws an NoMethodError, when trying to access the capture group.

This changes the regex to not rely on a capture group, which results in an empty string instead when nothing is matched.

This isn't ideal either, but far better than the current behavior.