### PR TITLE
Remove unnecessary default prop in status card

### DIFF
--- a/app/javascript/flavours/polyam/features/status/components/card.jsx
+++ b/app/javascript/flavours/polyam/features/status/components/card.jsx
@@ -56,10 +56,6 @@ export default class Card extends PureComponent {
     sensitive: PropTypes.bool,
   };
 
-  static defaultProps = {
-    compact: false,
-  };
-
   state = {
     previewLoaded: false,
     embedded: false,


### PR DESCRIPTION
This is a boolean value which is falsy by default, so explicitly setting it to false is redundant.

Also support for defaultProps will be removed.