### PR TITLE
Fix ColumnSearchHeader creating CSP violation on enter

### DIFF
--- a/app/javascript/flavours/polyam/components/column_search_header.tsx
+++ b/app/javascript/flavours/polyam/components/column_search_header.tsx
@@ -41,9 +41,14 @@ export const ColumnSearchHeader: React.FC<{
     onActivate();
   }, [onActivate]);
 
-  const handleSubmit = useCallback(() => {
-    onSubmit(value);
-  }, [onSubmit, value]);
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      // Polyam: Fixes issue where pressing enter creates a CSP form-action violation
+      e.preventDefault();
+      onSubmit(value);
+    },
+    [onSubmit, value],
+  );
 
   return (
     <form className='column-search-header' onSubmit={handleSubmit}>


### PR DESCRIPTION
This component uses the form element, which by default tries to make a request or reload the page when pressing enter.

This action is thankfully denied by the CSP, but it resulted in an error in the console.

This change adds the missing `e.prevenDefault` to avoid this.