### PR TITLE
Fix media attachments not showing in server pages

### DIFF
--- a/app/javascript/flavours/polyam/components/alt_text_badge.tsx
+++ b/app/javascript/flavours/polyam/components/alt_text_badge.tsx
@@ -2,16 +2,18 @@
 import { useCallback } from 'react';
 
 import { openModal } from 'flavours/polyam/actions/modal';
-import { useAppDispatch } from 'flavours/polyam/store';
+import { store } from 'flavours/polyam/store';
 
 export const AltTextBadge: React.FC<{
   description: string;
 }> = ({ description }) => {
-  const dispatch = useAppDispatch();
-
+  // Polyam: Cannot use `useAppDispatch()` directly as react-redux context is not available in server rendered pages.
+  // Essentially: doing so throws an error and prevents attachments from loading.
   const handleClick = useCallback(() => {
-    dispatch(openModal({ modalType: 'ALTTEXT', modalProps: { description } }));
-  }, [dispatch, description]);
+    store.dispatch(
+      openModal({ modalType: 'ALTTEXT', modalProps: { description } }),
+    );
+  }, [description]);
 
   return (
     <button className='media-gallery__alt__label' onClick={handleClick}>


### PR DESCRIPTION
The use of `useAppDispatch` prevented media from loading in server rendered pages. This fixes that by using store directly.

This makes media loading again, but clicking the badge just reloads the page. That issue is shared with upstream.