### PR TITLE
Update homogay with new SCSS

### DIFF
--- a/app/javascript/flavours/polyam/styles/homogay.scss
+++ b/app/javascript/flavours/polyam/styles/homogay.scss
@@ -1,4 +1,5 @@
-@import 'homogay/variables';
-@import 'index';
-@import 'homogay/diff';
-@import 'homogay/animations';
+@use 'homogay/variables';
+@use 'homogay/css_variables';
+@use 'application';
+@use 'homogay/diff';
+@use 'homogay/animations';

--- a/app/javascript/flavours/polyam/styles/homogay/css_variables.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/css_variables.scss
@@ -1,0 +1,29 @@
+@use 'sass:color';
+@use '../variables' as *;
+@use 'variables' as *;
+@use '../functions' as *;
+
+body {
+  --dropdown-background-color: #{$ui-base-lighter-color};
+  --modal-background-color: #{$ui-base-color};
+  --modal-background-variant-color: #{$ui-base-semi-lighter-color};
+  --background-border-color: #{lighten($ui-base-color, 12%)};
+  --background-color: #{$ui-base-color};
+  --background-color-tint: #{$ui-base-color};
+  --media-outline-color: #{rgba(#9c63c7, 0.15)};
+  --toot-focus-background-color: #{color-mix(
+      in srgb,
+      var(--background-color),
+      $ui-highlight-color 5%
+    )};
+  --toot-private-background-color: #{color-mix(
+      in srgb,
+      var(--background-color),
+      $ui-highlight-color 5%
+    )};
+  --toot-private-background-focus-color: #{color-mix(
+      in srgb,
+      var(--background-color),
+      $ui-highlight-color 10%
+    )};
+}

--- a/app/javascript/flavours/polyam/styles/homogay/diff.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/diff.scss
@@ -1,3 +1,8 @@
+@use 'sass:color';
+@use '../functions' as *;
+@use 'variables' as *;
+@use '../variables' as *;
+
 // Polyam: Fix scrollbar in chromium browsers
 // Keep in sync with values in reset.scss
 // uses background-border-color value from main variables.scss
