### PR TITLE
Fix backgrounds of focused toots and private mentions in homogay

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/variables.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/variables.scss
@@ -88,4 +88,19 @@ body {
   --background-border-color: #{lighten($ui-base-color, 12%)};
   --background-color: #{$ui-base-color};
   --background-color-tint: #{$ui-base-color};
+  --toot-focus-background-color: #{color-mix(
+      in srgb,
+      var(--background-color),
+      $ui-highlight-color 5%
+    )};
+  --toot-private-background-color: #{color-mix(
+      in srgb,
+      var(--background-color),
+      $ui-highlight-color 5%
+    )};
+  --toot-private-background-focus-color: #{color-mix(
+      in srgb,
+      var(--background-color),
+      $ui-highlight-color 10%
+    )};
 }


### PR DESCRIPTION
Follow-up to #640 

Because the CSS vars now attach to body, the vars for toot backgrounds used the background color var from the default skin.

This just copies the vars as is to fix that.