### PR TITLE
Fix border radius of buttons in compose form in homogay

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -190,6 +190,11 @@
   border-radius: $border-radius;
 }
 
+// Polyam: increased radius looks off in compose, so set to default
+.compose-form__actions .button {
+  border-radius: 4px;
+}
+
 .dropdown-menu {
   padding-top: $border-radius;
   padding-bottom: $border-radius;


### PR DESCRIPTION
The higher radius looks off in the compose form, so set it to default 4px