### PR TITLE
Remove ability to resolve reports with hiding toots

### DIFF
--- a/app/controllers/admin/reports/actions_controller.rb
+++ b/app/controllers/admin/reports/actions_controller.rb
@@ -12,7 +12,7 @@ class Admin::Reports::ActionsController < Admin::BaseController
     authorize @report, :show?
 
     case action_from_button
-    when 'delete', 'hide', 'mark_as_sensitive'
+    when 'delete', 'mark_as_sensitive'
       status_batch_action = Admin::StatusBatchAction.new(
         type: action_from_button,
         status_ids: @report.status_ids,
@@ -58,8 +58,6 @@ class Admin::Reports::ActionsController < Admin::BaseController
       'suspend'
     elsif params[:moderation_action]
       params[:moderation_action]
-    elsif params[:hide]
-      'hide'
     end
   end
 end

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -79,8 +79,6 @@ module Admin
         'remove_from_report'
       elsif params[:delete]
         'delete'
-      elsif params[:hide]
-        'hide'
       end
     end
   end

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -24,13 +24,6 @@
         = t('admin.reports.actions.delete_description_html')
     .report-actions__item
       .report-actions__item__button
-        = form.button t('admin.reports.hide_and_resolve'),
-                      name: :hide,
-                      class: 'button button--destructive'
-      .report-actions__item__description
-        = t('admin.reports.actions.hide_description_html')
-    .report-actions__item
-      .report-actions__item__button
         = form.button t('admin.accounts.silence'),
                       name: :silence,
                       class: 'button button--destructive',

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -1,5 +1,5 @@
 - target_acct = @report.target_account.acct
-- warning_action = { 'delete' => 'delete_statuses', 'mark_as_sensitive' => 'mark_statuses_as_sensitive', 'hide' => 'hide_statuses' }.fetch(@moderation_action, @moderation_action)
+- warning_action = { 'delete' => 'delete_statuses', 'mark_as_sensitive' => 'mark_statuses_as_sensitive' }.fetch(@moderation_action, @moderation_action)
 
 - content_for :page_title do
   = t('admin.reports.confirm_action', acct: target_acct)

--- a/config/locales-polyam/en.yml
+++ b/config/locales-polyam/en.yml
@@ -43,15 +43,6 @@ en:
         text: Simple text
         text_hint: Use this for simple recurring keywords and if you do not know regular expressions.
       updated_msg: Registration text filter successfully updated!
-    reports:
-      actions:
-        hide_description_html: The reported toots will be hidden and a strike will be recorded to help you escalate on future infractions by the same account.
-      hide_and_resolve: Hide toots
-      summary:
-        action_preambles:
-          hide_html: 'You are about to <strong>hide</strong> some of <strong>@%{acct}</strong>''s toots. This will:'
-        actions:
-          hide_html: Hide the offending toots behind a warning
     roles:
       privileges:
         bypass_invite_limits: Bypass invite restrictions

--- a/spec/controllers/admin/reports/actions_controller_spec.rb
+++ b/spec/controllers/admin/reports/actions_controller_spec.rb
@@ -49,14 +49,6 @@ RSpec.describe Admin::Reports::ActionsController do
         expect(response).to have_http_status(200)
       end
     end
-
-    context 'when the action is "hide"' do
-      let(:action) { 'hide' }
-
-      it 'returns http success' do
-        expect(response).to have_http_status(200)
-      end
-    end
   end
 
   describe 'POST #create' do
@@ -127,30 +119,6 @@ RSpec.describe Admin::Reports::ActionsController do
         let(:action) { 'delete' }
 
         it_behaves_like 'common behavior'
-      end
-
-      context 'when the action is "hide"' do
-        let(:action) { 'hide' }
-        let(:statuses) { [reported_status, reported_deleted_status] }
-
-        let(:reported_deleted_status) { Fabricate(:status, account: target_account, deleted_at: 1.day.ago) }
-        let(:reported_status) { Fabricate(:status, account: target_account) }
-
-        before do
-          _status = Fabricate(:status, account: target_account)
-        end
-
-        it_behaves_like 'common behavior'
-
-        it 'adds the non-deleted to instance filter' do
-          subject
-          expect(CustomFilter.instance_filter.statuses.pluck(:status_id)).to eq [reported_status.id]
-        end
-
-        it 'marks the non-deleted as hidden' do
-          subject
-          expect(reported_status.reload.hidden_by_moderators?).to be true
-        end
       end
 
       context 'when the action is "mark_as_sensitive"' do


### PR DESCRIPTION
Ref #757 

This removes the ability to hide toots behind a warning as this feature sees barely any use and is a mess.

This does not change hidden toots or prevent appeals. This is just a first step in removing this feature.