### PR TITLE
Reduce difference in status cards with upstream

### DIFF
--- a/app/javascript/flavours/polyam/features/status/components/card.jsx
+++ b/app/javascript/flavours/polyam/features/status/components/card.jsx
@@ -143,7 +143,7 @@ export default class Card extends PureComponent {
 
         <strong className='status-card__title' title={card.get('title')} lang={language}>{card.get('title')}</strong>
 
-        {!showAuthor && card.get('author_name').length > 0 ? <span className='status-card__author'><FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{card.get('author_name')}</strong> }} /></span> : <span className='status-card__description' lang={language}>{card.get('description')}</span>}
+        {!showAuthor && (card.get('author_name').length > 0 ? <span className='status-card__author'><FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{card.get('author_name')}</strong> }} /></span> : <span className='status-card__description' lang={language}>{card.get('description')}</span>)}
       </div>
     );
 

--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -681,18 +681,18 @@
   }
 }
 
-// Should be moved. Also probably not changed as polyam-glitch has ported change upstream postponed
+// Polyam: TODO: Move to new file?
 .status-card {
-  position: relative;
   display: flex;
+  align-items: center;
+  position: relative;
   font-size: 14px;
-  border: 1px solid var(--background-border-color);
-  border-radius: 8px;
   color: $darker-text-color;
   margin-top: 14px;
   text-decoration: none;
   overflow: hidden;
-  align-items: center;
+  border: 1px solid var(--background-border-color);
+  border-radius: 8px;
 
   &.bottomless {
     border-radius: 8px 8px 0 0;
@@ -707,6 +707,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    cursor: pointer;
 
     & > div {
       background: rgba($base-shadow-color, 0.6);
@@ -742,11 +743,6 @@
       position: relative;
       bottom: -1px;
     }
-
-    a .icon,
-    a:hover .icon {
-      color: inherit;
-    }
   }
 }
 
@@ -756,7 +752,7 @@ a.status-card {
   &:hover,
   &:focus,
   &:active {
-    // Fix underline being white
+    // Polyam: Fix underline being white
     text-decoration-color: $highlight-text-color;
 
     .status-card__title,
@@ -825,7 +821,7 @@ a.status-card {
 .status-card__content {
   flex: 1 1 auto;
   overflow: hidden;
-  padding: 0 8px; // Polyam: Different design
+  padding: 8px 10px; // glitch: reduced padding
   box-sizing: border-box;
   max-width: 100%;
 }
@@ -864,7 +860,7 @@ a.status-card {
 
 .status-card__image {
   flex: 0 0 auto;
-  width: 90px; // Polyam: Different design
+  width: 96px; // glitch: intentional change to better use space
   aspect-ratio: 1;
   background: lighten($ui-base-color, 8%);
   position: relative;
@@ -915,10 +911,6 @@ a.status-card {
 .status-card.expanded .status-card__image {
   width: 100%;
   aspect-ratio: auto;
-}
-
-.status-card.expanded .status-card__content {
-  padding: 15px;
 }
 
 .status-card__image,


### PR DESCRIPTION
Reorders style attributes, replaced polyam-glitch changed attributes with upstream, removed unneeded override.

This brings the design closer to upstream.

Before:
![Old design in home TL](https://github.com/polyamspace/mastodon/assets/117664621/c0337bdb-5b58-40e4-98a5-f309c06aa172)
![Old design in detailed view](https://github.com/polyamspace/mastodon/assets/117664621/6760653e-61f3-4edf-9ef2-52a875d44da9)

After:
![New design in home TL](https://github.com/polyamspace/mastodon/assets/117664621/a71beb51-6411-47c7-b1f9-afd03a629338)
![New design in detailed view](https://github.com/polyamspace/mastodon/assets/117664621/76861af3-af4d-4823-96ba-46083499a60a)
