### PR TITLE
Use Permalink component in notification groups

### DIFF
--- a/app/javascript/flavours/polyam/features/notifications_v2/components/avatar_group.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/avatar_group.tsx
@@ -1,6 +1,5 @@
-import { Link } from 'react-router-dom';
-
 import { Avatar } from 'flavours/polyam/components/avatar';
+import { Permalink } from 'flavours/polyam/components/permalink';
 import { NOTIFICATIONS_GROUP_MAX_AVATARS } from 'flavours/polyam/models/notification_group';
 import { useAppSelector } from 'flavours/polyam/store';
 
@@ -10,13 +9,14 @@ const AvatarWrapper: React.FC<{ accountId: string }> = ({ accountId }) => {
   if (!account) return null;
 
   return (
-    <Link
+    <Permalink
+      href={account.url}
       to={`/@${account.acct}`}
       title={`@${account.acct}`}
       data-hover-card-account={account.id}
     >
       <Avatar account={account} size={28} />
-    </Link>
+    </Permalink>
   );
 };
 

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/displayed_name.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/displayed_name.tsx
@@ -1,5 +1,4 @@
-import { Link } from 'react-router-dom';
-
+import { Permalink } from 'flavours/polyam/components/permalink';
 import { useAppSelector } from 'flavours/polyam/store';
 
 export const DisplayedName: React.FC<{
@@ -11,12 +10,13 @@ export const DisplayedName: React.FC<{
   if (!account) return null;
 
   return (
-    <Link
+    <Permalink
+      href={account.url}
       to={`/@${account.acct}`}
       title={`@${account.acct}`}
       data-hover-card-account={account.id}
     >
       <bdi dangerouslySetInnerHTML={{ __html: account.display_name_html }} />
-    </Link>
+    </Permalink>
   );
 };


### PR DESCRIPTION
I was hoping for upstream to address this, but this didn't happen.

This makes it easier to quickly copy the link to the account or open it in a new tab.