### PR TITLE
Pass description instead of attachment to alt-text-modal

### DIFF
--- a/app/javascript/flavours/polyam/containers/status_container.js
+++ b/app/javascript/flavours/polyam/containers/status_container.js
@@ -173,7 +173,7 @@ const mapDispatchToProps = (dispatch, { contextType }) => ({
   },
 
   onOpenAltText (media) {
-    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { media: media }}));
+    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { description: media.getIn(['translation', 'description']) || media.get('description') }}));
   },
 
   onBlock (status) {

--- a/app/javascript/flavours/polyam/features/account_gallery/index.jsx
+++ b/app/javascript/flavours/polyam/features/account_gallery/index.jsx
@@ -172,7 +172,7 @@ class AccountGallery extends ImmutablePureComponent {
   handleOpenAltText = attachment => {
     const { dispatch } = this.props;
 
-    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: attachment } }));
+    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { description: attachment.getIn(['translation', 'description']) || attachment.get('description') } }));
   };
 
   handleRef = c => {

--- a/app/javascript/flavours/polyam/features/status/index.jsx
+++ b/app/javascript/flavours/polyam/features/status/index.jsx
@@ -394,8 +394,9 @@ class Status extends ImmutablePureComponent {
 
   handleAltClick = (index) => {
     const { status } = this.props;
+    const media = status.getIn(['media_attachtments', index ? index : 0]);
 
-    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { media: status.getIn(['media_attachments', index ? index : 0]) } }));
+    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { description: media.getIn(['translation', 'description']) || media.get('description') } }));
   };
 
   handleHotkeyOpenMedia = e => {

--- a/app/javascript/flavours/polyam/features/ui/components/alttext_modal.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/alttext_modal.jsx
@@ -3,11 +3,9 @@ import { useCallback } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import ImmutablePropTypes from 'react-immutable-proptypes';
-
 import { Button } from 'flavours/polyam/components/button';
 
-export const AltTextModal = ({ media, onClose}) => {
+export const AltTextModal = ({ description, onClose}) => {
   const handleClick = useCallback(() => {
     onClose();
   }, [onClose]);
@@ -16,7 +14,7 @@ export const AltTextModal = ({ media, onClose}) => {
     <div className='modal-root__modal alttext-modal'>
       <div className='alttext-modal__top'>
         <div className='alttext-modal__description'>
-          <pre>{media.getIn(['translation', 'description']) || media.get('description')}</pre>
+          <pre>{description}</pre>
         </div>
       </div>
       <div className='alttext-modal__bottom'>
@@ -31,7 +29,7 @@ export const AltTextModal = ({ media, onClose}) => {
 };
 
 AltTextModal.propTypes = {
-  media: ImmutablePropTypes.map.isRequired,
+  description: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
There is no need to pass the attachment to the modal as only the description is needed.
This also makes it easier to convert the modal to TS.