### PR TITLE
Revert rich text color overrides

### DIFF
--- a/app/javascript/flavours/polyam/styles/mastodon-light/variables.scss
+++ b/app/javascript/flavours/polyam/styles/mastodon-light/variables.scss
@@ -76,5 +76,8 @@ body {
   --background-color-tint: rgba(255, 255, 255, 90%);
   --background-filter: blur(10px);
   --on-surface-color: #{transparentize($ui-base-color, 0.65)};
+  --rich-text-container-color: rgba(255, 216, 231, 100%);
+  --rich-text-text-color: rgba(114, 47, 83, 100%);
+  --rich-text-decorations-color: rgba(255, 175, 212, 100%);
   --toot-focus-background-color: #{lighten($white, 4%)};
 }

--- a/app/javascript/flavours/polyam/styles/rich_text.scss
+++ b/app/javascript/flavours/polyam/styles/rich_text.scss
@@ -35,7 +35,7 @@
 
   blockquote {
     padding-inline-start: 32px;
-    color: var(--rich-text-text-secondary-color);
+    color: var(--rich-text-text-color);
     white-space: normal;
     position: relative;
 

--- a/app/javascript/flavours/polyam/styles/variables.scss
+++ b/app/javascript/flavours/polyam/styles/variables.scss
@@ -124,7 +124,6 @@ $dismiss-overlay-width: 4rem;
   --on-error-color: #fff;
   --rich-text-container-color: #{darken($ui-base-color, 4%)}; // Polyam: Keep previous color
   --rich-text-text-color: #{$primary-text-color}; // Polyam: Keep previous color
-  --rich-text-text-secondary-color: #{$darker-text-color};
   --rich-text-decorations-color: #{$darker-text-color}; // Polyam: Keep previous color
   --toot-focus-background-color: #{color-mix(
       in srgb,

--- a/app/javascript/flavours/polyam/styles/variables.scss
+++ b/app/javascript/flavours/polyam/styles/variables.scss
@@ -122,9 +122,9 @@ $dismiss-overlay-width: 4rem;
   --error-background-color: #{darken($error-red, 16%)};
   --error-active-background-color: #{darken($error-red, 12%)};
   --on-error-color: #fff;
-  --rich-text-container-color: #{darken($ui-base-color, 4%)}; // Polyam: Keep previous color
-  --rich-text-text-color: #{$primary-text-color}; // Polyam: Keep previous color
-  --rich-text-decorations-color: #{$darker-text-color}; // Polyam: Keep previous color
+  --rich-text-container-color: rgba(87, 24, 60, 100%);
+  --rich-text-text-color: rgba(255, 175, 212, 100%);
+  --rich-text-decorations-color: rgba(128, 58, 95, 100%);
   --toot-focus-background-color: #{color-mix(
       in srgb,
       var(--background-color),


### PR DESCRIPTION
Reverts additional changes from #741

I do actually prefer a bit of more color in the interface.
The highlight theme doesn't work in the light skin, unfortunately.