### PR TITLE
Update homogay to new admin UI design

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -254,10 +254,21 @@
 
 // settings
 
+// Polyam: Keep background in admin UI a bit darker
+body.admin {
+  --background-color: #{darken($ui-base-color, 4%)};
+}
+
 .admin-wrapper {
   .sidebar ul .simple-navigation-active-leaf a,
   .content__heading__tabs a.selected {
-    background-color: $ui-highlight-color;
     text-shadow: 0 0 6px $faint-shadow-color;
+  }
+
+  // Polyam: Keep in different color to make it look less boring
+  .sidebar-wrapper {
+    &__inner {
+      background-color: $ui-base-color;
+    }
   }
 }

--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -260,11 +260,6 @@ body.admin {
 }
 
 .admin-wrapper {
-  .sidebar ul .simple-navigation-active-leaf a,
-  .content__heading__tabs a.selected {
-    text-shadow: 0 0 6px $faint-shadow-color;
-  }
-
   // Polyam: Keep in different color to make it look less boring
   .sidebar-wrapper {
     &__inner {

--- a/app/javascript/flavours/polyam/styles/homogay/variables.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/variables.scss
@@ -81,12 +81,11 @@ $media-modal-media-max-height: 80%;
 
 $border-radius: 8px;
 
-// Overrides do not apply without "!important"
-:root {
-  --dropdown-background-color: #{$ui-base-lighter-color} !important;
-  --modal-background-color: #{$ui-base-color} !important;
-  --modal-background-variant-color: #{$ui-base-semi-lighter-color} !important;
-  --background-border-color: #{lighten($ui-base-color, 12%)} !important;
-  --background-color: #{$ui-base-color} !important;
-  --background-color-tint: #{$ui-base-color} !important;
+body {
+  --dropdown-background-color: #{$ui-base-lighter-color};
+  --modal-background-color: #{$ui-base-color};
+  --modal-background-variant-color: #{$ui-base-semi-lighter-color};
+  --background-border-color: #{lighten($ui-base-color, 12%)};
+  --background-color: #{$ui-base-color};
+  --background-color-tint: #{$ui-base-color};
 }


### PR DESCRIPTION
Follow-up to #638 

I'm not sure I like the inputs being lighter now.
I preferred them darker, but I'll keep that for now.

Changed the background color to be darker as `--background-color` and `$ui-base-color` are the same.
Thanks to CSS vars, it can be easily overridden.

Kept the different background for the sidebar as the UI looked a bit too boring with a single color.