### PR TITLE
Fix CW button color in notifications in homogay skin

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -88,6 +88,17 @@
   }
 }
 
+// Polyam: Applies to notifications
+.status__content__spoiler-link {
+  background-color: lighten($ui-base-color, 30%);
+
+  &:hover,
+  &:focus {
+    // higher for more visibility
+    background-color: lighten($ui-base-color, 37%);
+  }
+}
+
 // hashtags in primary color
 .status__content a {
   color: $highlight-text-color;


### PR DESCRIPTION
Override in `status__content` needs to be kept, otherwise the color is wrong in toots.