### PR TITLE
Fix follow button being shown in compose

### DIFF
--- a/app/javascript/flavours/polyam/components/follow_icon_button.tsx
+++ b/app/javascript/flavours/polyam/components/follow_icon_button.tsx
@@ -81,7 +81,7 @@ export const FollowIconButton: React.FC<{
     }
   }, [dispatch, accountId, relationship, account, signedIn]);
 
-  if (!relationship) return null;
+  if (!relationship || accountId === me) return null;
 
   let label, icon, iconComponent;
 


### PR DESCRIPTION
Follow-up to #767 

The FollowIconComponent didn't check whether own accountId is given and showed the follow icon instead of returning null.