### PR TITLE
Fix PropType of `children` in CheckBoxWithLabel

### DIFF
--- a/app/javascript/flavours/polyam/features/notifications/components/checkbox_with_label.jsx
+++ b/app/javascript/flavours/polyam/features/notifications/components/checkbox_with_label.jsx
@@ -26,6 +26,6 @@ export const CheckboxWithLabel = ({ checked, disabled, children, onChange }) => 
 CheckboxWithLabel.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
-  children: PropTypes.children,
+  children: PropTypes.node,
   onChange: PropTypes.func,
 };


### PR DESCRIPTION
type "children" doesn't exist and throws an error in dev env