### PR TITLE
Fix missed change in port

### DIFF
--- a/app/javascript/flavours/polyam/styles/reset.scss
+++ b/app/javascript/flavours/polyam/styles/reset.scss
@@ -74,7 +74,6 @@ table {
 
 ::-webkit-scrollbar-track {
   background-color: var(--background-border-color);
-  background: $ui-base-color;
   border-radius: 0px;
 }
 


### PR DESCRIPTION
Interesting, the colors are wrong in Chromium browsers.
Or rather technically wrong in Firefox, but FF looks more correct.

Firefox uses the background-border-color as defined in the variables file, while Chromium uses it as defined in the skin file. 