### PR TITLE
Wrap scrollbar fix in additional class in homogay

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -1,13 +1,15 @@
 // Polyam: Fix scrollbar in chromium browsers
 // Keep in sync with values in reset.scss
 // uses background-border-color value from main variables.scss
-::-webkit-scrollbar-thumb {
-  border-color: lighten($ui-base-color, 4%);
-  box-shadow: inset 0 0 0 2px lighten($ui-base-color, 4%);
-}
+.custom-scrollbars {
+  ::-webkit-scrollbar-thumb {
+    border-color: lighten($ui-base-color, 4%);
+    box-shadow: inset 0 0 0 2px lighten($ui-base-color, 4%);
+  }
 
-::-webkit-scrollbar-track {
-  background-color: lighten($ui-base-color, 4%);
+  ::-webkit-scrollbar-track {
+    background-color: lighten($ui-base-color, 4%);
+  }
 }
 
 .button {


### PR DESCRIPTION
Wraps the fix for scrollbar colors in Chromium in the new `.custom-scrollbars` class like upstream.