### PR TITLE
Save confirmation modal strings for follow request

### DIFF
--- a/app/javascript/flavours/polyam/locales/af.json
+++ b/app/javascript/flavours/polyam/locales/af.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Herroep versoek",
+  "confirmations.cancel_follow_request.message": "Is jy seker jy wil jou versoek om {name} te volg, terugtrek?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/an.json
+++ b/app/javascript/flavours/polyam/locales/an.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar solicitut",
+  "confirmations.cancel_follow_request.message": "Yes seguro que deseyas retirar la tuya solicitut pa seguir a {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ar.json
+++ b/app/javascript/flavours/polyam/locales/ar.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "إلغاء الطلب",
+  "confirmations.cancel_follow_request.message": "متأكد من أنك تريد إلغاء طلب متابعتك لـ {name}؟",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "حساس",

--- a/app/javascript/flavours/polyam/locales/ast.json
+++ b/app/javascript/flavours/polyam/locales/ast.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirala",
+  "confirmations.cancel_follow_request.message": "¿De xuru que quies retirar la solicitú pa siguir a {name}?",
   "footer.documentation": "Documentación",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/be.json
+++ b/app/javascript/flavours/polyam/locales/be.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Скасаваць запыт",
+  "confirmations.cancel_follow_request.message": "Сапраўды хочаце скасаваць свой запыт на падпіску на {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/bg.json
+++ b/app/javascript/flavours/polyam/locales/bg.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Оттегляне на заявката",
+  "confirmations.cancel_follow_request.message": "Наистина ли искате да оттеглите заявката си за последване на {name}?",
   "footer.documentation": "Документация",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/bn.json
+++ b/app/javascript/flavours/polyam/locales/bn.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "অনুরোধ বাতিল করুন",
+  "confirmations.cancel_follow_request.message": "আপনি কি নিশ্চিত যে আপনি {name} কে অনুসরণ করার অনুরোধ প্রত্যাহার করতে চান?",
   "footer.documentation": "নথিপত্র",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/br.json
+++ b/app/javascript/flavours/polyam/locales/br.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Nullañ ar reked",
+  "confirmations.cancel_follow_request.message": "Ha sur oc'h e fell deoc'h nullañ ho reked evit heuliañ {name} ?",
   "footer.documentation": "Teuliadur",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/bs.json
+++ b/app/javascript/flavours/polyam/locales/bs.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ca.json
+++ b/app/javascript/flavours/polyam/locales/ca.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar la sol·licitud",
+  "confirmations.cancel_follow_request.message": "Segur que vols retirar la sol·licitud de seguiment de {name}?",
   "footer.documentation": "Documentació",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ckb.json
+++ b/app/javascript/flavours/polyam/locales/ckb.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "داواکاری کشانەوە",
+  "confirmations.cancel_follow_request.message": "ئایا دڵنیای کە دەتەوێت داواکارییەکەت بۆ شوێنکەوتنی {ناو} بکشێنیتەوە؟",
   "footer.documentation": "بەڵگەنامە",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/co.json
+++ b/app/javascript/flavours/polyam/locales/co.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Ducumentazione",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/cs.json
+++ b/app/javascript/flavours/polyam/locales/cs.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Zrušit žádost",
+  "confirmations.cancel_follow_request.message": "Opravdu chcete zrušit svou žádost o sledování {name}?",
   "footer.documentation": "Dokumentace",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Citlivý obsah",

--- a/app/javascript/flavours/polyam/locales/cy.json
+++ b/app/javascript/flavours/polyam/locales/cy.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Tynnu'r cais yn ôl",
+  "confirmations.cancel_follow_request.message": "Ydych chi'n siŵr eich bod am dynnu'ch cais i ddilyn {name} yn ôl?",
   "footer.documentation": "Dogfennaeth",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/da.json
+++ b/app/javascript/flavours/polyam/locales/da.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Annullér anmodning",
+  "confirmations.cancel_follow_request.message": "Er du sikker på, at anmodningen om at følge {name} skal annulleres?",
   "footer.documentation": "Dokumentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/de.json
+++ b/app/javascript/flavours/polyam/locales/de.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Anfrage zurückziehen",
+  "confirmations.cancel_follow_request.message": "Möchtest du deine Anfrage, {name} zu folgen, wirklich zurückziehen?",
   "footer.documentation": "Dokumentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Empfindlich",

