### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report (Web Interface)
 description: There is a problem using Mastodon's web interface.
-labels: ['status/to triage', 'area/web interface']
-type: Bug
+labels: ['bug', 'status/to triage', 'area/web interface']
+#type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
@@ -1,8 +1,8 @@
 name: Bug Report (server / API)
 description: |
   There is a problem with the HTTP server, REST API, ActivityPub interaction, etc.
-labels: ['status/to triage']
-type: 'Bug'
+labels: ['bug', 'status/to triage']
+#type: 'Bug'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3.troubleshooting.yml
+++ b/.github/ISSUE_TEMPLATE/3.troubleshooting.yml
@@ -1,8 +1,8 @@
 name: Deployment troubleshooting
 description: |
   You are a server administrator and you are encountering a technical issue during installation, upgrade or operations of Mastodon.
-labels: ['status/to triage']
-type: 'Troubleshooting'
+labels: ['troubleshooting', 'status/to triage']
+#type: 'Troubleshooting'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/4.feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: I have a suggestion
-type: Suggestion
+labels: [suggestion]
+#type: Suggestion
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: GitHub Discussions
-    url: https://github.com/mastodon/mastodon/discussions
+    url: https://github.com/polyamspace/mastodon/discussions
     about: Please ask and answer questions here.


### PR DESCRIPTION
The current templates don't work because they use an experimental key which is not permitted.

This disables the `type` key and reintroduces labels for categories.

Also changed the discussion link, since upstream's discussions aren't helpful.