### PR TITLE
Revert "Fix new grouped notifications not marked as unread (#637)"

### DIFF
--- a/app/javascript/flavours/polyam/reducers/notification_groups.ts
+++ b/app/javascript/flavours/polyam/reducers/notification_groups.ts
@@ -272,13 +272,11 @@ function shouldMarkNewNotificationsAsRead(
   );
 }
 
-// Polyam: Added `update` to always mark new notifications as unread.
 function updateLastReadId(
   state: NotificationGroupsState,
   group: NotificationGroup | undefined = undefined,
-  update = false,
 ) {
-  if (update && shouldMarkNewNotificationsAsRead(state)) {
+  if (shouldMarkNewNotificationsAsRead(state)) {
     group = group ?? state.groups.find(isNotificationGroup);
     if (
       group?.page_max_id &&


### PR DESCRIPTION
This reverts commit 82da958086dddcad57a4fe0d8e7f5db7356b2634.