### PR TITLE
Rename alt-text modal component

### DIFF
--- a/app/javascript/flavours/polyam/components/alt_text_badge.tsx
+++ b/app/javascript/flavours/polyam/components/alt_text_badge.tsx
@@ -11,7 +11,7 @@ export const AltTextBadge: React.FC<{
   // Essentially: doing so throws an error and prevents attachments from loading.
   const handleClick = useCallback(() => {
     store.dispatch(
-      openModal({ modalType: 'ALTTEXT', modalProps: { description } }),
+      openModal({ modalType: 'ALTTEXT_SHOW', modalProps: { description } }),
     );
   }, [description]);
 

--- a/app/javascript/flavours/polyam/containers/status_container.js
+++ b/app/javascript/flavours/polyam/containers/status_container.js
@@ -174,7 +174,7 @@ const mapDispatchToProps = (dispatch, { contextType }) => ({
   },
 
   onOpenAltText (media) {
-    dispatch(openModal({modalType: 'ALTTEXT', modalProps: { description: media.getIn(['translation', 'description']) || media.get('description') }}));
+    dispatch(openModal({modalType: 'ALTTEXT_SHOW', modalProps: { description: media.getIn(['translation', 'description']) || media.get('description') }}));
   },
 
   onBlock (status) {

--- a/app/javascript/flavours/polyam/features/account_gallery/index.jsx
+++ b/app/javascript/flavours/polyam/features/account_gallery/index.jsx
@@ -172,7 +172,7 @@ class AccountGallery extends ImmutablePureComponent {
   handleOpenAltText = attachment => {
     const { dispatch } = this.props;
 
-    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { description: attachment.getIn(['translation', 'description']) || attachment.get('description') } }));
+    dispatch(openModal({ modalType: 'ALTTEXT_SHOW', modalProps: { description: attachment.getIn(['translation', 'description']) || attachment.get('description') } }));
   };
 
   handleRef = c => {

--- a/app/javascript/flavours/polyam/features/status/index.jsx
+++ b/app/javascript/flavours/polyam/features/status/index.jsx
@@ -396,7 +396,7 @@ class Status extends ImmutablePureComponent {
     const { status } = this.props;
     const media = status.getIn(['media_attachments', index ? index : 0]);
 
-    this.props.dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { description: media.getIn(['translation', 'description']) || media.get('description') } }));
+    this.props.dispatch(openModal({ modalType: 'ALTTEXT_SHOW', modalProps: { description: media.getIn(['translation', 'description']) || media.get('description') } }));
   };
 
   handleHotkeyOpenMedia = e => {

--- a/app/javascript/flavours/polyam/features/ui/components/alttext_modal.tsx
+++ b/app/javascript/flavours/polyam/features/ui/components/alttext_modal.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { Button } from 'flavours/polyam/components/button';
 
-export const AltTextModal: React.FC<{
+export const AltTextDisplayModal: React.FC<{
   description: string;
   onClose: () => void;
 }> = ({ description, onClose }) => {

--- a/app/javascript/flavours/polyam/features/ui/components/modal_root.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/modal_root.jsx
@@ -26,7 +26,7 @@ import { getScrollbarWidth } from 'flavours/polyam/utils/scrollbar';
 import BundleContainer from '../containers/bundle_container';
 
 import ActionsModal from './actions_modal';
-import { AltTextModal } from './alttext_modal';
+import { AltTextDisplayModal } from './alttext_modal';
 import AudioModal from './audio_modal';
 import { BoostModal } from './boost_modal';
 import {
@@ -82,7 +82,7 @@ export const MODAL_COMPONENTS = {
   'SUBSCRIBED_LANGUAGES': SubscribedLanguagesModal,
   'INTERACTION': InteractionModal,
   'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
-  'ALTTEXT': () => Promise.resolve({ default: AltTextModal }),
+  'ALTTEXT': () => Promise.resolve({ default: AltTextDisplayModal }),
   'IGNORE_NOTIFICATIONS': IgnoreNotificationsModal,
   'ANNUAL_REPORT': AnnualReportModal,
 };

--- a/app/javascript/flavours/polyam/features/ui/components/modal_root.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/modal_root.jsx
@@ -82,7 +82,7 @@ export const MODAL_COMPONENTS = {
   'SUBSCRIBED_LANGUAGES': SubscribedLanguagesModal,
   'INTERACTION': InteractionModal,
   'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
-  'ALTTEXT': () => Promise.resolve({ default: AltTextDisplayModal }),
+  'ALTTEXT_SHOW': () => Promise.resolve({ default: AltTextDisplayModal }),
   'IGNORE_NOTIFICATIONS': IgnoreNotificationsModal,
   'ANNUAL_REPORT': AnnualReportModal,
 };


### PR DESCRIPTION
Upstream intends to use the `AltTextModal` name for the focal point modal (the one to add alt-text), which will cause a name conflict.

This renames it to `AltTextDisplayModal` though I'm not too happy with that name.
I might change it to `ShowAltTextModal`