### PR TITLE
Fix alt-badge acting as form submit

### DIFF
--- a/app/javascript/flavours/polyam/components/alt_text_badge.tsx
+++ b/app/javascript/flavours/polyam/components/alt_text_badge.tsx
@@ -16,7 +16,11 @@ export const AltTextBadge: React.FC<{
   }, [description]);
 
   return (
-    <button className='media-gallery__alt__label' onClick={handleClick}>
+    <button
+      type='button'
+      className='media-gallery__alt__label'
+      onClick={handleClick}
+    >
       ALT
     </button>
   );


### PR DESCRIPTION
Adds missing `type='button'` attribute, so clicking the badge doesn't act as submit in server-rendered pages.