### PR TITLE
Fix alt-text modal not opening in detailed view

### DIFF
--- a/app/javascript/flavours/polyam/features/status/index.jsx
+++ b/app/javascript/flavours/polyam/features/status/index.jsx
@@ -394,7 +394,7 @@ class Status extends ImmutablePureComponent {
 
   handleAltClick = (index) => {
     const { status } = this.props;
-    const media = status.getIn(['media_attachtments', index ? index : 0]);
+    const media = status.getIn(['media_attachments', index ? index : 0]);
 
     this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { description: media.getIn(['translation', 'description']) || media.get('description') } }));
   };


### PR DESCRIPTION
Follow-up to #716

A typo prevented the alt-text modal from opening when clicking the alt badge on video and audio attachments in the detailed view.

For some reason that still worked when viewing a toot in timelines.