### PR TITLE
Extract collapsing CSS to separate file

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/collapsing.scss
+++ b/app/javascript/flavours/polyam/styles/components/collapsing.scss
@@ -1,0 +1,66 @@
+// Polyam: Collapsing CSS kept from upstream
+
+.status__wrapper.collapsed {
+  .status {
+    background-position: center;
+    background-size: cover;
+    user-select: none;
+    min-height: 0;
+  }
+
+  .display-name:hover .display-name__html {
+    text-decoration: none;
+  }
+
+  .status__content {
+    height: 20px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-top: 0;
+    mask-image: linear-gradient(rgb(0 0 0 / 100%), transparent);
+
+    a:hover {
+      text-decoration: none;
+    }
+
+    // Polyam extra change for backgrounds of code blocks
+    pre,
+    code {
+      padding: 0;
+    }
+  }
+
+  .notification__message {
+    margin-bottom: 0;
+    white-space: nowrap;
+  }
+}
+
+.status__collapse-button.active > .icon {
+  transform: rotate(-180deg);
+}
+
+.no-reduce-motion .status__collapse-button {
+  &.activate {
+    & > .icon {
+      animation: spring-flip-in 1s linear;
+    }
+  }
+
+  &.deactivate {
+    & > .icon {
+      animation: spring-flip-out 1s linear;
+    }
+  }
+}
+
+.notification__message-collapse-button {
+  text-align: end;
+  flex-grow: 2;
+
+  // Polyam: Different size, because smaller for polyam-glitch
+  .status__collapse-button .icon {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/app/javascript/flavours/polyam/styles/components/index.scss
+++ b/app/javascript/flavours/polyam/styles/components/index.scss
@@ -10,6 +10,7 @@
 @import 'domains';
 @import 'status/index';
 @import 'notification';
+@import 'collapsing';
 @import 'modals/index';
 @import 'compose/index';
 @import 'scrollable';

--- a/app/javascript/flavours/polyam/styles/components/notification.scss
+++ b/app/javascript/flavours/polyam/styles/components/notification.scss
@@ -1,14 +1,3 @@
-.notification__message-collapse-button {
-  text-align: end;
-  flex-grow: 2;
-
-  // Polyam: Different size, because smaller for polyam-glitch
-  .status__collapse-button .icon {
-    width: 16px;
-    height: 16px;
-  }
-}
-
 .notification__relative_time {
   color: $dark-text-color;
   float: right;

--- a/app/javascript/flavours/polyam/styles/components/status/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status/status.scss
@@ -222,42 +222,6 @@
   }
 }
 
-.status__wrapper.collapsed {
-  .status {
-    background-position: center;
-    background-size: cover;
-    user-select: none;
-    min-height: 0;
-  }
-
-  .display-name:hover .display-name__html {
-    text-decoration: none;
-  }
-
-  .status__content {
-    height: 20px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding-top: 0;
-    mask-image: linear-gradient(rgb(0 0 0 / 100%), transparent);
-
-    a:hover {
-      text-decoration: none;
-    }
-
-    // Polyam extra change for backgrounds of code blocks
-    pre,
-    code {
-      padding: 0;
-    }
-  }
-
-  .notification__message {
-    margin-bottom: 0;
-    white-space: nowrap;
-  }
-}
-
 .status__relative-time {
   display: block;
   font-size: 14px;
@@ -322,24 +286,6 @@
   // Polyam: Temporary fix for language icon
   .text-icon {
     font-weight: 600;
-  }
-}
-
-.status__collapse-button.active > .icon {
-  transform: rotate(-180deg);
-}
-
-.no-reduce-motion .status__collapse-button {
-  &.activate {
-    & > .icon {
-      animation: spring-flip-in 1s linear;
-    }
-  }
-
-  &.deactivate {
-    & > .icon {
-      animation: spring-flip-out 1s linear;
-    }
   }
 }
 


### PR DESCRIPTION
Since upstream is dropping this feature, I think it makes sense to move it to a separate file.