@@ -131,7 +136,7 @@
   background: $ui-base-extra-light-color;
 
   &.active {
-    background: adjust-color($ui-button-background-color, $alpha: -0.5);
+    background: color.adjust($ui-button-background-color, $alpha: -0.5);
 
     .reactions-bar__item__count {
       color: $ui-button-color;

--- a/app/javascript/flavours/polyam/styles/homogay/variables.scss
+++ b/app/javascript/flavours/polyam/styles/homogay/variables.scss
@@ -1,6 +1,7 @@
+@use 'sass:color';
+@use '../functions' as *;
+
 // Commonly used web colors
-$black: #000000;
-$white: #ffffff;
 $red-600: #b7253d !default; // Deep Carmine
 $red-500: #df405a !default; // Cerise
 $blurple-600: #a71494;
@@ -9,13 +10,6 @@ $blurple-300: #ef6ede;
 $grey-600: #4e4c5a; // Trout
 $grey-100: #dadaf3; // Topaz
 
-$success-green: #5fe43d !default;
-$error-red: #c9343b !default;
-$warning-red: #c96932 !default;
-$gold-star: #e4ba3d !default;
-
-$red-bookmark: $success-green !default;
-
 // Values from the classic Mastodon UI
 $classic-base-color: #190e25;
 $classic-primary-color: #d4b6cb;
@@ -23,55 +17,20 @@ $classic-secondary-color: #ffe8fc;
 $classic-highlight-color: $blurple-500;
 
 // Variables for defaults in UI
-$base-shadow-color: $black !default;
-$faint-shadow-color: adjust-color($base-shadow-color, $alpha: -0.6);
-$base-overlay-background: $black !default;
-$base-border-color: $white !default;
-$valid-value-color: $success-green !default;
-$error-value-color: $error-red !default;
+$faint-shadow-color: color.adjust(#000000, $alpha: -0.6);
 
 // Tell UI to use selected colors
 $ui-base-darker-color: darken($classic-base-color, 5%) !default;
-$ui-base-color: $classic-base-color !default;
-$ui-base-semi-lighter-color: lighten($ui-base-color, 3%) !default;
-$ui-base-lighter-color: lighten($ui-base-color, 10%) !default;
-$ui-base-extra-light-color: lighten($ui-base-color, 18%) !default;
-$simple-background-color: $ui-base-lighter-color !default;
-$ui-primary-color: $classic-primary-color !default;
-$ui-secondary-color: $classic-secondary-color !default;
-$ui-highlight-color: $classic-highlight-color !default;
-$ui-button-color: #ffe9fc;
-$ui-button-background-color: $blurple-500;
-$ui-button-focus-background-color: $blurple-300;
+$ui-base-semi-lighter-color: lighten($classic-base-color, 3%) !default;
+$ui-base-extra-light-color: lighten($classic-base-color, 18%) !default;
 $ui-button-disabled-background-color: #a686a2;
 
-$ui-button-secondary-color: $blurple-500 !default;
-$ui-button-secondary-border-color: $blurple-500 !default;
 $ui-button-secondary-focus-background-color: $blurple-600 !default;
-$ui-button-secondary-focus-color: $ui-button-color !default;
-
-$ui-button-tertiary-color: #d0adf6 !default;
-$ui-button-tertiary-border-color: #d0adf6 !default;
-$ui-button-tertiary-focus-background-color: #674e83 !default;
-$ui-button-tertiary-focus-color: $white !default;
-
-$ui-button-destructive-background-color: $red-600 !default;
-$ui-button-destructive-focus-background-color: $red-500 !default;
 
 // Variables for texts
 $primary-text-color: $classic-secondary-color !default;
 $darker-text-color: lighten(#847198, 2%) !default;
 $dark-text-color: $darker-text-color !default;
-$secondary-text-color: $ui-secondary-color !default;
-$highlight-text-color: lighten($ui-highlight-color, 8%) !default;
-$action-button-color: $dark-text-color !default;
-$passive-text-color: $gold-star !default;
-$active-passive-text-color: $success-green !default;
-
-// For texts on inverted backgrounds
-$inverted-text-color: $primary-text-color !default; // we don't do inverted backgrounds
-$lighter-text-color: lighten($darker-text-color, 5%) !default;
-$light-text-color: $ui-primary-color !default;
 
 // Variables for components
 $media-modal-media-max-width: 100%;
@@ -81,27 +40,36 @@ $media-modal-media-max-height: 80%;
 
 $border-radius: 8px;
 
-body {
-  --dropdown-background-color: #{$ui-base-lighter-color};
-  --modal-background-color: #{$ui-base-color};
-  --modal-background-variant-color: #{$ui-base-semi-lighter-color};
-  --background-border-color: #{lighten($ui-base-color, 12%)};
-  --background-color: #{$ui-base-color};
-  --background-color-tint: #{$ui-base-color};
-  --media-outline-color: #{rgba(#9c63c7, 0.15)};
-  --toot-focus-background-color: #{color-mix(
-      in srgb,
-      var(--background-color),
-      $ui-highlight-color 5%
-    )};
-  --toot-private-background-color: #{color-mix(
-      in srgb,
-      var(--background-color),
-      $ui-highlight-color 5%
-    )};
-  --toot-private-background-focus-color: #{color-mix(
-      in srgb,
-      var(--background-color),
-      $ui-highlight-color 10%
-    )};
-}
+@use '../variables' with (
+  $success-green: #5fe43d,
+  $error-red: #c9343b,
+  $warning-red: #c96932,
+  $gold-star: #e4ba3d,
+
+  $ui-base-color: $classic-base-color,
+  $ui-base-lighter-color: lighten($classic-base-color, 10%),
+  $ui-highlight-color: $classic-highlight-color,
+  $simple-background-color: lighten($classic-base-color, 10%),
+  $ui-button-color: #ffe9fc,
+  $ui-button-background-color: $blurple-500,
+  $ui-button-focus-background-color: $blurple-300,
+
+  $ui-button-secondary-color: $blurple-500,
+  $ui-button-secondary-border-color: $blurple-500,
+  $ui-button-secondary-focus-color: #ffe9fc,
+
+  $ui-button-tertiary-color: #d0adf6,
+  $ui-button-tertiary-border-color: #d0adf6,
+  $ui-button-tertiary-focus-background-color: #674e83,
+
+  $ui-button-destructive-background-color: $red-600,
+  $ui-button-destructive-focus-background-color: $red-500,
+
+  $primary-text-color: $classic-secondary-color,
+  $darker-text-color: lighten(#847198, 2%),
+  $dark-text-color: lighten(#847198, 2%),
+  $action-button-color: lighten(#847198, 2%),
+  // we don't do inverted backgrounds
+  $inverted-text-color: $classic-secondary-color,
+  $lighter-text-color: lighten(lighten(#847198, 2%), 5%)
+);

--- a/app/javascript/skins/polyam/homogay/common.scss
+++ b/app/javascript/skins/polyam/homogay/common.scss
@@ -1,1 +1,1 @@
-@import 'flavours/polyam/styles/homogay';
+@use 'flavours/polyam/styles/homogay';


### PR DESCRIPTION
Follow-up to #832 

Fixes deprecation warnings by using `use` instead of `import` in homogay files.

Fixes wrong colors due to upstream changes.

Simplifies color overrides.