### PR TITLE
Remove old code block style from glitch flavour

### DIFF
--- a/app/javascript/flavours/glitch/styles/rich_text.scss
+++ b/app/javascript/flavours/glitch/styles/rich_text.scss
@@ -148,21 +148,4 @@
   ol {
     list-style-type: decimal;
   }
-
-  code {
-    background: darken($ui-base-color, 4%);
-    border-radius: 3px;
-    padding: 0 0.3em;
-  }
-
-  pre {
-    background: darken($ui-base-color, 4%);
-    border-radius: 3px;
-    padding: 0.5em;
-  }
-
-  pre code {
-    // prevent padding of code tags inside pre
-    padding: 0;
-  }
 }


### PR DESCRIPTION
Upstream now styles these, so this is no longer needed