### PR TITLE
Port status markup change

### DIFF
--- a/app/javascript/flavours/polyam/components/content_warning.tsx
+++ b/app/javascript/flavours/polyam/components/content_warning.tsx
@@ -1,17 +1,25 @@
+import type { IconName } from './media_icon';
+import { MediaIcon } from './media_icon';
 import { StatusBanner, BannerVariant } from './status_banner';
 
 export const ContentWarning: React.FC<{
   text: string;
   expanded?: boolean;
   onClick?: () => void;
-  icons?: React.ReactNode[];
+  icons?: IconName[];
 }> = ({ text, expanded, onClick, icons }) => (
   <StatusBanner
     expanded={expanded}
     onClick={onClick}
     variant={BannerVariant.Warning}
   >
-    {icons}
+    {icons?.map((icon) => (
+      <MediaIcon
+        className='status__content__spoiler-icon'
+        icon={icon}
+        key={`icon-${icon}`}
+      />
+    ))}
     <p dangerouslySetInnerHTML={{ __html: text }} />
   </StatusBanner>
 );

--- a/app/javascript/flavours/polyam/components/media_icon.tsx
+++ b/app/javascript/flavours/polyam/components/media_icon.tsx
@@ -1,0 +1,55 @@
+import { defineMessages, useIntl } from 'react-intl';
+
+import ImageIcon from '@/awesome-icons/regular/image.svg?react';
+import InsertChartIcon from '@/awesome-icons/solid/bars-progress.svg?react';
+import LinkIcon from '@/awesome-icons/solid/link.svg?react';
+import MusicNoteIcon from '@/awesome-icons/solid/music.svg?react';
+import MovieIcon from '@/awesome-icons/solid/video.svg?react';
+import { Icon } from 'flavours/polyam/components/icon';
+
+const messages = defineMessages({
+  link: {
+    id: 'status.has_preview_card',
+    defaultMessage: 'Features an attached preview card',
+  },
+  'picture-o': {
+    id: 'status.has_pictures',
+    defaultMessage: 'Features attached pictures',
+  },
+  tasks: { id: 'status.is_poll', defaultMessage: 'This toot is a poll' },
+  'video-camera': {
+    id: 'status.has_video',
+    defaultMessage: 'Features attached videos',
+  },
+  music: {
+    id: 'status.has_audio',
+    defaultMessage: 'Features attached audio files',
+  },
+});
+
+const iconComponents = {
+  link: LinkIcon,
+  'picture-o': ImageIcon,
+  tasks: InsertChartIcon,
+  'video-camera': MovieIcon,
+  music: MusicNoteIcon,
+};
+
+export type IconName = keyof typeof iconComponents;
+
+export const MediaIcon: React.FC<{
+  className?: string;
+  icon: IconName;
+}> = ({ className, icon }) => {
+  const intl = useIntl();
+
+  return (
+    <Icon
+      className={className}
+      id={icon}
+      icon={iconComponents[icon]}
+      title={intl.formatMessage(messages[icon])}
+      aria-hidden='true'
+    />
+  );
+};

--- a/app/javascript/flavours/polyam/components/mentions_placeholder.jsx
+++ b/app/javascript/flavours/polyam/components/mentions_placeholder.jsx
@@ -1,0 +1,28 @@
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+import { Permalink } from 'flavours/polyam/components/permalink';
+
+export const MentionsPlaceholder = ({ status }) => {
+  if (status.get('spoiler_text').length === 0 || !status.get('mentions')) {
+    return null;
+  }
+
+  return (
+    <div className='status__content'>
+      {status.get('mentions').map(item => (
+        <Permalink
+          to={`/@${item.get('acct')}`}
+          href={item.get('url')}
+          key={item.get('id')}
+          className='mention'
+        >
+          @<span>{item.get('username')}</span>
+        </Permalink>
+      )).reduce((aggregate, item) => [...aggregate, item, ' '], [])}
+    </div>
+  );
+};
+
+MentionsPlaceholder.propTypes = {
+  status: ImmutablePropTypes.map.isRequired,
+};