--- a/app/javascript/flavours/polyam/locales/el.json
+++ b/app/javascript/flavours/polyam/locales/el.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Απόσυρση αιτήματος",
+  "confirmations.cancel_follow_request.message": "Είσαι σίγουρος/η ότι θέλεις να αποσύρεις το αίτημά σου να ακολουθείς τον/την {name};",
   "footer.documentation": "Τεκμηρίωση",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/en-GB.json
+++ b/app/javascript/flavours/polyam/locales/en-GB.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/eo.json
+++ b/app/javascript/flavours/polyam/locales/eo.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Eksigi peton",
+  "confirmations.cancel_follow_request.message": "Ĉu vi certas ke vi volas eksigi vian peton por sekvi {name}?",
   "footer.documentation": "Dokumentado",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/es-AR.json
+++ b/app/javascript/flavours/polyam/locales/es-AR.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar solicitud",
+  "confirmations.cancel_follow_request.message": "¿Estás seguro que querés retirar tu solicitud para seguir a {name}?",
   "footer.documentation": "Documentación",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensible",

--- a/app/javascript/flavours/polyam/locales/es-MX.json
+++ b/app/javascript/flavours/polyam/locales/es-MX.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar solicitud",
+  "confirmations.cancel_follow_request.message": "¿Estás seguro de que deseas retirar tu solicitud para seguir a {name}?",
   "footer.documentation": "Documentación",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensible",

--- a/app/javascript/flavours/polyam/locales/es.json
+++ b/app/javascript/flavours/polyam/locales/es.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar solicitud",
+  "confirmations.cancel_follow_request.message": "¿Estás seguro de que deseas retirar tu solicitud para seguir a {name}?",
   "footer.documentation": "Documentación",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensible",

--- a/app/javascript/flavours/polyam/locales/et.json
+++ b/app/javascript/flavours/polyam/locales/et.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Tühista taotlus",
+  "confirmations.cancel_follow_request.message": "Oled kindel, et soovid kasutaja {name} jälgimistaotluse tagasi võtta?",
   "footer.documentation": "Dokumentatsioon",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/eu.json
+++ b/app/javascript/flavours/polyam/locales/eu.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Baztertu eskaera",
+  "confirmations.cancel_follow_request.message": "Ziur {name} jarraitzeko eskaera bertan behera utzi nahi duzula?",
   "footer.documentation": "Dokumentazioa",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/fa.json
+++ b/app/javascript/flavours/polyam/locales/fa.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "رد کردن درخواست",
+  "confirmations.cancel_follow_request.message": "مطمئنید که می خواهید درخواست پی‌گیری {name} را لغو کنید؟",
   "footer.documentation": "مستندات",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/fi.json
+++ b/app/javascript/flavours/polyam/locales/fi.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Peruuta pyyntö",
+  "confirmations.cancel_follow_request.message": "Haluatko varmasti perua pyyntösi seurata käyttäjätiliä {name}?",
   "footer.documentation": "Käyttöohjeet",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/fil.json
+++ b/app/javascript/flavours/polyam/locales/fil.json
@@ -25,6 +25,8 @@
   "account_note.glitch_placeholder": "No comment provided",
   "account_note.save": "Save",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Bawiin ang kahilingan",
+  "confirmations.cancel_follow_request.message": "Sigurdo ka bang gusto mong bawiin ang kahilingang sundan si/ang {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/fo.json
+++ b/app/javascript/flavours/polyam/locales/fo.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Tak umbønina aftur",
+  "confirmations.cancel_follow_request.message": "Er tað tilætlað, at tú tekur umbønina at fylgja {name} aftur?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/fr-CA.json
+++ b/app/javascript/flavours/polyam/locales/fr-CA.json
@@ -24,6 +24,8 @@
   "account_note.glitch_placeholder": "No comment provided",
   "account_note.save": "Save",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Retirer cette demande",
+  "confirmations.cancel_follow_request.message": "Êtes-vous sûr de vouloir retirer votre demande pour suivre {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensible",

--- a/app/javascript/flavours/polyam/locales/fr.json
+++ b/app/javascript/flavours/polyam/locales/fr.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirer la demande",
+  "confirmations.cancel_follow_request.message": "Êtes-vous sûr de vouloir retirer votre demande pour suivre {name} ?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensible",

--- a/app/javascript/flavours/polyam/locales/fy.json
+++ b/app/javascript/flavours/polyam/locales/fy.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Fersyk annulearje",
+  "confirmations.cancel_follow_request.message": "Binne jo wis dat jo jo fersyk om {name} te folgjen annulearje wolle?",
   "footer.documentation": "Dokumintaasje",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ga.json
