### PR TITLE
Fix scrollbar colors in homogay

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -1,3 +1,15 @@
+// Polyam: Fix scrollbar in chromium browsers
+// Keep in sync with values in reset.scss
+// uses background-border-color value from main variables.scss
+::-webkit-scrollbar-thumb {
+  border-color: lighten($ui-base-color, 4%);
+  box-shadow: inset 0 0 0 2px lighten($ui-base-color, 4%);
+}
+
+::-webkit-scrollbar-track {
+  background-color: lighten($ui-base-color, 4%);
+}
+
 .button {
   text-shadow: 0 0 6px $faint-shadow-color;
 }


### PR DESCRIPTION
Fixes scrollbar colors for homogay skin.
While Chromium technically uses the correct colors, it looks wrong.

This overrides the colors with better looking ones.