### PR TITLE
Port changes adding follow button to follow notifications

### DIFF
--- a/app/javascript/flavours/polyam/components/follow_icon_button.tsx
+++ b/app/javascript/flavours/polyam/components/follow_icon_button.tsx
@@ -1,0 +1,116 @@
+// Simplified follow button using icons for polyam-glitch
+import { useCallback, useEffect } from 'react';
+
+import { useIntl, defineMessages } from 'react-intl';
+
+import PendingApprovalIcon from '@/awesome-icons/solid/hourglass-half.svg?react';
+import FollowIcon from '@/awesome-icons/solid/user-plus.svg?react';
+import UnfollowIcon from '@/awesome-icons/solid/user-xmark.svg?react';
+import { useIdentity } from '@/flavours/polyam/identity_context';
+import {
+  fetchRelationships,
+  followAccount,
+  unfollowAccount,
+} from 'flavours/polyam/actions/accounts';
+import { openModal } from 'flavours/polyam/actions/modal';
+import { IconButton } from 'flavours/polyam/components/icon_button';
+import { me, unfollowModal } from 'flavours/polyam/initial_state';
+import { useAppDispatch, useAppSelector } from 'flavours/polyam/store';
+
+const messages = defineMessages({
+  unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
+  follow: { id: 'account.follow', defaultMessage: 'Follow' },
+  cancel_follow_request: {
+    id: 'account.cancel_follow_request',
+    defaultMessage: 'Withdraw follow request',
+  },
+});
+
+export const FollowIconButton: React.FC<{
+  accountId?: string;
+}> = ({ accountId }) => {
+  const intl = useIntl();
+  const dispatch = useAppDispatch();
+  const { signedIn } = useIdentity();
+  const account = useAppSelector((state) =>
+    accountId ? state.accounts.get(accountId) : undefined,
+  );
+  const relationship = useAppSelector((state) =>
+    accountId ? state.relationships.get(accountId) : undefined,
+  );
+  const following = relationship?.following || relationship?.requested;
+
+  useEffect(() => {
+    if (accountId && signedIn) {
+      dispatch(fetchRelationships([accountId]));
+    }
+  }, [dispatch, accountId, signedIn]);
+
+  const handleClick = useCallback(() => {
+    if (!signedIn) {
+      dispatch(
+        openModal({
+          modalType: 'INTERACTION',
+          modalProps: {
+            type: 'follow',
+            accountId: accountId,
+            url: account?.url,
+          },
+        }),
+      );
+    }
+
+    if (!relationship) return;
+
+    if (accountId === me) {
+      return;
+    } else if (account && (relationship.following || relationship.requested)) {
+      // Polyam: Keep unfollow modal optional
+      if (unfollowModal) {
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM_UNFOLLOW',
+            modalProps: { account, requested: relationship.requested },
+          }),
+        );
+      } else {
+        dispatch(unfollowAccount(accountId));
+      }
+    } else {
+      dispatch(followAccount(accountId));
+    }
+  }, [dispatch, accountId, relationship, account, signedIn]);
+
+  if (!relationship) return null;
+
+  let label, icon, iconComponent;
+
+  if (!signedIn) {
+    label = intl.formatMessage(messages.follow);
+    icon = 'user-add';
+    iconComponent = FollowIcon;
+  } else if (relationship.requested) {
+    label = intl.formatMessage(messages.cancel_follow_request);
+    icon = 'hourglass';
+    iconComponent = PendingApprovalIcon;
+  } else if (relationship.following) {
+    label = intl.formatMessage(messages.unfollow);
+    icon = 'user-xmark';
+    iconComponent = UnfollowIcon;
+  } else {
+    label = intl.formatMessage(messages.follow);
+    icon = 'user-add';
+    iconComponent = FollowIcon;
+  }
+
+  return (
+    <IconButton
+      onClick={handleClick}
+      disabled={relationship.blocked_by || relationship.blocking}
+      active={following}
+      icon={icon}
+      iconComponent={iconComponent}
+      title={label}
+    />
+  );
+};

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_follow.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_follow.tsx
@@ -2,7 +2,7 @@ import { FormattedMessage } from 'react-intl';
 
 import PersonAddIcon from '@/awesome-icons/solid/user-plus.svg?react';
 import { FollowersCounter } from 'flavours/polyam/components/counters';
-import { FollowButton } from 'flavours/polyam/components/follow_button';
+import { FollowIconButton } from 'flavours/polyam/components/follow_icon_button';
 import { ShortNumber } from 'flavours/polyam/components/short_number';
 import type { NotificationGroupFollow } from 'flavours/polyam/models/notification_group';
 import { useAppSelector } from 'flavours/polyam/store';
