### PR TITLE
Add custom icons to propshaft config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,8 +117,10 @@ module ApplicationHelper
   end
 
   def awesome_icon(icon, attributes = {})
+    variant = "#{attributes[:variant] || 'solid'}/" unless attributes[:variant] == ''
+
     inline_svg_tag(
-      "#{attributes[:variant] || 'solid'}/#{icon}.svg",
+      "#{variant}#{icon}.svg",
       class: ['icon', "fa-#{icon}"].concat(attributes[:class].to_s.split),
       role: :img,
       data: attributes[:data]

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -30,7 +30,7 @@
         %span.negative-hint= t('admin.statuses.deleted')
       ·
       - if status.reblog?
-        = material_symbol('repeat_active', 'boost')
+        = material_symbol('repeat_active', 'boost', variant: '')
         = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(status.proper.account))
       - else
         = fa_visibility_icon(status)

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -66,7 +66,7 @@
     ·
     - if status.public_visibility? || status.unlisted_visibility?
       %span.detailed-status__link
-        = material_symbol('repeat', 'boost')
+        = material_symbol('repeat', 'boost', variant: '')
         %span.detailed-status__reblogs>= friendly_number_to_human status.reblogs_count
         &nbsp;
       ·

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -61,7 +61,7 @@
       %span.icon-button__counter= obscured_counter status.replies_count
     %span.status__action-bar-button.icon-button
       - if status.distributable?
-        = material_symbol 'repeat', 'boost'
+        = material_symbol 'repeat', 'boost', variant: ''
       - elsif status.private_visibility? || status.limited_visibility?
         = material_symbol 'lock', 'lock'
       - else

--- a/config/initializers/propshaft.rb
+++ b/config/initializers/propshaft.rb
@@ -2,6 +2,7 @@
 
 # SVG icons
 Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'images')
+Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'svg-icons')
 
 # Material Design icons
 Rails.application.config.assets.paths << Rails.root.join('app', 'javascript', 'material-icons')


### PR DESCRIPTION
Fixes some icons not working because they aren't available.

For custom icons, variant needs to be set to empty string as otherwise it defaults to solid FA icons.

The `awesome_icon` method was changed to only add a `/` when variant isn't an empty string.