### PR TITLE
Increase button size in follow request notifications

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -307,6 +307,11 @@
       border: 1px solid var(--background-border-color);
       border-radius: 50%;
       padding: 1px;
+
+      // Polyam: Match upstream's button size
+      .icon {
+        padding: 3px;
+      }
     }
   }
 


### PR DESCRIPTION
Makes the accept and deny buttons larger to match upstream's size.

This essentially increases the clickable area without changing the icon size.