+++ b/app/javascript/flavours/polyam/locales/ga.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Éirigh as iarratas",
+  "confirmations.cancel_follow_request.message": "An bhfuil tú cinnte gur mhaith leat éirigh as an iarratas leanta {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/gd.json
+++ b/app/javascript/flavours/polyam/locales/gd.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Cuir d’ iarrtas dhan dàrna taobh",
+  "confirmations.cancel_follow_request.message": "A bheil thu cinnteach gu bheil thu airson d’ iarrtas airson {name} a leantainn a chur dhan dàrna taobh?",
   "footer.documentation": "Docamaideadh",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/gl.json
+++ b/app/javascript/flavours/polyam/locales/gl.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar solicitude",
+  "confirmations.cancel_follow_request.message": "Tes a certeza de querer retirar a solicitude para seguir a {name}?",
   "footer.documentation": "Documentación",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/he.json
+++ b/app/javascript/flavours/polyam/locales/he.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "ויתור על בקשה",
+  "confirmations.cancel_follow_request.message": "לבטל את בקשת המעקב אחרי {name}?",
   "footer.documentation": "תיעוד",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/hi.json
+++ b/app/javascript/flavours/polyam/locales/hi.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "रिक्वेस्ट वापस लें",
+  "confirmations.cancel_follow_request.message": "क्या आप सुनिश्चित है की आप {name} का फॉलो रिक्वेस्ट वापिस लेना चाहते हैं?",
   "footer.documentation": "प्रलेखन",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/hr.json
+++ b/app/javascript/flavours/polyam/locales/hr.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Povuci zahtjev",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Dokumentacija",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/hu.json
+++ b/app/javascript/flavours/polyam/locales/hu.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Kérés visszavonása",
+  "confirmations.cancel_follow_request.message": "Biztos, hogy visszavonod a(z) {name} felhasználóra vonatkozó követési kérésedet?",
   "footer.documentation": "Dokumentáció",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/hy.json
+++ b/app/javascript/flavours/polyam/locales/hy.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Կասեցնել հայցը",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Փաստաթղթեր",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ia.json
+++ b/app/javascript/flavours/polyam/locales/ia.json
@@ -25,6 +25,8 @@
   "account_note.glitch_placeholder": "No comment provided",
   "account_note.save": "Save",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Retirar requesta",
+  "confirmations.cancel_follow_request.message": "Es tu secur que tu vole retirar tu requesta de sequer {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/id.json
+++ b/app/javascript/flavours/polyam/locales/id.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Batalkan permintaan",
+  "confirmations.cancel_follow_request.message": "Apakah Anda yakin ingin membatalkan permintaan Anda untuk mengikuti {name}?",
   "footer.documentation": "Dokumentasi",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ie.json
+++ b/app/javascript/flavours/polyam/locales/ie.json
@@ -25,6 +25,8 @@
   "account_note.glitch_placeholder": "No comment provided",
   "account_note.save": "Save",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Retraer petition",
+  "confirmations.cancel_follow_request.message": "Esque tu vermen vole retraer tui petition sequer {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ig.json
+++ b/app/javascript/flavours/polyam/locales/ig.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/io.json
+++ b/app/javascript/flavours/polyam/locales/io.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Desendez demando",
+  "confirmations.cancel_follow_request.message": "Ka vu certe volas desendar vua demando di sequar {name}?",
   "footer.documentation": "Dokumentajo",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/is.json
+++ b/app/javascript/flavours/polyam/locales/is.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Taka beiðni til baka",
+  "confirmations.cancel_follow_request.message": "Ertu viss um að þú viljir taka til baka beiðnina um að fylgjast með {name}?",
   "footer.documentation": "Hjálparskjöl",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/it.json
+++ b/app/javascript/flavours/polyam/locales/it.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Annulla la richiesta",
+  "confirmations.cancel_follow_request.message": "Sei sicuro di voler annullare la tua richiesta per seguire {name}?",
   "footer.documentation": "Documentazione",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ja.json
+++ b/app/javascript/flavours/polyam/locales/ja.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "フォローリクエストを取り消す",
+  "confirmations.cancel_follow_request.message": "{name}に対するフォローリクエストを取り消しますか?",
   "footer.documentation": "ドキュメント",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "閲覧注意",

