### PR TITLE
Switch to upstream's overlay for alt-text of images

### DIFF
--- a/app/javascript/flavours/polyam/components/alt_text_badge.tsx
+++ b/app/javascript/flavours/polyam/components/alt_text_badge.tsx
@@ -1,27 +1,78 @@
-/* Polyam: Significantly different from upstream as modal instead of overlay */
-import { useCallback } from 'react';
+import { useState, useCallback, useRef, useId } from 'react';
 
-import { openModal } from 'flavours/polyam/actions/modal';
-import { store } from 'flavours/polyam/store';
+import { FormattedMessage } from 'react-intl';
+
+import Overlay from 'react-overlays/Overlay';
+import type {
+  OffsetValue,
+  UsePopperOptions,
+} from 'react-overlays/esm/usePopper';
+
+import { useSelectableClick } from 'flavours/polyam/hooks/useSelectableClick';
+
+const offset = [0, 4] as OffsetValue;
+const popperConfig = { strategy: 'fixed' } as UsePopperOptions;
 
 export const AltTextBadge: React.FC<{
   description: string;
 }> = ({ description }) => {
-  // Polyam: Cannot use `useAppDispatch()` directly as react-redux context is not available in server rendered pages.
-  // Essentially: doing so throws an error and prevents attachments from loading.
+  const accessibilityId = useId();
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+
   const handleClick = useCallback(() => {
-    store.dispatch(
-      openModal({ modalType: 'ALTTEXT_SHOW', modalProps: { description } }),
-    );
-  }, [description]);
+    setOpen((v) => !v);
+  }, [setOpen]);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+
+  const [handleMouseDown, handleMouseUp] = useSelectableClick(handleClose);
 
   return (
-    <button
-      type='button'
-      className='media-gallery__alt__label'
-      onClick={handleClick}
-    >
-      ALT
-    </button>
+    <>
+      <button
+        ref={anchorRef}
+        type='button'
+        className='media-gallery__alt__label'
+        onClick={handleClick}
+        aria-expanded={open}
+        aria-controls={accessibilityId}
+      >
+        ALT
+      </button>
+
+      <Overlay
+        rootClose
+        onHide={handleClose}
+        show={open}
+        target={anchorRef.current}
+        placement='top-end'
+        flip
+        offset={offset}
+        popperConfig={popperConfig}
+      >
+        {({ props }) => (
+          <div {...props} className='hover-card-controller'>
+            <div // eslint-disable-line jsx-a11y/no-noninteractive-element-interactions
+              className='media-gallery__alt__popover dropdown-animation'
+              role='region'
+              id={accessibilityId}
+              onMouseDown={handleMouseDown}
+              onMouseUp={handleMouseUp}
+            >
+              <h4>
+                <FormattedMessage
+                  id='alt_text_badge.title'
+                  defaultMessage='Alt text'
+                />
+              </h4>
+              <p>{description}</p>
+            </div>
+          </div>
+        )}
+      </Overlay>
+    </>
   );
 };

--- a/app/javascript/flavours/polyam/components/media_gallery.jsx
+++ b/app/javascript/flavours/polyam/components/media_gallery.jsx
@@ -147,7 +147,6 @@ class Item extends PureComponent {
             srcSet={srcSet}
             sizes={sizes}
             alt={description}
-            title={description}
             lang={lang}
             style={{ objectPosition: letterbox ? null : `${x}% ${y}%` }}
             onLoad={this.handleImageLoad}
@@ -170,7 +169,6 @@ class Item extends PureComponent {
           <video
             className={`media-gallery__item-gifv-thumbnail${letterbox ? ' letterbox' : ''}`}
             aria-label={description}
-            title={description}
             lang={lang}
             role='application'
             src={attachment.get('url')}

--- a/app/javascript/flavours/polyam/features/account_gallery/components/media_item.tsx
+++ b/app/javascript/flavours/polyam/features/account_gallery/components/media_item.tsx
@@ -100,7 +100,6 @@ export const MediaItem: React.FC<{
         <img
           src={previewUrl || avatarUrl}
           alt={description}
-          title={description}
           lang={lang}
           onLoad={handleImageLoad}
         />
@@ -120,7 +119,6 @@ export const MediaItem: React.FC<{
       <img
         src={previewUrl}
         alt={description}
-        title={description}
         lang={lang}
         style={{ objectPosition: `${x}% ${y}%` }}
         onLoad={handleImageLoad}
@@ -138,7 +136,6 @@ export const MediaItem: React.FC<{
         <video
           className='media-gallery__item-gifv-thumbnail'
           aria-label={description}
-          title={description}
           lang={lang}
           src={fullUrl}
           onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
Fixes #815

I'm still not too fond of the overlay, but I can't think of a good solution to fix the issue.

Todo?:
- Audio and video attachments still use the modal, ~upstream doesn't show alt-text at all anymore afaik~.
Correction: The tooltip is still used for audio and video