### PR TITLE
Add ability to search domains by comment

### DIFF
--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -28,6 +28,7 @@ class Instance < ApplicationRecord
   scope :domain_starts_with, ->(value) { where(arel_table[:domain].matches("#{sanitize_sql_like(value)}%", false, true)) }
   scope :by_domain_and_subdomains, ->(domain) { where("reverse('.' || domain) LIKE reverse(?)", "%.#{domain}") }
   scope :with_domain_follows, ->(domains) { where(domain: domains).where(domain_account_follows) }
+  scope :matches_comment, ->(value) { joins(:domain_block).where(DomainBlock.arel_table[:private_comment].matches("%#{value}%").or(DomainBlock.arel_table[:public_comment].matches("%#{value}%"))) }
 
   def self.domain_account_follows
     Arel.sql(

--- a/app/models/instance_filter.rb
+++ b/app/models/instance_filter.rb
@@ -6,6 +6,7 @@ class InstanceFilter
     suspended
     by_domain
     availability
+    by_comment
   ).freeze
 
   attr_reader :params
@@ -38,6 +39,8 @@ class InstanceFilter
       Instance.matches_domain(value)
     when 'availability'
       availability_scope(value)
+    when 'by_comment'
+      Instance.matches_comment(value)
     else
       raise Mastodon::InvalidParameterError, "Unknown filter: #{key}"
     end

--- a/app/views/admin/instances/index.html.haml
+++ b/app/views/admin/instances/index.html.haml
@@ -41,6 +41,13 @@
                             class: 'string optional',
                             placeholder: I18n.t("admin.instances.#{key}")
 
+      - %i(by_comment).each do |key|
+        .input.string.optional
+          = form.text_field key,
+                            value: params[key],
+                            class: 'string optional',
+                            placeholder: I18n.t("admin.instances.#{key}")
+
       .actions
         %button.button= t('admin.accounts.search')
         = link_to t('admin.accounts.reset'), admin_instances_path, class: 'button negative'

--- a/config/locales-polyam/en.yml
+++ b/config/locales-polyam/en.yml
@@ -15,6 +15,7 @@ en:
       visible_in_picker: Show in emoji picker
       visible_in_picker_hint: Makes this emoji available in the emoji picker and API.
     instances:
+      by_comment: Public or private comment
       content_policies:
         policies:
           noop: None

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -100,5 +100,26 @@ RSpec.describe Instance do
           .and not_include(none_domain)
       end
     end
+
+    describe '#matches_comment' do
+      let(:match_domain) { 'example.host' }
+      let(:match_other_domain) { 'other.host' }
+      let(:no_match_domain) { 'none.host' }
+
+      before do
+        Fabricate(:domain_block, domain: match_domain, private_comment: 'test')
+        Fabricate(:domain_block, domain: match_other_domain, public_comment: 'test')
+        Fabricate(:domain_block, domain: no_match_domain, public_comment: 'no match')
+      end
+
+      it 'returns matching instances' do
+        results = described_class.matches_comment('test').pluck(:domain)
+
+        expect(results)
+          .to include(match_domain)
+          .and include(match_other_domain)
+          .and not_include(no_match_domain)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #651 

Adds a new text field and param to allow searching instances by domain block public and private comment

Preview:
![Screenshot of the instances page showing the new text input below domain search](https://github.com/user-attachments/assets/adb205d1-2744-49be-b2a0-268461137617)
