### PR TITLE
Disallow more LLM scrapers in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,6 +12,9 @@ Disallow: /
 User-agent: FacebookBot
 Disallow: /
 
+User-agent: Meta-ExternalAgent
+Disallow: /
+
 User-agent: CCBot
 Disallow: /
 
@@ -28,6 +31,15 @@ User-agent: cohere-ai
 Disallow: /
 
 User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Timpibot
 Disallow: /
 
 User-agent: *


### PR DESCRIPTION
You should redirect those request and poison the data, but I started this, so I continue to add them.