--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -836,8 +836,9 @@ class Status extends ImmutablePureComponent {
 
             {status.get('spoiler_text').length > 0 && <ContentWarning text={status.getIn(['translation', 'spoilerHtml']) || status.get('spoilerHtml')} expanded={expanded} onClick={this.handleExpandedToggle} icons={mediaIcons} />}
 
+            {/* Polyam: div with className to allow collapsing */}
             {expanded && (
-              <>
+              <div className='status__content__wrapper'>
                 <StatusContent
                   status={status}
                   onClick={this.handleClick}
@@ -853,7 +854,7 @@ class Status extends ImmutablePureComponent {
 
                 {media}
                 {hashtagBar}
-              </>
+              </div>
             )}
 
             {/* This is a glitch-soc addition to have a placeholder */}

--- a/app/javascript/flavours/polyam/components/status_content.jsx
+++ b/app/javascript/flavours/polyam/components/status_content.jsx
@@ -9,20 +9,13 @@ import { withRouter } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-import ImageIcon from '@/awesome-icons/regular/image.svg?react';
-import PollIcon from '@/awesome-icons/solid/bars-progress.svg?react';
 import ChevronRightIcon from '@/awesome-icons/solid/chevron-right.svg?react';
-import LinkIcon from '@/awesome-icons/solid/link.svg?react';
-import MusicIcon from '@/awesome-icons/solid/music.svg?react';
-import VideoIcon from '@/awesome-icons/solid/video.svg?react';
-import { ContentWarning } from 'flavours/polyam/components/content_warning';
 import { Icon } from 'flavours/polyam/components/icon';
+import PollContainer from 'flavours/polyam/containers/poll_container';
 import { identityContextPropShape, withIdentity } from 'flavours/polyam/identity_context';
 import { autoPlayGif, languages as preloadedLanguages } from 'flavours/polyam/initial_state';
 import { highlightCode } from 'flavours/polyam/utils/html';
 import { decode as decodeIDNA } from 'flavours/polyam/utils/idna';
-
-import { Permalink } from './permalink';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
@@ -136,16 +129,10 @@ class StatusContent extends PureComponent {
     identity: identityContextPropShape,
     status: ImmutablePropTypes.map.isRequired,
     statusContent: PropTypes.string,
-    expanded: PropTypes.bool,
-    onExpandedToggle: PropTypes.func,
     onTranslate: PropTypes.func,
-    media: PropTypes.node,
-    extraMedia: PropTypes.node,
-    mediaIcons: PropTypes.arrayOf(PropTypes.string),
     onClick: PropTypes.func,
     collapsible: PropTypes.bool,
     onCollapsedToggle: PropTypes.func,
-    onUpdate: PropTypes.func,
     tagLinks: PropTypes.bool,
     rewriteMentions: PropTypes.string,
     languages: ImmutablePropTypes.map,
@@ -163,12 +150,8 @@ class StatusContent extends PureComponent {
     rewriteMentions: 'no',
   };
 
-  state = {
-    hidden: true,
-  };
-
   _updateStatusLinks () {
-    const node = this.contentsNode;
+    const node = this.node;
     const { tagLinks, rewriteMentions } = this.props;
 
     if (!node) {
@@ -283,7 +266,6 @@ class StatusContent extends PureComponent {
 
   componentDidUpdate () {
     this._updateStatusLinks();
-    if (this.props.onUpdate) this.props.onUpdate();
   }
 
   onMentionClick = (mention, e) => {
@@ -329,49 +311,27 @@ class StatusContent extends PureComponent {
     this.startXY = null;
   };
 
-  handleSpoilerClick = (e) => {
-    e.preventDefault();
-
-    if (this.props.onExpandedToggle) {
-      this.props.onExpandedToggle();
-    } else {
-      this.setState({ hidden: !this.state.hidden });
-    }
-  };
-
   handleTranslate = () => {
     this.props.onTranslate();
   };
 
-  setContentsRef = (c) => {
-    this.contentsNode = c;
+  setRef = (c) => {
+    this.node = c;
   };
 
   render () {
-    const {
-      status,
-      media,
-      extraMedia,
-      mediaIcons,
-      tagLinks,
-      rewriteMentions,
-      intl,
-      statusContent,
-    } = this.props;
+    const { status, intl, statusContent } = this.props;
 
     const renderReadMore = this.props.onClick && status.get('collapsed');
-    const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
     const contentLocale = intl.locale.replace(/[_-].*/, '');
     const targetLanguages = this.props.languages?.get(status.get('language') || 'und');
     const renderTranslate = this.props.onTranslate && this.props.identity.signedIn && ['public', 'unlisted'].includes(status.get('visibility')) && status.get('search_index').trim().length > 0 && targetLanguages?.includes(contentLocale);
 
     const content = { __html: highlightCode(statusContent ?? getStatusContent(status)) };
-    const spoilerHtml = status.getIn(['translation', 'spoilerHtml']) || status.get('spoilerHtml');
     const language = status.getIn(['translation', 'language']) || status.get('language');
     const classNames = classnames('status__content', {
       'status__content--with-action': this.props.onClick && this.props.history,
       'status__content--collapsed': renderReadMore,
-      'status__content--with-spoiler': status.get('spoiler_text').length > 0,
     });
 
     const readMoreButton = renderReadMore && (
@@ -389,111 +349,30 @@ class StatusContent extends PureComponent {
       <TranslateButton onClick={this.handleTranslate} translation={status.get('translation')} />
     );
 
-    if (status.get('spoiler_text').length > 0) {
-      let mentionsPlaceholder = '';
+    const poll = !!status.get('poll') && (
+      <PollContainer pollId={status.get('poll')} status={status} lang={language} />
+    );
 
-      const mentionLinks = status.get('mentions').map(item => (
-        <Permalink
-          to={`/@${item.get('acct')}`}
-          href={item.get('url')}
-          key={item.get('id')}
-          className='mention'
-        >
-          @<span>{item.get('username')}</span>
-        </Permalink>
-      )).reduce((aggregate, item) => [...aggregate, item, ' '], []);
-
-      let spoilerIcons = [];
-      if (mediaIcons) {
-        const mediaComponents = {
-          'link': LinkIcon,
-          'picture-o': ImageIcon,
-          'tasks': PollIcon,
-          'video-camera': VideoIcon,
-          'music': MusicIcon,
-        };
-
-        spoilerIcons = mediaIcons.map((mediaIcon) => (
-          <Icon
-            fixedWidth
-            className='status__content__spoiler-icon'
-            id={mediaIcon}
-            icon={mediaComponents[mediaIcon]}
-            aria-hidden='true'
-            key={`icon-${mediaIcon}`}
-          />
-        ));
-      }
-
-      if (hidden) {
-        mentionsPlaceholder = <div>{mentionLinks}</div>;
-      }
-
+    if (this.props.onClick) {
       return (
-        <div className={classNames} tabIndex={0} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp}>
-          <ContentWarning text={spoilerHtml} expanded={!hidden} onClick={this.handleSpoilerClick} icons={spoilerIcons} />
+        <>
+          <div className={classNames} ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} tabIndex={0} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+            <div className='status__content__text status__content__text--visible translate' lang={language} dangerouslySetInnerHTML={content} />
 
-          {mentionsPlaceholder}
-
-          <div className={`status__content__spoiler ${!hidden ? 'status__content__spoiler--visible' : ''}`}>
-            <div
-              ref={this.setContentsRef}
-              key={`contents-${tagLinks}`}
-              tabIndex={!hidden ? 0 : null}
-              dangerouslySetInnerHTML={content}
-              className='status__content__text translate'
-              onMouseEnter={this.handleMouseEnter}
-              onMouseLeave={this.handleMouseLeave}
-              lang={language}
-            />
-            {!hidden && translateButton}
-            {media}
+            {poll}
+            {translateButton}
           </div>
 
-          {extraMedia}
-        </div>
-      );
-    } else if (this.props.onClick) {
-      return (
-        <div
-          className={classNames}
-          onMouseDown={this.handleMouseDown}
-          onMouseUp={this.handleMouseUp}
-          tabIndex={0}
-        >
-          <div
-            ref={this.setContentsRef}
-            key={`contents-${tagLinks}-${rewriteMentions}`}
-            dangerouslySetInnerHTML={content}
-            className='status__content__text translate'
-            onMouseEnter={this.handleMouseEnter}
-            onMouseLeave={this.handleMouseLeave}
-            lang={language}
-          />
-          {translateButton}
           {readMoreButton}
-          {media}
-          {extraMedia}
-        </div>
+        </>
       );
     } else {
       return (
-        <div
-          className='status__content'
-          tabIndex={0}
-        >
-          <div
-            ref={this.setContentsRef}
-            key={`contents-${tagLinks}`}
-            className='status__content__text translate'
-            dangerouslySetInnerHTML={content}
-            onMouseEnter={this.handleMouseEnter}
-            onMouseLeave={this.handleMouseLeave}
-            lang={language}
-          />
+        <div className={classNames} ref={this.setRef} tabIndex={0} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+          <div className='status__content__text status__content__text--visible translate' lang={language} dangerouslySetInnerHTML={content} />
+
+          {poll}
           {translateButton}
-          {media}
-          {extraMedia}
         </div>
       );
     }

--- a/app/javascript/flavours/polyam/components/status_icons.jsx
+++ b/app/javascript/flavours/polyam/components/status_icons.jsx
@@ -6,15 +6,11 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-import ImageIcon from '@/awesome-icons/regular/image.svg?react';
-import PollIcon from '@/awesome-icons/solid/bars-progress.svg?react';
 import CommentingIcon from '@/awesome-icons/solid/comment-dots.svg?react';
 import CommentIcon from '@/awesome-icons/solid/comment.svg?react';
 import HomeIcon from '@/awesome-icons/solid/house.svg?react';
-import LinkIcon from '@/awesome-icons/solid/link.svg?react';
-import MusicIcon from '@/awesome-icons/solid/music.svg?react';
-import VideoIcon from '@/awesome-icons/solid/video.svg?react';
 import { Icon } from 'flavours/polyam/components/icon';
+import { MediaIcon } from 'flavours/polyam/components/media_icon';
 import { languages } from 'flavours/polyam/initial_state';
 
 import { CollapseButton } from './collapse_button';
@@ -24,12 +20,7 @@ const messages = defineMessages({
   collapse: { id: 'status.collapse', defaultMessage: 'Collapse' },
   uncollapse: { id: 'status.uncollapse', defaultMessage: 'Uncollapse' },
   inReplyTo: { id: 'status.in_reply_to', defaultMessage: 'This toot is a reply' },
-  previewCard: { id: 'status.has_preview_card', defaultMessage: 'Features an attached preview card' },
-  pictures: { id: 'status.has_pictures', defaultMessage: 'Features attached pictures' },
-  poll: { id: 'status.is_poll', defaultMessage: 'This toot is a poll' },
   thread: { id: 'status.is_thread', defaultMessage: 'This toot is part of a thread' },
-  video: { id: 'status.has_video', defaultMessage: 'Features attached videos' },
-  audio: { id: 'status.has_audio', defaultMessage: 'Features attached audio files' },
   localOnly: { id: 'status.local_only', defaultMessage: 'Only visible from your instance' },
 });
 
@@ -61,46 +52,6 @@ class StatusIcons extends PureComponent {
     collapsed: PropTypes.bool,
     setCollapsed: PropTypes.func,
   };
-
-  renderIcon (mediaIcon) {
-    const { intl } = this.props;
-
-    let title, iconComponent;
-
-    switch (mediaIcon) {
-    case 'link':
-      title = messages.previewCard;
-      iconComponent = LinkIcon;
-      break;
-    case 'picture-o':
-      title = messages.pictures;
-      iconComponent = ImageIcon;
-      break;
-    case 'tasks':
-      title = messages.poll;
-      iconComponent = PollIcon;
-      break;
-    case 'video-camera':
-      title = messages.video;
-      iconComponent = VideoIcon;
-      break;
-    case 'music':
-      title = messages.audio;
-      iconComponent = MusicIcon;
-      break;
-    }
-
-    return (
-      <Icon
-        className='status__media-icon'
-        key={`media-icon--${mediaIcon}`}
-        id={mediaIcon}
-        icon={iconComponent}
-        aria-hidden='true'
-        title={title && intl.formatMessage(title)}
-      />
-    );
-  }
 
   render () {
     const {
@@ -141,7 +92,7 @@ class StatusIcons extends PureComponent {
             aria-hidden='true'
             title={intl.formatMessage(messages.localOnly)}
           />}
-        {settings.get('media') && !!mediaIcons && mediaIcons.map(icon => this.renderIcon(icon))}
+        {settings.get('media') && !!mediaIcons && mediaIcons.map(icon => (<MediaIcon key={`media-icon--${icon}`} className='status__media-icon' icon={icon} />))}
         {settings.get('visibility') && <VisibilityIcon visibility={status.get('visibility')} />}
         {collapsible && <CollapseButton collapsed={collapsed} setCollapsed={setCollapsed} />}
       </div>

--- a/app/javascript/flavours/polyam/features/local_settings/page/index.jsx
+++ b/app/javascript/flavours/polyam/features/local_settings/page/index.jsx
@@ -341,15 +341,6 @@ class LocalSettingsPage extends PureComponent {
           <FormattedMessage id='settings.content_warnings_shared_state' defaultMessage='Show/hide content of all copies at once' />
           <span className='hint'><FormattedMessage id='settings.content_warnings_shared_state_hint' defaultMessage='Reproduce upstream Mastodon behavior by having the Content Warning button affect all copies of a post at once. This will prevent automatic collapsing of any copy of a toot with unfolded CW' /></span>
         </LocalSettingsPageItem>
-        <LocalSettingsPageItem
-          settings={settings}
-          item={['content_warnings', 'media_outside']}
-          id='mastodon-settings--content_warnings-media_outside'
-          onChange={onChange}
-        >
-          <FormattedMessage id='settings.content_warnings_media_outside' defaultMessage='Display media attachments outside content warnings' />
-          <span className='hint'><FormattedMessage id='settings.content_warnings_media_outside_hint' defaultMessage='Reproduce upstream Mastodon behavior by having the Content Warning toggle not affect media attachments' /></span>
-        </LocalSettingsPageItem>
         <section>
           <h2><FormattedMessage id='settings.content_warnings_unfold_opts' defaultMessage='Auto-unfolding options' /></h2>
           <DeprecatedLocalSettingsPageItem

--- a/app/javascript/flavours/polyam/features/status/components/detailed_status.tsx
+++ b/app/javascript/flavours/polyam/features/status/components/detailed_status.tsx
@@ -13,14 +13,15 @@ import { Link } from 'react-router-dom';
 
 import { AnimatedNumber } from 'flavours/polyam/components/animated_number';
 import AttachmentList from 'flavours/polyam/components/attachment_list';
+import { ContentWarning } from 'flavours/polyam/components/content_warning';
 import EditedTimestamp from 'flavours/polyam/components/edited_timestamp';
 import type { StatusLike } from 'flavours/polyam/components/hashtag_bar';
 import { getHashtagBarForStatus } from 'flavours/polyam/components/hashtag_bar';
 import { IconLogo } from 'flavours/polyam/components/logo';
+import { MentionsPlaceholder } from 'flavours/polyam/components/mentions_placeholder';
 import { Permalink } from 'flavours/polyam/components/permalink';
 import PictureInPicturePlaceholder from 'flavours/polyam/components/picture_in_picture_placeholder';
 import { VisibilityIcon } from 'flavours/polyam/components/visibility_icon';
-import PollContainer from 'flavours/polyam/containers/poll_container';
 import { useAppSelector } from 'flavours/polyam/store';
 
 import { Avatar } from '../../../components/avatar';
@@ -85,13 +86,6 @@ export const DetailedStatus: React.FC<{
     (state) =>
       state.local_settings.get('tag_misleading_links', false) as boolean,
   );
-  const mediaOutsideCW = useAppSelector(
-    (state) =>
-      state.local_settings.getIn(
-        ['content_warnings', 'media_outside'],
-        false,
-      ) as boolean,
-  );
   const letterboxMedia = useAppSelector(
     (state) =>
       state.local_settings.getIn(['media', 'letterbox'], false) as boolean,
@@ -110,6 +104,10 @@ export const DetailedStatus: React.FC<{
     },
     [onOpenVideo, status],
   );
+
+  const handleExpandedToggle = useCallback(() => {
+    if (onToggleHidden) onToggleHidden(status);
+  }, [onToggleHidden, status]);
 
   const _measureHeight = useCallback(
     (heightJustChanged?: boolean) => {
@@ -135,10 +133,6 @@ export const DetailedStatus: React.FC<{
     [_measureHeight],
   );
 
-  const handleChildUpdate = useCallback(() => {
-    _measureHeight();
-  }, [_measureHeight]);
-
   const handleTranslate = useCallback(() => {
     if (onTranslate) onTranslate(status);
   }, [onTranslate, status]);
@@ -147,23 +141,11 @@ export const DetailedStatus: React.FC<{
     return null;
   }
 
+  let media;
   let applicationLink;
   let reblogLink;
 
-  //  Depending on user settings, some media are considered as parts of the
-  //  contents (affected by CW) while other will be displayed outside of the
-  //  CW.
-  const contentMedia: React.ReactNode[] = [];
-  const contentMediaIcons: string[] = [];
-  const extraMedia: React.ReactNode[] = [];
-  const extraMediaIcons: string[] = [];
-  let media = contentMedia;
-  let mediaIcons: string[] = contentMediaIcons;
-
-  if (mediaOutsideCW) {
-    media = extraMedia;
-    mediaIcons = extraMediaIcons;
-  }
+  const mediaIcons: string[] = [];
 
   const outerStyle = { boxSizing: 'border-box' } as CSSProperties;
 
@@ -175,7 +157,7 @@ export const DetailedStatus: React.FC<{
     status.getIn(['translation', 'language']) || status.get('language');
 
   if (pictureInPicture.get('inUse')) {
-    media.push(<PictureInPicturePlaceholder />);
+    media = <PictureInPicturePlaceholder />;
     mediaIcons.push('video-camera');
   } else if (status.get('media_attachments').size > 0) {
     if (
@@ -185,14 +167,14 @@ export const DetailedStatus: React.FC<{
           (item: Immutable.Map<string, any>) => item.get('type') === 'unknown',
         )
     ) {
-      media.push(<AttachmentList media={status.get('media_attachments')} />);
+      media = <AttachmentList media={status.get('media_attachments')} />;
     } else if (
       ['image', 'gifv', 'unknown'].includes(
         status.getIn(['media_attachments', 0, 'type']) as string,
       ) ||
       status.get('media_attachments').size > 1
     ) {
-      media.push(
+      media = (
         <MediaGallery
           standalone
           sensitive={status.get('sensitive')}
@@ -206,7 +188,7 @@ export const DetailedStatus: React.FC<{
           visible={showMedia}
           onToggleVisibility={onToggleMediaVisibility}
           onOpenAltText={onOpenAltText}
-        />,
+        />
       );
       mediaIcons.push('picture-o');
     } else if (status.getIn(['media_attachments', 0, 'type']) === 'audio') {
@@ -215,7 +197,7 @@ export const DetailedStatus: React.FC<{
         attachment.getIn(['translation', 'description']) ||
         attachment.get('description');
 
-      media.push(
+      media = (
         <Audio
           src={attachment.get('url')}
           alt={description}
@@ -234,7 +216,7 @@ export const DetailedStatus: React.FC<{
           height={150}
           onToggleVisibility={onToggleMediaVisibility}
           onOpenAltText={onOpenAltText}
-        />,
+        />
       );
       mediaIcons.push('music');
     } else if (status.getIn(['media_attachments', 0, 'type']) === 'video') {
@@ -243,7 +225,7 @@ export const DetailedStatus: React.FC<{
         attachment.getIn(['translation', 'description']) ||
         attachment.get('description');
 
-      media.push(
+      media = (
         <Video
           preview={attachment.get('preview_url')}
           frameRate={attachment.getIn(['meta', 'original', 'frame_rate'])}
@@ -263,31 +245,23 @@ export const DetailedStatus: React.FC<{
           fullwidth={fullwidthMedia}
           preventPlayback={!expanded}
           onOpenAltText={onOpenAltText}
-        />,
+        />
       );
       mediaIcons.push('video-camera');
     }
   } else if (status.get('spoiler_text').length === 0) {
-    media.push(
+    media = (
       <Card
         sensitive={status.get('sensitive')}
         onOpenMedia={onOpenMedia}
         card={status.get('card', null)}
-      />,
+      />
     );
     mediaIcons.push('link');
   }
 
   if (status.get('poll')) {
-    contentMedia.push(
-      <PollContainer
-        pollId={status.get('poll')}
-        // @ts-expect-error -- Poll/PollContainer is not typed yet
-        status={status}
-        lang={status.get('language')}
-      />,
-    );
-    contentMediaIcons.push('tasks');
+    mediaIcons.push('tasks');
   }
 
   if (status.get('application')) {
@@ -367,7 +341,8 @@ export const DetailedStatus: React.FC<{
   const { statusContentProps, hashtagBar } = getHashtagBarForStatus(
     status as StatusLike,
   );
-  contentMedia.push(hashtagBar);
+
+  expanded ||= status.get('spoiler_text').length === 0;
 
   return (
     <div style={outerStyle}>
@@ -401,20 +376,35 @@ export const DetailedStatus: React.FC<{
           )}
         </Permalink>
 
-        <StatusContent
-          status={status}
-          media={contentMedia}
-          extraMedia={extraMedia}
-          mediaIcons={contentMediaIcons}
-          expanded={expanded}
-          collapsed={false}
-          onExpandedToggle={onToggleHidden}
-          onTranslate={handleTranslate}
-          onUpdate={handleChildUpdate}
-          tagLinks={tagMisleadingLinks}
-          rewriteMentions={rewriteMentions}
-          {...(statusContentProps as any)}
-        />
+        {status.get('spoiler_text').length > 0 && (
+          <ContentWarning
+            text={
+              status.getIn(['translation', 'spoilerHtml']) ||
+              status.get('spoilerHtml')
+            }
+            expanded={expanded}
+            onClick={handleExpandedToggle}
+          />
+        )}
+
+        {expanded && (
+          <>
+            <StatusContent
+              status={status}
+              onTranslate={handleTranslate}
+              tagLinks={tagMisleadingLinks}
+              rewriteMentions={rewriteMentions}
+              collapsed={false}
+              {...(statusContentProps as any)}
+            />
+
+            {media}
+            {hashtagBar}
+          </>
+        )}
+
+        {/* This is a glitch-soc addition to have a placeholder */}
+        {!expanded && <MentionsPlaceholder status={status} />}
 
         <StatusReactions
           statusId={status.get('id')}

--- a/app/javascript/flavours/polyam/reducers/local_settings.js
+++ b/app/javascript/flavours/polyam/reducers/local_settings.js
@@ -23,7 +23,6 @@ const initialState = ImmutableMap({
   rewrite_mentions: 'no',
   content_warnings : ImmutableMap({
     filter       : null,
-    media_outside: false,
     shared_state : false,
   }),
   // Polyam: Collapsing kept from upstream

--- a/app/javascript/flavours/polyam/styles/components/collapsing.scss
+++ b/app/javascript/flavours/polyam/styles/components/collapsing.scss
@@ -12,7 +12,7 @@
     text-decoration: none;
   }
 
-  .status__content {
+  .status__content__wrapper {
     height: 20px;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/javascript/flavours/polyam/styles/components/status/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status/status.scss
@@ -11,14 +11,8 @@
   @include status-content;
 }
 
-.status__content {
-  // glitch: necessary for fullwidth media options
-  overflow: visible;
-}
-
 .status__content.status__content--collapsed .status__content__text {
   max-height: 20px * 15; // 15 lines is roughly above 500 characters
-  overflow: hidden;
 }
 
 .status__content__read-more-button,
@@ -168,9 +162,23 @@
     // Polyam: Reactions bar
     .status__content,
     .status__action-bar,
-    .reactions-bar {
+    .reactions-bar,
+    .media-gallery,
+    .video-player,
+    .audio-player,
+    .attachment-list,
+    .picture-in-picture-placeholder,
+    .more-from-author,
+    .status-card,
+    .hashtag-bar,
+    .content-warning,
+    .filter-warning {
       margin-inline-start: $thread-margin;
       width: calc(100% - $thread-margin);
+    }
+
+    .more-from-author {
+      width: calc(100% - $thread-margin + 2px);
     }
 
     .status__content__read-more-button {
@@ -326,14 +334,6 @@
 
   .media-gallery__item-thumbnail {
     cursor: default;
-  }
-
-  .content-warning {
-    margin-bottom: 16px;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
   }
 }
 


### PR DESCRIPTION
Port change postponed in #798

Ported changes:
- b7afca0f053a74518c2c0742907e8e4f7d92d709

Wraps content and media in a div, similar to before, but way simpler.
CWs are no longer collapsed, which I think is better.