### PR TITLE
Re-add missing `maxReactions` import in glitch flavour

### DIFF
--- a/app/javascript/flavours/glitch/components/status_action_bar.jsx
+++ b/app/javascript/flavours/glitch/components/status_action_bar.jsx
@@ -28,7 +28,7 @@ import { WithRouterPropTypes } from 'flavours/glitch/utils/react_router';
 
 import { Dropdown } from 'flavours/glitch/components/dropdown_menu';
 import EmojiPickerDropdown from '../features/compose/containers/emoji_picker_dropdown_container';
-import { me } from '../initial_state';
+import { me, maxReactions } from '../initial_state';
 
 import { IconButton } from './icon_button';
 import { RelativeTimestamp } from './relative_timestamp';


### PR DESCRIPTION
Follow-up to #851

I'm certain I explicitly added that one back when resolving merge conflicts.
Anyway, this fixes the glitch flavour crashing.

(I'm actually confused how this passed lint/tests, since it should've given an error)