### PR TITLE
Add missing `button--block` class to some buttons

### DIFF
--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -38,8 +38,8 @@
                           placeholder: I18n.t("admin.accounts.#{key}")
 
   .actions
-    %button.button= t('admin.accounts.search')
-    = link_to t('admin.accounts.reset'), admin_accounts_path, class: 'button button--dangerous'
+    %button.button.button--block= t('admin.accounts.search')
+    = link_to t('admin.accounts.reset'), admin_accounts_path, class: 'button button--block button--dangerous'
 
 %hr.spacer/
 

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -41,8 +41,8 @@
                           placeholder: I18n.t("admin.custom_emojis.#{key}")
 
     .actions
-      %button.button= t('admin.accounts.search')
-      = link_to t('admin.accounts.reset'), admin_custom_emojis_path, class: 'button button--dangerous'
+      %button.button.button--block= t('admin.accounts.search')
+      = link_to t('admin.accounts.reset'), admin_custom_emojis_path, class: 'button button--block button--dangerous'
 
 = form_with model: @form, url: batch_admin_custom_emojis_path do |f|
   = hidden_field_tag :page, params[:page] || 1

--- a/app/views/admin/instances/index.html.haml
+++ b/app/views/admin/instances/index.html.haml
@@ -49,8 +49,8 @@
                             placeholder: I18n.t("admin.instances.#{key}")
 
       .actions
-        %button.button= t('admin.accounts.search')
-        = link_to t('admin.accounts.reset'), admin_instances_path, class: 'button button--dangerous'
+        %button.button.button--block= t('admin.accounts.search')
+        = link_to t('admin.accounts.reset'), admin_instances_path, class: 'button button--block button--dangerous'
 
 %hr.spacer/
 

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -27,8 +27,8 @@
                           placeholder: I18n.t("admin.reports.#{key}")
 
     .actions
-      %button.button= t('admin.accounts.search')
-      = link_to t('admin.accounts.reset'), admin_reports_path, class: 'button button--dangerous'
+      %button.button.button--block= t('admin.accounts.search')
+      = link_to t('admin.accounts.reset'), admin_reports_path, class: 'button button--block button--dangerous'
 
 - @reports.group_by(&:target_account_id).each_value do |reports|
   - target_account = reports.first.target_account

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -24,8 +24,8 @@
                         placeholder: t('admin.tags.name')
 
   .actions
-    %button.button= t('admin.tags.search')
-    = link_to t('admin.tags.reset'), admin_tags_path, class: 'button button--dangerous'
+    %button.button.button--block= t('admin.tags.search')
+    = link_to t('admin.tags.reset'), admin_tags_path, class: 'button button--block button--dangerous'
 
 %hr.spacer/
 


### PR DESCRIPTION
Follow-up to #814 
This fixes the button width of buttons used in server-rendered pages

Before:
![Search and reset buttons are too short](https://github.com/user-attachments/assets/501282c2-f3e6-412f-9ceb-843248eb272b)

After:
![Buttons have proper width](https://github.com/user-attachments/assets/c2900c5a-2fb3-431d-95ee-fd59c9fe7352)
