### PR TITLE
Convert private comment field on domain blocks to text input

### DIFF
--- a/app/views/admin/domain_blocks/_form.html.haml
+++ b/app/views/admin/domain_blocks/_form.html.haml
@@ -34,7 +34,8 @@
                wrapper: :with_label
 .field-group
   = form.input :private_comment,
-               as: :string,
+               as: :text,
+               input_html: { rows: 8 },
                hint: t('admin.domain_blocks.private_comment_hint'),
                label: I18n.t('admin.domain_blocks.private_comment'),
                wrapper: :with_label

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -98,7 +98,8 @@
         %tbody
           %tr
             %th= t('admin.instances.content_policies.comment')
-            %td= @instance.domain_block.private_comment
+            %td
+              %pre= @instance.domain_block.private_comment
           %tr
             %th= t('admin.instances.content_policies.reason')
             %td= @instance.domain_block.public_comment


### PR DESCRIPTION
This allows easier adding and editing of private comments by giving more space.

Also when hitting enter on string inputs, it sends the form, with a text input that doesn't happen.

I'm also considering to change the markup of private comments, so the formatting is preserved.

Preview:
![Screenshot of the edit domain block page showing a larger text input for private comment](https://github.com/user-attachments/assets/a1eaf992-4a7f-4c1c-83ac-07fe6323aa0e)

![Screenshot of an instance page showing a long private comment with new lines preserved](https://github.com/user-attachments/assets/ecc2d75f-4318-4f10-ad27-59b3010fd2dc)

