### PR TITLE
Fix alignment of icons in views

### DIFF
--- a/app/javascript/flavours/polyam/styles/admin.scss
+++ b/app/javascript/flavours/polyam/styles/admin.scss
@@ -14,7 +14,7 @@ $content-width: 840px;
   .icon {
     width: 13px;
     height: 13px;
-    vertical-align: top;
+    vertical-align: text-bottom; // Polyam: `text-bottom` instead of `top` for better alignment
     margin: 3px 2px; // Polyam: 3px to simulate material padding
   }
 

--- a/app/javascript/flavours/polyam/styles/tables.scss
+++ b/app/javascript/flavours/polyam/styles/tables.scss
@@ -146,6 +146,11 @@ a.table-action-link {
   &:first-child {
     padding-inline-start: 0;
   }
+
+  // Polyam: Fix alignment due to `text-bottom` in admin-wrapper
+  .icon {
+    vertical-align: top;
+  }
 }
 
 .batch-table {


### PR DESCRIPTION
Fixes #693

This improves the alignment of icons by changing `vertical-align` to `text-bottom` in `.admin-wrapper` and keeping `top` in `.table-action-link`

A consistent style without having to override would be preferred, but that would require more significant changes.

Before:
![Screenshot of a toot in the moderation interface. The globe icon is slightly bottom heavy](https://github.com/user-attachments/assets/cbc23b3f-3355-4d79-a9e8-83d4163f5cc5)

After:
![Screenshot of a toot in the moderation interface. The icon is aligned with the text](https://github.com/user-attachments/assets/d0c03c41-a4a3-49b4-921a-453f1f564def)
