### PR TITLE
Grouped notifications UI tweaks

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -474,7 +474,6 @@
         font-size: 15px;
         line-height: 22px;
         color: $darker-text-color;
-        justify-content: space-between; // Polyam: Consistent timestamps
 
         a {
           color: inherit;
@@ -488,10 +487,22 @@
 
         time {
           color: $dark-text-color;
+          text-align: end; // Polyam: Fixes timestamp leaving gap
+          white-space: nowrap; // Polyam: Prevent wrapping
         }
 
-        // Polyam: Removed time as it should be visible.
+        // Polyam: Align timestamp to end
+        &-separator {
+          text-align: end;
+          flex-grow: 1;
+        }
+
         @container (width < 350px) {
+          // Polyam: Prevent reflow on timestamp change
+          display: grid;
+          grid-template-columns: 1fr minmax(10%, max-content);
+
+          // Polyam: Removed time as it should be visible.
           &-separator {
             display: none;
           }

--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -644,6 +644,14 @@
     border: 0;
     padding: 0;
   }
+
+  // Polyam: Temporarily disable header in mentions (also affects PMs)
+  // This is easier and reversible than deleting it in the component
+  &--mention {
+    .notification-ungrouped__header {
+      display: none;
+    }
+  }
 }
 
 .notification-group--unread,


### PR DESCRIPTION
Some tweaks for the grouped notifications UI.

This aligns the timestamp towards the end of the header and hides the header in mentions.

Before:
![Screenshot of a reply and reaction notification. Above the reply is a header with an arrow to the left and the text "Reply"](https://github.com/user-attachments/assets/e176555b-c809-4cf3-bbe5-432ac5e8941f)

After:
![Screenshot of a reply and reaction notification. No header above the reply. The text of the reaction notification wraps to a new line while the timestamp is still aligned to the end](https://github.com/user-attachments/assets/497ca8b2-c0aa-4c43-97e1-f5ae4a5b6451)

(The reflow issue is difficult to capture in screenshots as it requires a changing timestamp)