### PR TITLE
Fix typo in notification-ungrouped classes

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status.scss
@@ -428,7 +428,7 @@
 }
 
 .status__wrapper-direct,
-.notifications-ungrouped--direct {
+.notification-ungrouped--direct {
   background: var(--toot-private-background-color);
 
   &:focus {
@@ -437,9 +437,9 @@
 }
 
 .status__wrapper-direct,
-.notifications-ungrouped--direct {
+.notification-ungrouped--direct {
   .status__prepend,
-  .notifications-ungrouped__header {
+  .notification-ungrouped__header {
     color: $highlight-text-color;
   }
 }


### PR DESCRIPTION
Follow-up to #624

I added an extra "s" by accident while porting grouped notifications UI.