@@ -40,7 +40,9 @@ export const NotificationFollow: React.FC<{
     const account = notification.sampleAccountIds[0];
 
     if (account) {
-      actions = <FollowButton accountId={notification.sampleAccountIds[0]} />;
+      actions = (
+        <FollowIconButton accountId={notification.sampleAccountIds[0]} />
+      );
       // Polyam: Don't show follower count
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       additionalContent = undefined && <FollowerCount accountId={account} />;

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_follow.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_follow.tsx
@@ -1,7 +1,11 @@
 import { FormattedMessage } from 'react-intl';
 
 import PersonAddIcon from '@/awesome-icons/solid/user-plus.svg?react';
+import { FollowersCounter } from 'flavours/polyam/components/counters';
+import { FollowButton } from 'flavours/polyam/components/follow_button';
+import { ShortNumber } from 'flavours/polyam/components/short_number';
 import type { NotificationGroupFollow } from 'flavours/polyam/models/notification_group';
+import { useAppSelector } from 'flavours/polyam/store';
 
 import type { LabelRenderer } from './notification_group_with_status';
 import { NotificationGroupWithStatus } from './notification_group_with_status';
@@ -14,18 +18,47 @@ const labelRenderer: LabelRenderer = (values) => (
   />
 );
 
+const FollowerCount: React.FC<{ accountId: string }> = ({ accountId }) => {
+  const account = useAppSelector((s) => s.accounts.get(accountId));
+
+  if (!account) return null;
+
+  return (
+    <ShortNumber value={account.followers_count} renderer={FollowersCounter} />
+  );
+};
+
 export const NotificationFollow: React.FC<{
   notification: NotificationGroupFollow;
   unread: boolean;
-}> = ({ notification, unread }) => (
-  <NotificationGroupWithStatus
-    type='follow'
-    icon={PersonAddIcon}
-    iconId='person-add'
-    accountIds={notification.sampleAccountIds}
-    timestamp={notification.latest_page_notification_at}
-    count={notification.notifications_count}
-    labelRenderer={labelRenderer}
-    unread={unread}
-  />
-);
+}> = ({ notification, unread }) => {
+  let actions: JSX.Element | undefined;
+  let additionalContent: JSX.Element | undefined;
+
+  if (notification.sampleAccountIds.length === 1) {
+    // only display those if the group contains 1 account, otherwise it does not make sense
+    const account = notification.sampleAccountIds[0];
+
+    if (account) {
+      actions = <FollowButton accountId={notification.sampleAccountIds[0]} />;
+      // Polyam: Don't show follower count
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      additionalContent = undefined && <FollowerCount accountId={account} />;
+    }
+  }
+
+  return (
+    <NotificationGroupWithStatus
+      type='follow'
+      icon={PersonAddIcon}
+      iconId='person-add'
+      accountIds={notification.sampleAccountIds}
+      timestamp={notification.latest_page_notification_at}
+      count={notification.notifications_count}
+      labelRenderer={labelRenderer}
+      unread={unread}
+      actions={actions}
+      additionalContent={additionalContent}
+    />
+  );
+};

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_follow_request.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_follow_request.tsx
@@ -46,7 +46,7 @@ export const NotificationFollowRequest: React.FC<{
   }, [dispatch, notification.sampleAccountIds]);
 
   const actions = (
-    <div className='notification-group__actions'>
+    <>
       <IconButton
         title={intl.formatMessage(messages.reject)}
         icon='times'
@@ -59,7 +59,7 @@ export const NotificationFollowRequest: React.FC<{
         iconComponent={CheckIcon}
         onClick={onAuthorize}
       />
-    </div>
+    </>
   );
 
   return (

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -31,6 +31,7 @@ export const NotificationGroupWithStatus: React.FC<{
   labelSeeMoreHref?: string;
   type: string;
   unread: boolean;
+  additionalContent?: JSX.Element;
 }> = ({
   icon,
   iconId,
@@ -43,6 +44,7 @@ export const NotificationGroupWithStatus: React.FC<{
   labelSeeMoreHref,
   type,
   unread,
+  additionalContent,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -92,7 +94,9 @@ export const NotificationGroupWithStatus: React.FC<{
             <div className='notification-group__main__header__wrapper'>
               <AvatarGroup accountIds={accountIds} />
 
-              {actions}
+              {actions && (
+                <div className='notification-group__actions'>{actions}</div>
+              )}
             </div>
 
             <div className='notification-group__main__header__label'>
@@ -104,6 +108,12 @@ export const NotificationGroupWithStatus: React.FC<{
           {statusId && (
             <div className='notification-group__main__status'>
               <EmbeddedStatus statusId={statusId} />
+            </div>
+          )}
+
+          {additionalContent && (
+            <div className='notification-group__main__additional-content'>
+              {additionalContent}
             </div>
           )}
         </div>

--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -316,6 +316,9 @@
     gap: 8px;
     flex: 1 1 auto;
     overflow: hidden;
+    container-type: inline-size;
+
+    // Polyam: Removed @container here as timestamps should remain visible
 
     &__header {
       display: flex;
@@ -356,6 +359,11 @@
       border: 1px solid var(--background-border-color);
       border-radius: 8px;
       padding: 8px;
+    }
+
+    &__additional-content {
+      color: $darker-text-color;
+      margin-top: -8px; // to offset the parent's `gap` property
     }
   }
 

--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -310,6 +310,11 @@
     }
   }
 
+  // Polyam: Style for icon buttons
+  &--follow &__actions {
+    @include follow-unfollow-icons;
+  }
+
   &__main {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Ported changes:
- 32a78e56e0a9934f65b89a455f2d118642b998de

The gap between the avatar and "x followed you" text is an upstream issue.
The new notification design really doesn't leave much room for customisation, but I don't have any better ideas.

Preview:
![Screenshot of follow notifications showing icon buttons instead of text](https://github.com/user-attachments/assets/e10d2530-f464-4152-b324-db732f5f43b9)
