### PR TITLE
Add rule hint to rule selector in report modal

### DIFF
--- a/app/javascript/flavours/polyam/features/report/rules.jsx
+++ b/app/javascript/flavours/polyam/features/report/rules.jsx
@@ -51,6 +51,7 @@ class Rules extends PureComponent {
               onToggle={this.handleRulesToggle}
               label={item.get('text')}
               multiple
+              description={item.get('hint')}
             />
           ))}
         </div>


### PR DESCRIPTION
Fixes #656 

Upstream doesn't want to show the hint in the web UI, but I think it's useful as the hint can be used to clarify rules, which avoids having users to visit the about page when unsure which rule to select when reporting.

I also think the redesign of modals will take long enough that it's worth adding now.

Preview:
![Screenshot of report modal rule selector showing additional text on the options](https://github.com/user-attachments/assets/efd69d37-0231-4fe4-aefb-f54617d12195)
