### PR TITLE
Add notifications for report notes

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -72,6 +72,9 @@ class Notification < ApplicationRecord
     'admin.report': {
       filterable: false,
     }.freeze,
+    'admin.report_note': {
+      filterable: false,
+    },
   }.freeze
 
   TYPES = PROPERTIES.keys.freeze
@@ -102,6 +105,7 @@ class Notification < ApplicationRecord
     belongs_to :status_reaction, inverse_of: :notification
     belongs_to :account_relationship_severance_event, inverse_of: false
     belongs_to :account_warning, inverse_of: false
+    belongs_to :report_note, inverse_of: false
   end
 
   validates :type, inclusion: { in: TYPES }
@@ -263,7 +267,7 @@ class Notification < ApplicationRecord
     return unless new_record?
 
     case activity_type
-    when 'Status', 'Follow', 'Favourite', 'StatusReaction', 'FollowRequest', 'Poll', 'Report'
+    when 'Status', 'Follow', 'Favourite', 'StatusReaction', 'FollowRequest', 'Poll', 'Report', 'ReportNote'
       self.from_account_id = activity&.account_id
     when 'Mention'
       self.from_account_id = activity&.status&.account_id

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -37,5 +37,6 @@ class NotificationGroup < ActiveModelSerializers::Model
            :report,
            :account_relationship_severance_event,
            :account_warning,
+           :report_note,
            to: :notification, prefix: false
 end

--- a/app/models/report_note.rb
+++ b/app/models/report_note.rb
@@ -15,6 +15,7 @@
 class ReportNote < ApplicationRecord
   CONTENT_SIZE_LIMIT = 2_000
 
+  has_many :notifications, as: :activity, dependent: :destroy
   belongs_to :account
   belongs_to :report, inverse_of: :notes, touch: true
 

--- a/app/serializers/rest/notification_group_serializer.rb
+++ b/app/serializers/rest/notification_group_serializer.rb
@@ -13,6 +13,7 @@ class REST::NotificationGroupSerializer < ActiveModel::Serializer
   belongs_to :report, if: :report_type?, serializer: REST::ReportSerializer
   belongs_to :account_relationship_severance_event, key: :event, if: :relationship_severance_event?, serializer: REST::AccountRelationshipSeveranceEventSerializer
   belongs_to :account_warning, key: :moderation_warning, if: :moderation_warning_event?, serializer: REST::AccountWarningSerializer
+  belongs_to :report_note, if: :report_note_type?, serializer: REST::ReportNoteSerializer
 
   def status_type?
     [:favourite, :reblog, :reaction, :status, :mention, :poll, :update].include?(object.type)
@@ -20,6 +21,10 @@ class REST::NotificationGroupSerializer < ActiveModel::Serializer
 
   def report_type?
     object.type == :'admin.report'
+  end
+
+  def report_note_type?
+    object.type == :'admin.report_note'
   end
 
   def relationship_severance_event?

--- a/app/serializers/rest/notification_serializer.rb
+++ b/app/serializers/rest/notification_serializer.rb
@@ -11,6 +11,7 @@ class REST::NotificationSerializer < ActiveModel::Serializer
   belongs_to :report, if: :report_type?, serializer: REST::ReportSerializer
   belongs_to :account_relationship_severance_event, key: :event, if: :relationship_severance_event?, serializer: REST::AccountRelationshipSeveranceEventSerializer
   belongs_to :account_warning, key: :moderation_warning, if: :moderation_warning_event?, serializer: REST::AccountWarningSerializer
+  belongs_to :report_note, if: :report_note_type?, serializer: REST::ReportNoteSerializer
 
   def id
     object.id.to_s
@@ -26,6 +27,10 @@ class REST::NotificationSerializer < ActiveModel::Serializer
 
   def report_type?
     object.type == :'admin.report'
+  end
+
+  def report_note_type?
+    object.type == :'admin.report_note'
   end
 
   def relationship_severance_event?

--- a/app/serializers/rest/report_note_serializer.rb
+++ b/app/serializers/rest/report_note_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class REST::ReportNoteSerializer < ActiveModel::Serializer
+  attributes :id, :content, :created_at
+
+  has_one :report, serializer: REST::ReportSerializer
+
+  def id
+    object.id.to_s
+  end
+end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -8,6 +8,7 @@ class NotifyService < BaseService
   NON_EMAIL_TYPES = %i(
     admin.report
     admin.sign_up
+    admin.report_note
     update
     poll
     status
@@ -77,6 +78,7 @@ class NotifyService < BaseService
     NON_FILTERABLE_TYPES = %i(
       admin.sign_up
       admin.report
+      admin.report_note
       poll
       update
       account_warning


### PR DESCRIPTION
Ref #657 

TODO:
- Add specs (admin notifications don't really seem to have specs)

### API Changes
Adds new `admin.report_note` type and optional `report_note` attribute to Notification

```JSON
{
 //... See Notification entity in upstream docs
  "report_note" : {
    "id": "123456",
    "content": "This is a test note",
    "created_at": "2019-11-23T07:28:34.210Z",
    "report": {
        "id": "654321",
        "action_taken": false,
        //... See Report entity in upstream docs
    }
  }
}
```