### PR TITLE
Remove additional `/` from notification policy requests

### DIFF
--- a/app/javascript/flavours/polyam/api/notification_policies.ts
+++ b/app/javascript/flavours/polyam/api/notification_policies.ts
@@ -2,9 +2,9 @@ import { apiRequest } from 'flavours/polyam/api';
 import type { NotificationPolicyJSON } from 'mastodon/api_types/notification_policies';
 
 export const apiGetNotificationPolicy = () =>
-  apiRequest<NotificationPolicyJSON>('GET', '/v1/notifications/policy');
+  apiRequest<NotificationPolicyJSON>('GET', 'v1/notifications/policy');
 
 export const apiUpdateNotificationsPolicy = (
   policy: Partial<NotificationPolicyJSON>,
 ) =>
-  apiRequest<NotificationPolicyJSON>('PUT', '/v1/notifications/policy', policy);
+  apiRequest<NotificationPolicyJSON>('PUT', 'v1/notifications/policy', policy);


### PR DESCRIPTION
Follow-up to #593 (d558dfd77dc4f64d3a633efcfc0683ee603a1520)

`apiRequest` already adds a `/` after "/api", which results in the requests being `/api//v1/notifications/policy`

That still worked somehow, but I'd rather have correct URLs