### PR TITLE
Port removal of unfollow modal setting

### DIFF
--- a/app/javascript/flavours/polyam/components/follow_button.tsx
+++ b/app/javascript/flavours/polyam/components/follow_button.tsx
@@ -6,12 +6,11 @@ import { useIdentity } from '@/flavours/polyam/identity_context';
 import {
   fetchRelationships,
   followAccount,
-  unfollowAccount,
 } from 'flavours/polyam/actions/accounts';
 import { openModal } from 'flavours/polyam/actions/modal';
 import { Button } from 'flavours/polyam/components/button';
 import { LoadingIndicator } from 'flavours/polyam/components/loading_indicator';
-import { me, unfollowModal } from 'flavours/polyam/initial_state';
+import { me } from 'flavours/polyam/initial_state';
 import { useAppDispatch, useAppSelector } from 'flavours/polyam/store';
 
 const messages = defineMessages({
@@ -64,17 +63,12 @@ export const FollowButton: React.FC<{
     if (accountId === me) {
       return;
     } else if (account && (relationship.following || relationship.requested)) {
-      // Polyam: Keep unfollow modal optional
-      if (unfollowModal) {
-        dispatch(
-          openModal({
-            modalType: 'CONFIRM_UNFOLLOW',
-            modalProps: { account, requested: relationship.requested },
-          }),
-        );
-      } else {
-        dispatch(unfollowAccount(accountId));
-      }
+      dispatch(
+        openModal({
+          modalType: 'CONFIRM_UNFOLLOW',
+          modalProps: { account, requested: relationship.requested },
+        }),
+      );
     } else {
       dispatch(followAccount(accountId));
     }

--- a/app/javascript/flavours/polyam/components/follow_icon_button.tsx
+++ b/app/javascript/flavours/polyam/components/follow_icon_button.tsx
@@ -10,11 +10,10 @@ import { useIdentity } from '@/flavours/polyam/identity_context';
 import {
   fetchRelationships,
   followAccount,
-  unfollowAccount,
 } from 'flavours/polyam/actions/accounts';
 import { openModal } from 'flavours/polyam/actions/modal';
 import { IconButton } from 'flavours/polyam/components/icon_button';
-import { me, unfollowModal } from 'flavours/polyam/initial_state';
+import { me } from 'flavours/polyam/initial_state';
 import { useAppDispatch, useAppSelector } from 'flavours/polyam/store';
 
 const messages = defineMessages({
@@ -65,17 +64,12 @@ export const FollowIconButton: React.FC<{
     if (accountId === me) {
       return;
     } else if (account && (relationship.following || relationship.requested)) {
-      // Polyam: Keep unfollow modal optional
-      if (unfollowModal) {
-        dispatch(
-          openModal({
-            modalType: 'CONFIRM_UNFOLLOW',
-            modalProps: { account, requested: relationship.requested },
-          }),
-        );
-      } else {
-        dispatch(unfollowAccount(accountId));
-      }
+      dispatch(
+        openModal({
+          modalType: 'CONFIRM_UNFOLLOW',
+          modalProps: { account, requested: relationship.requested },
+        }),
+      );
     } else {
       dispatch(followAccount(accountId));
     }

--- a/app/javascript/flavours/polyam/containers/account_container.jsx
+++ b/app/javascript/flavours/polyam/containers/account_container.jsx
@@ -6,7 +6,6 @@ import { openModal } from 'flavours/polyam/actions/modal';
 
 import {
   followAccount,
-  unfollowAccount,
   blockAccount,
   unblockAccount,
   muteAccount,
@@ -14,7 +13,6 @@ import {
 } from '../actions/accounts';
 import { initMuteModal } from '../actions/mutes';
 import Account from '../components/account';
-import { unfollowModal } from '../initial_state';
 import { makeGetAccount } from '../selectors';
 
 const makeMapStateToProps = () => {
@@ -31,11 +29,7 @@ const mapDispatchToProps = (dispatch) => ({
 
   onFollow (account) {
     if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
-      if (unfollowModal) {
-        dispatch(openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account } }));
-      } else {
-        dispatch(unfollowAccount(account.get('id')));
-      }
+      dispatch(openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account } }));
     } else {
       dispatch(followAccount(account.get('id')));
     }

--- a/app/javascript/flavours/polyam/features/account_timeline/containers/header_container.jsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/containers/header_container.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 
 import {
   followAccount,
-  unfollowAccount,
   unblockAccount,
   unmuteAccount,
   pinAccount,
@@ -19,7 +18,6 @@ import { initDomainBlockModal, unblockDomain } from '../../../actions/domain_blo
 import { openModal } from '../../../actions/modal';
 import { initMuteModal } from '../../../actions/mutes';
 import { initReport } from '../../../actions/reports';
-import { unfollowModal } from '../../../initial_state';
 import { makeGetAccount, getAccountHidden } from '../../../selectors';
 import Header from '../components/header';
 
@@ -39,11 +37,7 @@ const mapDispatchToProps = (dispatch) => ({
 
   onFollow (account) {
     if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
-      if (unfollowModal) {
-        dispatch(openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account, requested: account.getIn(['relationship', 'requested']) } }));
-      } else {
-        dispatch(unfollowAccount(account.get('id')));
-      }
+      dispatch(openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account, requested: account.getIn(['relationship', 'requested']) } }));
     } else {
       dispatch(followAccount(account.get('id')));
     }

--- a/app/javascript/flavours/polyam/features/directory/components/account_card.tsx
+++ b/app/javascript/flavours/polyam/features/directory/components/account_card.tsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 
 import {
   followAccount,
-  unfollowAccount,
   unblockAccount,
   unmuteAccount,
 } from 'flavours/polyam/actions/accounts';
@@ -17,7 +16,7 @@ import { Button } from 'flavours/polyam/components/button';
 import { DisplayName } from 'flavours/polyam/components/display_name';
 import { Permalink } from 'flavours/polyam/components/permalink';
 import { ShortNumber } from 'flavours/polyam/components/short_number';
-import { autoPlayGif, me, unfollowModal } from 'flavours/polyam/initial_state';
+import { autoPlayGif, me } from 'flavours/polyam/initial_state';
 import type { Account } from 'flavours/polyam/models/account';
 import { makeGetAccount } from 'flavours/polyam/selectors';
 import { useAppDispatch, useAppSelector } from 'flavours/polyam/store';
@@ -85,20 +84,15 @@ export const AccountCard: React.FC<{ accountId: string }> = ({ accountId }) => {
       account.getIn(['relationship', 'following']) ||
       account.getIn(['relationship', 'requested'])
     ) {
-      // Polyam: Keep unfollow modal optional
-      if (unfollowModal) {
-        dispatch(
-          openModal({
-            modalType: 'CONFIRM_UNFOLLOW',
-            modalProps: {
-              account,
-              requested: account.getIn(['relationship', 'requested']),
-            },
-          }),
-        );
-      } else {
-        dispatch(unfollowAccount(account.get('id')));
-      }
+      dispatch(
+        openModal({
+          modalType: 'CONFIRM_UNFOLLOW',
+          modalProps: {
+            account,
+            requested: account.getIn(['relationship', 'requested']),
+          },
+        }),
+      );
     } else {
       dispatch(followAccount(account.get('id')));
     }

--- a/app/javascript/flavours/polyam/initial_state.js
+++ b/app/javascript/flavours/polyam/initial_state.js
@@ -43,7 +43,6 @@
  * @property {string} title
  * @property {boolean} show_trends
  * @property {boolean} trends_as_landing_page
- * @property {boolean} unfollow_modal
  * @property {boolean} use_blurhash
  * @property {boolean=} use_pending_items
  * @property {string} version
@@ -157,7 +156,6 @@ export const maxReactions = (initialState && initialState.max_reactions) || 1;
 export const visibleReactions = getMeta('visible_reactions');
 export const notificationSound = getMeta('notification_sound');
 export const searchPreview = getMeta('search_preview');
-export const unfollowModal = getMeta('unfollow_modal'); // Kept from upstream
 export const publishButtonText = getMeta('publish_button_text');
 export const showReblogsPublicTimelines = getMeta('show_reblogs_in_public_timelines');
 export const showRepliesPublicTimelines = getMeta('show_replies_in_public_timelines');

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -27,10 +27,6 @@ module User::HasSettings
     settings['default_sensitive']
   end
 
-  def setting_unfollow_modal
-    settings['web.unfollow_modal']
-  end
-
   def setting_boost_modal
     settings['web.reblog_modal']
   end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -36,7 +36,6 @@ class UserSettings
     setting :disable_hover_cards, default: false
     setting :delete_modal, default: true
     setting :reblog_modal, default: false
-    setting :unfollow_modal, default: true
     setting :favourite_modal, default: false
     setting :reduce_motion, default: false
     setting :expand_content_warnings, default: false

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -35,7 +35,6 @@ class InitialStateSerializer < ActiveModel::Serializer
 
     if object.current_account
       store[:me]                = object.current_account.id.to_s
-      store[:unfollow_modal]    = object_account_user.setting_unfollow_modal
       store[:boost_modal]       = object_account_user.setting_boost_modal
       store[:favourite_modal]   = object_account_user.setting_favourite_modal
       store[:delete_modal]      = object_account_user.setting_delete_modal

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -66,7 +66,6 @@
     %h4= t 'appearance.confirmation_dialogs'
 
     .fields-group
-      = ff.input :'web.unfollow_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_unfollow_modal'), polyam_only: true
       = ff.input :'web.reblog_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
       = ff.input :'web.favourite_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_polyam_favourite_modal'), glitch_only: true
       = ff.input :'web.delete_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_delete_modal')


### PR DESCRIPTION
Ported changes:
- 37ca59815cd3a3b2662e20f0c28185eb0d604dd4

I came around on this. I hate needless extra clicks, but I guess for potentially "destructive" changes like unfollowing it's fine.