### PR TITLE
Fix accidental import from mastodon in notification policy

### DIFF
--- a/app/javascript/flavours/polyam/api/notification_policies.ts
+++ b/app/javascript/flavours/polyam/api/notification_policies.ts
@@ -1,5 +1,5 @@
 import { apiRequest } from 'flavours/polyam/api';
-import type { NotificationPolicyJSON } from 'mastodon/api_types/notification_policies';
+import type { NotificationPolicyJSON } from 'flavours/polyam/api_types/notification_policies';
 
 export const apiGetNotificationPolicy = () =>
   apiRequest<NotificationPolicyJSON>('GET', 'v1/notifications/policy');


### PR DESCRIPTION
This was caused by a now unneeded exception for restricted paths.