### PR TITLE
Fix redirect to `/home` in onboarding in advanced interface

### DIFF
--- a/app/javascript/flavours/polyam/features/onboarding/follows.tsx
+++ b/app/javascript/flavours/polyam/features/onboarding/follows.tsx
@@ -146,7 +146,11 @@ export const Follows: React.FC<{
             {displayedAccountIds.length > 0 && <div className='spacer' />}
 
             <div className='column-footer'>
-              <Link className='button button--block' to='/home'>
+              <Link
+                className='button button--block'
+                /* Polyam: Redirect to getting-started in advanced interface */
+                to={multiColumn ? '/getting-started' : '/home'}
+              >
                 <FormattedMessage
                   id='onboarding.follows.done'
                   defaultMessage='Done'


### PR DESCRIPTION
Follow-up to #767 

There is probably a more proper fix, but this also works for now