### PR TITLE
Cherry-pick cache hydration from upstream PR

### DIFF
--- a/app/lib/status_cache_hydrator.rb
+++ b/app/lib/status_cache_hydrator.rb
@@ -32,7 +32,7 @@ class StatusCacheHydrator
       payload[:bookmarked] = Bookmark.exists?(account_id: account_id, status_id: @status.id)
       payload[:pinned]     = StatusPin.exists?(account_id: account_id, status_id: @status.id) if @status.account_id == account_id
       payload[:filtered]   = mapped_applied_custom_filter(account_id, @status)
-      payload[:reactions]  = serialized_reactions(account_id)
+      payload[:reactions]  = serialized_reactions(account_id, @status)
 
       if payload[:poll]
         payload[:poll][:voted] = @status.account_id == account_id
@@ -58,7 +58,7 @@ class StatusCacheHydrator
       payload[:reblog][:bookmarked] = Bookmark.exists?(account_id: account_id, status_id: @status.reblog_of_id)
       payload[:reblog][:pinned]     = StatusPin.exists?(account_id: account_id, status_id: @status.reblog_of_id) if @status.reblog.account_id == account_id
       payload[:reblog][:filtered]   = payload[:filtered]
-      payload[:reblog][:reactions]  = serialized_reactions(account_id)
+      payload[:reblog][:reactions]  = serialized_reactions(account_id, @status.reblog)
 
       if payload[:reblog][:poll]
         if @status.reblog.account_id == account_id
@@ -73,7 +73,6 @@ class StatusCacheHydrator
 
       payload[:favourited] = payload[:reblog][:favourited]
       payload[:reblogged]  = payload[:reblog][:reblogged]
-      payload[:reactions]  = payload[:reblog][:reactions]
     end
   end
 
@@ -90,8 +89,8 @@ class StatusCacheHydrator
     ).as_json
   end
 
-  def serialized_reactions(account_id)
-    reactions = @status.reactions(account_id)
+  def serialized_reactions(account_id, status)
+    reactions = status.reactions(account_id)
     ActiveModelSerializers::SerializableResource.new(
       reactions,
       each_serializer: REST::ReactionSerializer,

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -292,10 +292,10 @@ class Status < ApplicationRecord
     @emojis = CustomEmoji.from_text(fields.join(' '), account.domain)
   end
 
-  def reactions(account = nil)
+  def reactions(account_id = nil)
     grouped_ordered_status_reactions.select(
       [:name, :custom_emoji_id, 'COUNT(*) as count'].tap do |values|
-        values << value_for_reaction_me_column(account)
+        values << value_for_reaction_me_column(account_id)
       end
     ).to_a.tap do |records|
       ActiveRecord::Associations::Preloader.new(records: records, associations: :custom_emoji).call
@@ -469,15 +469,15 @@ class Status < ApplicationRecord
       )
   end
 
-  def value_for_reaction_me_column(account)
-    if account.nil?
+  def value_for_reaction_me_column(account_id)
+    if account_id.nil?
       'FALSE AS me'
     else
       <<~SQL.squish
         EXISTS(
           SELECT 1
           FROM status_reactions inner_reactions
-          WHERE inner_reactions.account_id = #{account.id}
+          WHERE inner_reactions.account_id = #{account_id}
             AND inner_reactions.status_id = status_reactions.status_id
             AND inner_reactions.name = status_reactions.name
             AND (

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -164,7 +164,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def reactions
-    object.reactions(current_user&.account)
+    object.reactions(current_user&.account&.id)
   end
 
   def hidden_by_moderators

--- a/spec/lib/status_cache_hydrator_spec.rb
+++ b/spec/lib/status_cache_hydrator_spec.rb
@@ -123,6 +123,16 @@ describe StatusCacheHydrator do
             expect(subject).to eql(compare_to_hash)
           end
         end
+
+        context 'when it has been reacted to' do
+          before do
+            ReactService.new.call(account, reblog, '👍')
+          end
+
+          it 'renders same attributes as a full render' do
+            expect(subject).to eql(compare_to_hash)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
There is no explanation as to why this is needed or what if any problem it solves, but other interactions are hydrated, so it seems logical to do the same with reactions.

Also added a new test to hydrate specs.