--- a/app/javascript/flavours/polyam/locales/ka.json
+++ b/app/javascript/flavours/polyam/locales/ka.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "დოკუმენტაცია",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/kab.json
+++ b/app/javascript/flavours/polyam/locales/kab.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Amnir",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/kk.json
+++ b/app/javascript/flavours/polyam/locales/kk.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Құжаттама",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/kn.json
+++ b/app/javascript/flavours/polyam/locales/kn.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ko.json
+++ b/app/javascript/flavours/polyam/locales/ko.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "요청 삭제",
+  "confirmations.cancel_follow_request.message": "정말 {name}님에 대한 팔로우 요청을 취소하시겠습니까?",
   "footer.documentation": "문서",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "민감함",

--- a/app/javascript/flavours/polyam/locales/ku.json
+++ b/app/javascript/flavours/polyam/locales/ku.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Daxwazê vekişîne",
+  "confirmations.cancel_follow_request.message": "Tu dixwazî ​​daxwaza xwe ya şopandina {name} vekşînî?",
   "footer.documentation": "Pelbend",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/kw.json
+++ b/app/javascript/flavours/polyam/locales/kw.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Dogvenva",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/la.json
+++ b/app/javascript/flavours/polyam/locales/la.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/lad.json
+++ b/app/javascript/flavours/polyam/locales/lad.json
@@ -25,6 +25,8 @@
   "account_note.glitch_placeholder": "No comment provided",
   "account_note.save": "Save",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Anula solisitud",
+  "confirmations.cancel_follow_request.message": "Estas siguro ke keres anular tu solisitud de segir a {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/lt.json
+++ b/app/javascript/flavours/polyam/locales/lt.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Atšaukti prašymą",
+  "confirmations.cancel_follow_request.message": "Ar tikrai nori atšaukti savo prašymą sekti {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/lv.json
+++ b/app/javascript/flavours/polyam/locales/lv.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Atsaukt pieprasījumu",
+  "confirmations.cancel_follow_request.message": "Vai tiešām vēlies atsaukt pieprasījumu sekot {name}?",
   "footer.documentation": "Dokumentācija",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/mk.json
+++ b/app/javascript/flavours/polyam/locales/mk.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Документација",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ml.json
+++ b/app/javascript/flavours/polyam/locales/ml.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "രേഖാ സമാഹരണം",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/mr.json
+++ b/app/javascript/flavours/polyam/locales/mr.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ms.json
+++ b/app/javascript/flavours/polyam/locales/ms.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Tarik balik permintaan",
+  "confirmations.cancel_follow_request.message": "Adakah anda pasti ingin menarik balik permintaan anda untuk mengikut {name}?",
   "footer.documentation": "Pendokumenan",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/my.json
+++ b/app/javascript/flavours/polyam/locales/my.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "ပန်ကြားချက်ကို ပယ်ဖျက်မည်",
+  "confirmations.cancel_follow_request.message": "{name} ကို စောင့်ကြည့်ခြင်းအားပယ်ဖျက်ရန် သေချာပါသလား။",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ne.json
+++ b/app/javascript/flavours/polyam/locales/ne.json
@@ -25,6 +25,8 @@
   "account_note.glitch_placeholder": "No comment provided",
   "account_note.save": "Save",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/nl.json
+++ b/app/javascript/flavours/polyam/locales/nl.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Verzoek annuleren",
+  "confirmations.cancel_follow_request.message": "Weet je zeker dat je jouw verzoek om {name} te volgen wilt annuleren?",
   "footer.documentation": "Documentatie",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/nn.json
+++ b/app/javascript/flavours/polyam/locales/nn.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Trekk attende førespurnad",
+  "confirmations.cancel_follow_request.message": "Er du sikker på at du vil trekkje attende førespurnaden din om å fylgje {name}?",
   "footer.documentation": "Dokumentasjon",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/no.json
+++ b/app/javascript/flavours/polyam/locales/no.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Trekk tilbake forespørsel",
+  "confirmations.cancel_follow_request.message": "Er du sikker på at du vil trekke tilbake forespørselen din for å følge {name}?",
   "footer.documentation": "Dokumentasjon",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/oc.json
+++ b/app/javascript/flavours/polyam/locales/oc.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar la demandar",
+  "confirmations.cancel_follow_request.message": "Volètz vertadièrament retirar la demanda de seguiment de {name} ?",
   "footer.documentation": "Documentacion",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/pa.json
