### PR TITLE
Fix empty reactions bar being displayed in grouped notifications

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -404,6 +404,11 @@
       }
     }
   }
+
+  // Polyam: Fix empty reactions bar adding margin
+  .reactions-bar--empty {
+    display: none;
+  }
 }
 
 .notification-ungrouped {


### PR DESCRIPTION
Empty reactions bar wasn't hidden in grouped notifications, which caused weird spacing.