### PR TITLE
Change toot background values to match upstream

### DIFF
--- a/app/javascript/flavours/polyam/styles/css_variables.scss
+++ b/app/javascript/flavours/polyam/styles/css_variables.scss
@@ -30,19 +30,7 @@
   --input-placeholder-color: #{$dark-text-color};
   --input-background-color: var(--surface-variant-background-color);
   --on-input-color: #{$secondary-text-color};
-  --toot-focus-background-color: #{color-mix(
-      in srgb,
-      var(--background-color),
-      $ui-highlight-color 5%
-    )};
-  --toot-private-background-color: #{color-mix(
-      in srgb,
-      var(--background-color),
-      $ui-highlight-color 5%
-    )};
-  --toot-private-background-focus-color: #{color-mix(
-      in srgb,
-      var(--background-color),
-      $ui-highlight-color 10%
-    )};
+  --toot-focus-background-color: #{rgba($ui-highlight-color, 0.05)};
+  --toot-private-background-color: #{rgba($ui-highlight-color, 0.05)};
+  --toot-private-background-focus-color: #{rgba($ui-highlight-color, 0.1)};
 }


### PR DESCRIPTION
Follow-up to #585 

I don't know what caused the values to not apply correctly in skins, but they do now, so it doesn't make sense to keep using color-mix.