+++ b/app/javascript/flavours/polyam/locales/pa.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/pl.json
+++ b/app/javascript/flavours/polyam/locales/pl.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Wycofaj prośbę",
+  "confirmations.cancel_follow_request.message": "Czy na pewno chcesz wycofać prośbę o możliwość obserwowania {name}?",
   "footer.documentation": "Dokumentacja",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Zawartość wrażliwa",

--- a/app/javascript/flavours/polyam/locales/pt-BR.json
+++ b/app/javascript/flavours/polyam/locales/pt-BR.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Cancelar a solicitação",
+  "confirmations.cancel_follow_request.message": "Tem certeza de que deseja cancelar seu pedido para seguir {name}?",
   "footer.documentation": "Documentação",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensível",

--- a/app/javascript/flavours/polyam/locales/pt-PT.json
+++ b/app/javascript/flavours/polyam/locales/pt-PT.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retirar pedido",
+  "confirmations.cancel_follow_request.message": "Tem a certeza que pretende retirar o pedido para seguir {name}?",
   "footer.documentation": "Documentação",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ro.json
+++ b/app/javascript/flavours/polyam/locales/ro.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Retrage cererea",
+  "confirmations.cancel_follow_request.message": "Sunteți sigur că doriți să retrageți cererea dvs. de urmărire pentru {name}?",
   "footer.documentation": "Documentație",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ru.json
+++ b/app/javascript/flavours/polyam/locales/ru.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Отменить запрос",
+  "confirmations.cancel_follow_request.message": "Вы уверены, что хотите отозвать свой запрос на подписку {name}?",
   "footer.documentation": "Документация",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ry.json
+++ b/app/javascript/flavours/polyam/locales/ry.json
@@ -19,6 +19,8 @@
   "account.request_follow": "Request follow",
   "account.unmute_notifications": "Unmute notifications from @{name}",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sa.json
+++ b/app/javascript/flavours/polyam/locales/sa.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "अनुरोधनमपनय",
+  "confirmations.cancel_follow_request.message": "{name} अनुसरणस्यानुरोधमपनेतुं दृढीकृतं वा?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sc.json
+++ b/app/javascript/flavours/polyam/locales/sc.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentatzione",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sco.json
+++ b/app/javascript/flavours/polyam/locales/sco.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Tak back yer request",
+  "confirmations.cancel_follow_request.message": "Ye shair thit ye'r wantin tae tak back yer request fir tae follae {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/si.json
+++ b/app/javascript/flavours/polyam/locales/si.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "ප්‍රලේඛනය",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sk.json
+++ b/app/javascript/flavours/polyam/locales/sk.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Stiahnuť žiadosť",
+  "confirmations.cancel_follow_request.message": "Určite chcete stiahnuť svoju žiadosť o sledovanie {name}?",
   "footer.documentation": "Dokumentácia",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sl.json
+++ b/app/javascript/flavours/polyam/locales/sl.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Umakni zahtevo",
+  "confirmations.cancel_follow_request.message": "Ali ste prepričani, da želite umakniti svojo zahtevo, da bi sledili {name}?",
   "footer.documentation": "Dokumentacija",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sq.json
+++ b/app/javascript/flavours/polyam/locales/sq.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Tërhiqeni mbrapsht kërkesën",
+  "confirmations.cancel_follow_request.message": "Jeni i sigurt se doni të tërhiqni mbrapsht kërkesën tuaj për ndjekje të {name}?",
   "footer.documentation": "Dokumentim",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sr-Latn.json
+++ b/app/javascript/flavours/polyam/locales/sr-Latn.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Povuci zahtev",
+  "confirmations.cancel_follow_request.message": "Da li ste sigurni da želite da povučete zahtev da pratite {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sr.json
+++ b/app/javascript/flavours/polyam/locales/sr.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Повуци захтев",
+  "confirmations.cancel_follow_request.message": "Да ли сте сигурни да желите да повучете захтев да пратите {name}?",
   "footer.documentation": "Документација",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/sv.json
+++ b/app/javascript/flavours/polyam/locales/sv.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Återkalla förfrågan",
+  "confirmations.cancel_follow_request.message": "Är du säker på att du vill återkalla din begäran om att följa {name}?",
   "footer.documentation": "Dokumentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/szl.json
+++ b/app/javascript/flavours/polyam/locales/szl.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ta.json
+++ b/app/javascript/flavours/polyam/locales/ta.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "ஆவணங்கள்",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/tai.json
+++ b/app/javascript/flavours/polyam/locales/tai.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/te.json
+++ b/app/javascript/flavours/polyam/locales/te.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "డాక్యుమెంటేషన్",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/th.json
+++ b/app/javascript/flavours/polyam/locales/th.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "ถอนคำขอ",
+  "confirmations.cancel_follow_request.message": "คุณแน่ใจหรือไม่ว่าต้องการถอนคำขอเพื่อติดตาม {name} ของคุณ?",
   "footer.documentation": "เอกสารประกอบ",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/tok.json
