### PR TITLE
Keep different message for cancelling follow request

### DIFF
--- a/app/javascript/flavours/polyam/components/follow_button.tsx
+++ b/app/javascript/flavours/polyam/components/follow_button.tsx
@@ -23,10 +23,6 @@ const messages = defineMessages({
     defaultMessage: 'Withdraw follow request',
   },
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
-  cancelFollowRequestConfirm: {
-    id: 'confirmations.cancel_follow_request.confirm',
-    defaultMessage: 'Withdraw request',
-  },
 });
 
 export const FollowButton: React.FC<{
@@ -71,7 +67,10 @@ export const FollowButton: React.FC<{
       // Polyam: Keep unfollow modal optional
       if (unfollowModal) {
         dispatch(
-          openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account } }),
+          openModal({
+            modalType: 'CONFIRM_UNFOLLOW',
+            modalProps: { account, requested: relationship.requested },
+          }),
         );
       } else {
         dispatch(unfollowAccount(accountId));

--- a/app/javascript/flavours/polyam/features/account_timeline/containers/header_container.jsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/containers/header_container.jsx
@@ -1,4 +1,4 @@
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import { connect } from 'react-redux';
 
@@ -23,10 +23,6 @@ import { unfollowModal } from '../../../initial_state';
 import { makeGetAccount, getAccountHidden } from '../../../selectors';
 import Header from '../components/header';
 
-const messages = defineMessages({
-  cancelFollowRequestConfirm: { id: 'confirmations.cancel_follow_request.confirm', defaultMessage: 'Withdraw request' },
-});
-
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();
 
@@ -39,26 +35,12 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-const mapDispatchToProps = (dispatch, { intl }) => ({
+const mapDispatchToProps = (dispatch) => ({
 
   onFollow (account) {
-    if (account.getIn(['relationship', 'following'])) {
+    if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
       if (unfollowModal) {
-        dispatch(openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account } }));
-      } else {
-        dispatch(unfollowAccount(account.get('id')));
-      }
-    } else if (account.getIn(['relationship', 'requested'])) {
-      // Polyam: Kept from upstream as otherwise confusing
-      if (unfollowModal) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: <FormattedMessage id='confirmations.cancel_follow_request.message' defaultMessage='Are you sure you want to withdraw your request to follow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-            confirm: intl.formatMessage(messages.cancelFollowRequestConfirm),
-            onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
-          },
-        }));
+        dispatch(openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account, requested: account.getIn(['relationship', 'requested']) } }));
       } else {
         dispatch(unfollowAccount(account.get('id')));
       }

--- a/app/javascript/flavours/polyam/features/directory/components/account_card.tsx
+++ b/app/javascript/flavours/polyam/features/directory/components/account_card.tsx
@@ -29,10 +29,6 @@ const messages = defineMessages({
     id: 'account.cancel_follow_request',
     defaultMessage: 'Withdraw follow request',
   },
-  cancelFollowRequestConfirm: {
-    id: 'confirmations.cancel_follow_request.confirm',
-    defaultMessage: 'Withdraw request',
-  },
   requested: {
     id: 'account.requested',
     defaultMessage: 'Awaiting approval. Click to cancel follow request',
@@ -85,33 +81,18 @@ export const AccountCard: React.FC<{ accountId: string }> = ({ accountId }) => {
   const handleFollow = useCallback(() => {
     if (!account) return;
 
-    if (account.getIn(['relationship', 'following'])) {
-      // Polyam: Keep unfollow modal optional
-      if (unfollowModal) {
-        dispatch(
-          openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account } }),
-        );
-      } else {
-        dispatch(unfollowAccount(account.get('id')));
-      }
-    } else if (account.getIn(['relationship', 'requested'])) {
+    if (
+      account.getIn(['relationship', 'following']) ||
+      account.getIn(['relationship', 'requested'])
+    ) {
       // Polyam: Keep unfollow modal optional
       if (unfollowModal) {
         dispatch(
           openModal({
-            modalType: 'CONFIRM',
+            modalType: 'CONFIRM_UNFOLLOW',
             modalProps: {
-              message: (
-                <FormattedMessage
-                  id='confirmations.cancel_follow_request.message'
-                  defaultMessage='Are you sure you want to withdraw your request to follow {name}?'
-                  values={{ name: <strong>@{account.get('acct')}</strong> }}
-                />
-              ),
-              confirm: intl.formatMessage(messages.cancelFollowRequestConfirm),
-              onConfirm: () => {
-                dispatch(unfollowAccount(account.get('id')));
-              },
+              account,
+              requested: account.getIn(['relationship', 'requested']),
             },
           }),
         );
@@ -121,7 +102,7 @@ export const AccountCard: React.FC<{ accountId: string }> = ({ accountId }) => {
     } else {
       dispatch(followAccount(account.get('id')));
     }
-  }, [account, dispatch, intl]);
+  }, [account, dispatch]);
 
   const handleBlock = useCallback(() => {
     if (account?.relationship?.blocking) {

--- a/app/javascript/flavours/polyam/features/ui/components/confirmation_modals/unfollow.tsx
+++ b/app/javascript/flavours/polyam/features/ui/components/confirmation_modals/unfollow.tsx
@@ -18,13 +18,19 @@ const messages = defineMessages({
     id: 'confirmations.unfollow.confirm',
     defaultMessage: 'Unfollow',
   },
+  cancelRequestConfirm: {
+    id: 'confirmations.cancel_follow_request.confirm',
+    defaultMessage: 'Withdraw request',
+  },
 });
 
+// Polyam: Kept different message for cancelling follow requests
 export const ConfirmUnfollowModal: React.FC<
   {
     account: Account;
+    requested: boolean;
   } & BaseConfirmationModalProps
-> = ({ account, onClose }) => {
+> = ({ account, requested, onClose }) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
 
@@ -36,13 +42,23 @@ export const ConfirmUnfollowModal: React.FC<
     <ConfirmationModal
       title={intl.formatMessage(messages.unfollowTitle)}
       message={
-        <FormattedMessage
-          id='confirmations.unfollow.message'
-          defaultMessage='Are you sure you want to unfollow {name}?'
-          values={{ name: <strong>@{account.acct}</strong> }}
-        />
+        requested ? (
+          <FormattedMessage
+            id='confirmations.cancel_follow_request.message'
+            defaultMessage='Are you sure you want to withdraw your request to follow {name}?'
+            values={{ name: <strong>@{account.acct}</strong> }}
+          />
+        ) : (
+          <FormattedMessage
+            id='confirmations.unfollow.message'
+            defaultMessage='Are you sure you want to unfollow {name}?'
+            values={{ name: <strong>@{account.acct}</strong> }}
+          />
+        )
       }
-      confirm={intl.formatMessage(messages.unfollowConfirm)}
+      confirm={intl.formatMessage(
+        requested ? messages.cancelRequestConfirm : messages.unfollowConfirm,
+      )}
       onConfirm={onConfirm}
       onClose={onClose}
     />


### PR DESCRIPTION
Follow-up to #649 

I still think having a different message in the confirmation modal is less confusing.
A follow request is more of a "follow" than a follow.

The requested value needs to be passed down to the modal as trying to retrieve the value from account yields undefined.