### PR TITLE
Remove margin and restricted width from ungrouped notifications

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -455,20 +455,7 @@
 
   $icon-margin: 48px; // 40px avatar + 8px gap
 
-  .status__content,
-  .status__action-bar,
-  .media-gallery,
-  .video-player,
-  .audio-player,
-  .attachment-list,
-  .picture-in-picture-placeholder,
-  .more-from-author,
-  .status-card,
-  .hashtag-bar,
-  .reactions-bar {
-    margin-inline-start: $icon-margin;
-    width: calc(100% - $icon-margin);
-  }
+  // Polyam: Removed margin and restricted width of elements here
 
   .more-from-author {
     width: calc(100% - $icon-margin + 2px);


### PR DESCRIPTION
I thought upstream would fix this, but they made it clear it's an intentional "design choice".

This removes the margin and width for status elements in ungrouped notifications to waste less space.

Before:
![Screenshot of a private mention notification. The text has a large margin on the left of it](https://github.com/user-attachments/assets/385cc80d-e397-459a-9782-5fbddb96c754)

After:
![Screenshot of a private mention notification. The text is aligned with the profile picture. No empty space](https://github.com/user-attachments/assets/92602407-97fc-424f-a8de-c7427b40357c)

