### PR TITLE
Redirect to  main instances path when creating domain block with noop…

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -66,8 +66,10 @@ module Admin
 
         if @domain_block.severity == 'suspend'
           redirect_to admin_instances_path(suspended: '1'), notice: I18n.t('admin.domain_blocks.created_msg')
-        else
+        elsif @domain_block.severity == 'silence'
           redirect_to admin_instances_path(limited: '1'), notice: I18n.t('admin.domain_blocks.created_msg')
+        else
+          redirect_to admin_instances_path, notice: I18n.t('admin.domain_blocks.created_msg')
         end
       else
         render :new

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -121,6 +121,26 @@ RSpec.describe Admin::DomainBlocksController do
       end
     end
 
+    # Polyam: Redirect to "all"
+    context 'with "noop" severity and no conflict' do
+      before do
+        post :create, params: { domain_block: { domain: 'example.com', severity: 'noop' } }
+      end
+
+      it 'records a block' do
+        expect(DomainBlock.exists?(domain: 'example.com', severity: 'noop')).to be true
+      end
+
+      it 'calls DomainBlockWorker' do
+        expect(DomainBlockWorker).to have_received(:perform_async)
+      end
+
+      it 'redirects with a success message' do
+        expect(flash[:notice]).to eq I18n.t('admin.domain_blocks.created_msg')
+        expect(response).to redirect_to(admin_instances_path)
+      end
+    end
+
     context 'when upgrading an existing block' do
       before do
         Fabricate(:domain_block, domain: 'example.com', severity: 'silence')


### PR DESCRIPTION
… severity

This completes redirecting to the appropriate filter when creating domain blocks.

Follow-up to #160 