### PR TITLE
Reuse CustomEmoji RegEx for reactions

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -8,6 +8,9 @@ class ActivityPub::Activity
   SUPPORTED_TYPES = %w(Note Question).freeze
   CONVERTED_TYPES = %w(Image Audio Video Article Page Event).freeze
 
+  # Used for reactions
+  CUSTOM_EMOJI_REGEX = /^:#{CustomEmoji::SHORTCODE_RE_FRAGMENT}:$/
+
   def initialize(json, account, **options)
     @json    = json
     @account = account

--- a/app/lib/activitypub/activity/emoji_react.rb
+++ b/app/lib/activitypub/activity/emoji_react.rb
@@ -8,7 +8,7 @@ class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
               !original_status.account.local? ||
               delete_arrived_first?(@json['id'])
 
-    if /^:.*:$/.match?(name)
+    if CUSTOM_EMOJI_REGEX.match?(name)
       name.delete! ':'
       custom_emoji = process_emoji_tags(name, @json['tag'])
 

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -23,7 +23,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
     name = @json['content'] || @json['_misskey_reaction']
     return false if name.nil?
 
-    if /^:.*:$/.match?(name)
+    if CUSTOM_EMOJI_REGEX.match?(name)
       name.delete! ':'
       custom_emoji = process_emoji_tags(name, @json['tag'])
 

--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -125,7 +125,7 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
 
     return if status.nil? || !status.account.local?
 
-    if /^:.*:$/.match?(name)
+    if CUSTOM_EMOJI_REGEX.match?(name)
       name.delete! ':'
       custom_emoji = process_emoji_tags(name, @object['tag'])
 


### PR DESCRIPTION
This is cleaner and matches shortcodes which are actually accepted.

The old regex matched everything between two colons, even invalid shortcodes.