+++ b/app/javascript/flavours/polyam/locales/tok.json
@@ -19,6 +19,8 @@
   "account.request_follow": "Request follow",
   "account.unmute_notifications": "Unmute notifications from @{name}",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "o weka e wile sina",
+  "confirmations.cancel_follow_request.message": "sina awen ala awen wile weka e wile kute sina lon {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/tr.json
+++ b/app/javascript/flavours/polyam/locales/tr.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "İsteği geri çek",
+  "confirmations.cancel_follow_request.message": "{name} kişisini takip etme isteğini geri çekmek istediğinden emin misin?",
   "footer.documentation": "Belgeler",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/tt.json
+++ b/app/javascript/flavours/polyam/locales/tt.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Сорауны баш тарту",
+  "confirmations.cancel_follow_request.message": "Сез абонемент соравыгызны кире кайтарырга телисез {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/ug.json
+++ b/app/javascript/flavours/polyam/locales/ug.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/uk.json
+++ b/app/javascript/flavours/polyam/locales/uk.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Відкликати запит",
+  "confirmations.cancel_follow_request.message": "Ви дійсно бажаєте відкликати запит на стеження за {name}?",
   "footer.documentation": "Документація",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Чутливі",

--- a/app/javascript/flavours/polyam/locales/ur.json
+++ b/app/javascript/flavours/polyam/locales/ur.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "اسناد",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/uz.json
+++ b/app/javascript/flavours/polyam/locales/uz.json
@@ -25,6 +25,8 @@
   "account_note.glitch_placeholder": "No comment provided",
   "account_note.save": "Save",
   "column.reacted_by": "Reacted by",
+  "confirmations.cancel_follow_request.confirm": "Bekor qilish",
+  "confirmations.cancel_follow_request.message": "Haqiqatan ham {name}ga obuna boʻlish soʻrovingizni qaytarib olmoqchimisiz?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/vi.json
+++ b/app/javascript/flavours/polyam/locales/vi.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Thu hồi yêu cầu",
+  "confirmations.cancel_follow_request.message": "Bạn có chắc muốn thu hồi yêu cầu theo dõi của bạn với {name}?",
   "footer.documentation": "Tài liệu",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/zgh.json
+++ b/app/javascript/flavours/polyam/locales/zgh.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "Withdraw request",
+  "confirmations.cancel_follow_request.message": "Are you sure you want to withdraw your request to follow {name}?",
   "footer.documentation": "Documentation",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/zh-CN.json
+++ b/app/javascript/flavours/polyam/locales/zh-CN.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "撤回请求",
+  "confirmations.cancel_follow_request.message": "确定撤回关注 {name} 的请求吗？",
   "footer.documentation": "文档",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "敏感内容",

--- a/app/javascript/flavours/polyam/locales/zh-HK.json
+++ b/app/javascript/flavours/polyam/locales/zh-HK.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "撤回請求",
+  "confirmations.cancel_follow_request.message": "您確定要撤回追蹤 {name} 的請求嗎？",
   "footer.documentation": "文件",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "Sensitive",

--- a/app/javascript/flavours/polyam/locales/zh-TW.json
+++ b/app/javascript/flavours/polyam/locales/zh-TW.json
@@ -27,6 +27,8 @@
   "column.reacted_by": "Reacted by",
   "compose_form.alt_text_warning.header": "Your attachments are missing a description!",
   "compose_form.alt_text_warning.message": "Descriptions are for users who are deaf, hard of hearing, blind, or have low vision that prevent them from seeing or hearing an image, video, or audio file. It's recommended that you provide a description for all attached media files so everyone can enjoy using Mastodon.",
+  "confirmations.cancel_follow_request.confirm": "收回跟隨請求",
+  "confirmations.cancel_follow_request.message": "您確定要收回跟隨 {name} 的請求嗎？",
   "footer.documentation": "文件",
   "home.column_settings.show_threads": "Show threads",
   "media_gallery.sensitive": "敏感",


### PR DESCRIPTION
These are currently unused upstream and I expect them to get deleted sometime soon.

Also `confirmations.cancel_follow_request.confirm` would be a good replacement for the the current "Cancel Follow" text