### PR TITLE
Hide reactions bar by default outside announcements

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/announcements.scss
+++ b/app/javascript/flavours/polyam/styles/components/announcements.scss
@@ -97,6 +97,11 @@
       width: 0.625rem;
       height: 0.625rem;
     }
+
+    // Polyam: Show empty bar in announcements
+    .reactions-bar--empty {
+      display: flex;
+    }
   }
 
   // Polyam: Added display flex to align arrows better in FF, Chrome still slightly misaligned
@@ -234,6 +239,8 @@
   }
 
   &--empty {
+    display: none; // Polyam: hide by default
+
     .emoji-button {
       padding: 0;
     }

--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -231,11 +231,6 @@
       }
     }
   }
-
-  // Polyam: Reactions
-  .reactions-bar--empty {
-    display: none;
-  }
 }
 
 .status__wrapper.collapsed {
@@ -515,11 +510,6 @@
   .status__prepend {
     padding: 0;
     margin-bottom: 16px;
-  }
-
-  // Polyam: Reactions
-  .reactions-bar--empty {
-    display: none;
   }
 }
 


### PR DESCRIPTION
Alternative to #630 

The empty bar has to be shown in announcements as otherwise the react button is also hidden. But outside announcements it adds weird spacing and needs to be hidden.

Currently `.reactions-bar--empty` was and needed to be added to every place they were shown outside announcements to hide the empty bar.

This hides the empty reactions bar by default and adds an exception to announcements instead