### PR TITLE
Change design of alt-text-modal

### DIFF
--- a/app/javascript/flavours/glitch/components/status.jsx
+++ b/app/javascript/flavours/glitch/components/status.jsx
@@ -425,7 +425,7 @@ class Status extends ImmutablePureComponent {
   handleAltClick = (index) => {
     const { status } = this.props;
 
-    this.props.onOpenAltText(status.get('id'), status.getIn(['media_attachments', index ? index : 0]));
+    this.props.onOpenAltText(status.getIn(['media_attachments', index ? index : 0]));
   };
 
   handleHotkeyOpenMedia = e => {

--- a/app/javascript/flavours/glitch/containers/status_container.js
+++ b/app/javascript/flavours/glitch/containers/status_container.js
@@ -255,8 +255,8 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }));
   },
 
-  onOpenAltText (statusId, media) {
-    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { statusId, media }}));
+  onOpenAltText (media) {
+    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { media }}));
   },
 
   onBlock (status) {

--- a/app/javascript/flavours/glitch/features/account_gallery/index.jsx
+++ b/app/javascript/flavours/glitch/features/account_gallery/index.jsx
@@ -171,9 +171,8 @@ class AccountGallery extends ImmutablePureComponent {
 
   handleOpenAltText = attachment => {
     const { dispatch } = this.props;
-    const statusId = attachment.getIn(['status', 'id']);
 
-    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: attachment, statusId } }));
+    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: attachment } }));
   };
 
   handleRef = c => {

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.jsx
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.jsx
@@ -87,7 +87,7 @@ class DetailedStatus extends ImmutablePureComponent {
   handleAltClick = (index) => {
     const { status } = this.props;
 
-    this.props.onOpenAltText(status.get('id'), status.getIn(['media_attachments', index ? index : 0]));
+    this.props.onOpenAltText(status.getIn(['media_attachments', index ? index : 0]));
   };
 
   _measureHeight (heightJustChanged) {

--- a/app/javascript/flavours/glitch/features/status/index.jsx
+++ b/app/javascript/flavours/glitch/features/status/index.jsx
@@ -445,7 +445,7 @@ class Status extends ImmutablePureComponent {
   handleAltClick = (index) => {
     const { status } = this.props;
 
-    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { statusId: status.get('id'), media: status.getIn(['media_attachments', index ? index : 0]) } }));
+    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: status.getIn(['media_attachments', index ? index : 0]) } }));
   };
 
   handleHotkeyOpenMedia = e => {

--- a/app/javascript/flavours/glitch/features/ui/components/alttext_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/alttext_modal.jsx
@@ -1,41 +1,38 @@
 import PropTypes from 'prop-types';
+import { useCallback } from 'react';
 
-import { injectIntl, FormattedMessage } from 'react-intl';
-
-import { withRouter } from 'react-router';
+import { FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import { Button } from 'flavours/glitch/components/button';
-import { WithRouterPropTypes } from 'flavours/glitch/utils/react_router';
 
-class AltTextModal extends ImmutablePureComponent {
+export const AltTextModal = ({ media, onClose}) => {
+  const handleClick = useCallback(() => {
+    onClose();
+  }, [onClose]);
 
-  static propTypes = {
-    media: ImmutablePropTypes.map.isRequired,
-    statusId: PropTypes.string,
-    onClose: PropTypes.func.isRequired,
-    ...WithRouterPropTypes,
-  };
-
-  render () {
-    const { media, onClose } = this.props;
-
-    return (
-      <div className='modal-root__modal alttext-modal'>
-        <div className='alttext-modal__container'>
-          <pre>{media.get('description')}</pre>
+  return (
+    <div className='modal-root__modal alttext-modal'>
+      <div className='alttext-modal__top'>
+        <div className='alttext-modal__description'>
+          <pre>{media.getIn(['translation', 'description']) || media.get('description')}</pre>
         </div>
-        <div className='alttext-modal__action-bar'>
-          <Button onClick={onClose} className='alttext-modal__button'>
+      </div>
+      <div className='alttext-modal__bottom'>
+        <div className='alttext-modal__actions'>
+          <Button onClick={handleClick}>
             <FormattedMessage id='lightbox.close' defaultMessage='Close' />
           </Button>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
+};
 
-}
+AltTextModal.propTypes = {
+  media: ImmutablePropTypes.map.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
 
-export default withRouter(injectIntl(AltTextModal));
+export default AltTextModal;

--- a/app/javascript/flavours/glitch/features/ui/components/modal_root.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/modal_root.jsx
@@ -25,7 +25,7 @@ import { getScrollbarWidth } from 'flavours/glitch/utils/scrollbar';
 import BundleContainer from '../containers/bundle_container';
 
 import ActionsModal from './actions_modal';
-import AltTextModal from './alttext_modal';
+import { AltTextModal } from './alttext_modal';
 import AudioModal from './audio_modal';
 import { BoostModal } from './boost_modal';
 import BundleModalError from './bundle_modal_error';

--- a/app/javascript/flavours/glitch/styles/components.scss
+++ b/app/javascript/flavours/glitch/styles/components.scss
@@ -9836,29 +9836,52 @@ noscript {
 
 // Polyam: Alt-text modal
 .alttext-modal {
-  max-width: 90vw;
-  background: $ui-base-color;
-  border-radius: 8px;
-  overflow-x: hidden;
+  flex-direction: column;
+  max-width: 600px;
   overflow-y: auto;
-  position: relative;
-  display: block;
-  padding: 20px;
 
-  &__action-bar {
+  &__top,
+  &__bottom {
     display: flex;
-    justify-content: center;
-    padding-top: 20px;
+    gap: 8px;
+    padding: 24px;
+    flex-direction: column;
+    background: var(--modal-background-color);
+    backdrop-filter: var(--background-filter);
+    border: 1px solid var(--modal-border-color);
   }
 
-  &__container {
+  &__top {
+    border-radius: 16px 16px 0 0;
+    border-bottom: 0;
+    gap: 16px;
+  }
+
+  &__bottom {
+    border-radius: 0 0 16px 16px;
+    border-top: 0;
+    padding-top: 0;
+
+    @media screen and (max-width: $no-gap-breakpoint) {
+      border-radius: 0;
+      border-bottom: 0;
+      padding-bottom: 32px;
+    }
+  }
+
+  &__actions {
     display: flex;
-    max-width: 600px;
-    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  &__description {
+    font-size: 16px;
+    line-height: 22px;
 
     pre {
       white-space: pre-wrap;
-      font-size: 17px;
     }
   }
 }

--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -425,7 +425,7 @@ class Status extends ImmutablePureComponent {
   handleAltClick = (index) => {
     const { status } = this.props;
 
-    this.props.onOpenAltText(status.get('id'), status.getIn(['media_attachments', index ? index : 0]));
+    this.props.onOpenAltText(status.getIn(['media_attachments', index ? index : 0]));
   };
 
   handleHotkeyOpenMedia = e => {

--- a/app/javascript/flavours/polyam/containers/status_container.js
+++ b/app/javascript/flavours/polyam/containers/status_container.js
@@ -255,8 +255,8 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }));
   },
 
-  onOpenAltText (statusId, media) {
-    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { statusId, media }}));
+  onOpenAltText (media) {
+    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { media: media }}));
   },
 
   onBlock (status) {

--- a/app/javascript/flavours/polyam/features/account_gallery/index.jsx
+++ b/app/javascript/flavours/polyam/features/account_gallery/index.jsx
@@ -171,9 +171,8 @@ class AccountGallery extends ImmutablePureComponent {
 
   handleOpenAltText = attachment => {
     const { dispatch } = this.props;
-    const statusId = attachment.getIn(['status', 'id']);
 
-    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: attachment, statusId } }));
+    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: attachment } }));
   };
 
   handleRef = c => {

--- a/app/javascript/flavours/polyam/features/status/components/detailed_status.jsx
+++ b/app/javascript/flavours/polyam/features/status/components/detailed_status.jsx
@@ -88,7 +88,7 @@ class DetailedStatus extends ImmutablePureComponent {
   handleAltClick = (index) => {
     const { status } = this.props;
 
-    this.props.onOpenAltText(status.get('id'), status.getIn(['media_attachments', index ? index : 0]));
+    this.props.onOpenAltText(status.getIn(['media_attachments', index ? index : 0]));
   };
 
   _measureHeight (heightJustChanged) {

--- a/app/javascript/flavours/polyam/features/status/index.jsx
+++ b/app/javascript/flavours/polyam/features/status/index.jsx
@@ -446,7 +446,7 @@ class Status extends ImmutablePureComponent {
   handleAltClick = (index) => {
     const { status } = this.props;
 
-    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { statusId: status.get('id'), media: status.getIn(['media_attachments', index ? index : 0]) } }));
+    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: status.getIn(['media_attachments', index ? index : 0]) } }));
   };
 
   handleHotkeyOpenMedia = e => {

--- a/app/javascript/flavours/polyam/features/ui/components/alttext_modal.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/alttext_modal.jsx
@@ -1,41 +1,38 @@
 import PropTypes from 'prop-types';
+import { useCallback } from 'react';
 
-import { injectIntl, FormattedMessage } from 'react-intl';
-
-import { withRouter } from 'react-router';
+import { FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import { Button } from 'flavours/polyam/components/button';
-import { WithRouterPropTypes } from 'flavours/polyam/utils/react_router';
 
-class AltTextModal extends ImmutablePureComponent {
+export const AltTextModal = ({ media, onClose}) => {
+  const handleClick = useCallback(() => {
+    onClose();
+  }, [onClose]);
 
-  static propTypes = {
-    media: ImmutablePropTypes.map.isRequired,
-    statusId: PropTypes.string,
-    onClose: PropTypes.func.isRequired,
-    ...WithRouterPropTypes,
-  };
-
-  render () {
-    const { media, onClose } = this.props;
-
-    return (
-      <div className='modal-root__modal alttext-modal'>
-        <div className='alttext-modal__container'>
-          <pre>{media.get('description')}</pre>
+  return (
+    <div className='modal-root__modal alttext-modal'>
+      <div className='alttext-modal__top'>
+        <div className='alttext-modal__description'>
+          <pre>{media.getIn(['translation', 'description']) || media.get('description')}</pre>
         </div>
-        <div className='alttext-modal__action-bar'>
-          <Button onClick={onClose} className='alttext-modal__button'>
+      </div>
+      <div className='alttext-modal__bottom'>
+        <div className='alttext-modal__actions'>
+          <Button onClick={handleClick}>
             <FormattedMessage id='lightbox.close' defaultMessage='Close' />
           </Button>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
+};
 
-}
+AltTextModal.propTypes = {
+  media: ImmutablePropTypes.map.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
 
-export default withRouter(injectIntl(AltTextModal));
+export default AltTextModal;

--- a/app/javascript/flavours/polyam/features/ui/components/modal_root.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/modal_root.jsx
@@ -25,7 +25,7 @@ import { getScrollbarWidth } from 'flavours/polyam/utils/scrollbar';
 import BundleContainer from '../containers/bundle_container';
 
 import ActionsModal from './actions_modal';
-import AltTextModal from './alttext_modal';
+import { AltTextModal } from './alttext_modal';
 import AudioModal from './audio_modal';
 import { BoostModal } from './boost_modal';
 import BundleModalError from './bundle_modal_error';

--- a/app/javascript/flavours/polyam/styles/components/modal.scss
+++ b/app/javascript/flavours/polyam/styles/components/modal.scss
@@ -1494,29 +1494,52 @@ img.modal-warning {
 
 // Polyam: Alt-text modal feature
 .alttext-modal {
-  max-width: 90vw;
-  background: $ui-base-color;
-  border-radius: 8px;
-  overflow-x: hidden;
+  flex-direction: column;
+  max-width: 600px;
   overflow-y: auto;
-  position: relative;
-  display: block;
-  padding: 20px;
 
-  &__action-bar {
+  &__top,
+  &__bottom {
     display: flex;
-    justify-content: center;
-    padding-top: 20px;
+    gap: 8px;
+    padding: 24px;
+    flex-direction: column;
+    background: var(--modal-background-color);
+    backdrop-filter: var(--background-filter);
+    border: 1px solid var(--modal-border-color);
   }
 
-  &__container {
+  &__top {
+    border-radius: 16px 16px 0 0;
+    border-bottom: 0;
+    gap: 16px;
+  }
+
+  &__bottom {
+    border-radius: 0 0 16px 16px;
+    border-top: 0;
+    padding-top: 0;
+
+    @media screen and (max-width: $no-gap-breakpoint) {
+      border-radius: 0;
+      border-bottom: 0;
+      padding-bottom: 32px;
+    }
+  }
+
+  &__actions {
     display: flex;
-    max-width: 600px;
-    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  &__description {
+    font-size: 16px;
+    line-height: 22px;
 
     pre {
       white-space: pre-wrap;
-      font-size: 17px;
     }
   }
 }


### PR DESCRIPTION
Refactors the alt-text-modal and changes the design to match upstream's new modal design.

Passing `statusId` to the modal served no purpose and it didn't need router props either.

The modal now shows translated image description when toot was translated.

Preview:
![Long alt-text of lorem ipsum. The modal covers the middle third of the screen](https://github.com/polyamspace/mastodon/assets/117664621/e1114407-0da5-4813-953e-398013ceb88e)

![Short alt-text saying "meow". The modal is smaller](https://github.com/polyamspace/mastodon/assets/117664621/bc5342ab-7a38-44cb-9664-bd4dab3bc2e0)
