### PR TITLE
Fix checkmark color in report modal in homogay

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -252,6 +252,11 @@
   }
 }
 
+// Polyam: Fix color of checkmark
+.report-dialog-modal .dialog-option .poll__input {
+  color: $ui-base-color;
+}
+
 // settings
 
 // Polyam: Keep background in admin UI a bit darker


### PR DESCRIPTION
The checkmark had the same color as the box, which made it invisible.
This changes the color to the ui base color.
Not sure it's the best color, but it has the highest contrast.