### PR TITLE
Fix new grouped notifications not marked as unread

### DIFF
--- a/app/javascript/flavours/polyam/reducers/notification_groups.ts
+++ b/app/javascript/flavours/polyam/reducers/notification_groups.ts
@@ -270,7 +270,7 @@ function shouldMarkNewNotificationsAsRead(
   );
 }
 
-// Polyam: Added `update` to always mark new notifications as read.
+// Polyam: Added `update` to always mark new notifications as unread.
 function updateLastReadId(
   state: NotificationGroupsState,
   group: NotificationGroup | undefined = undefined,

--- a/app/javascript/flavours/polyam/reducers/notification_groups.ts
+++ b/app/javascript/flavours/polyam/reducers/notification_groups.ts
@@ -270,11 +270,13 @@ function shouldMarkNewNotificationsAsRead(
   );
 }
 
+// Polyam: Added `update` to always mark new notifications as read.
 function updateLastReadId(
   state: NotificationGroupsState,
   group: NotificationGroup | undefined = undefined,
+  update = false,
 ) {
-  if (shouldMarkNewNotificationsAsRead(state)) {
+  if (update && shouldMarkNewNotificationsAsRead(state)) {
     group = group ?? state.groups.find(isNotificationGroup);
     if (
       group?.page_max_id &&


### PR DESCRIPTION
Fixes #636 

Skips `shouldMarkNewNotificationsAsRead` by adding a param that will always be false to always mark new notifications as unread.

I see no value in automatically marking notifications as read.