### PR TITLE
Port Add dropdown to lists of accounts in web UI

### DIFF
--- a/app/javascript/flavours/polyam/components/account.tsx
+++ b/app/javascript/flavours/polyam/components/account.tsx
@@ -106,7 +106,8 @@ export const Account: React.FC<{
   const menu = useMemo(() => {
     let arr: MenuItem[] = [];
 
-    if (defaultAction === 'mute') {
+    // Polyam: Relationship check to show items for muted accounts
+    if (defaultAction === 'mute' || relationship?.muting) {
       const handleMuteNotifications = () => {
         dispatch(muteAccount(id, true));
       };

--- a/app/javascript/flavours/polyam/components/account.tsx
+++ b/app/javascript/flavours/polyam/components/account.tsx
@@ -175,8 +175,8 @@ export const Account: React.FC<{
     );
   }
 
-  // Polyam: IconButton instead of Button
-  if (defaultAction === 'block') {
+  // Polyam: IconButton instead of Button and relationship in if
+  if (defaultAction === 'block' || relationship?.blocking) {
     button = (
       <IconButton
         title={intl.formatMessage(
@@ -187,7 +187,7 @@ export const Account: React.FC<{
         onClick={handleBlock}
       />
     );
-  } else if (defaultAction === 'mute') {
+  } else if (defaultAction === 'mute' || relationship?.muting) {
     button = (
       <IconButton
         title={intl.formatMessage(

--- a/app/javascript/flavours/polyam/components/account.tsx
+++ b/app/javascript/flavours/polyam/components/account.tsx
@@ -34,6 +34,7 @@ import { RelativeTimestamp } from 'flavours/polyam/components/relative_timestamp
 import { ShortNumber } from 'flavours/polyam/components/short_number';
 import { Skeleton } from 'flavours/polyam/components/skeleton';
 import { VerifiedBadge } from 'flavours/polyam/components/verified_badge';
+import { useIdentity } from 'flavours/polyam/identity_context';
 import { me } from 'flavours/polyam/initial_state';
 import type { MenuItem } from 'flavours/polyam/models/dropdown_menu';
 import { useAppSelector, useAppDispatch } from 'flavours/polyam/store';
@@ -79,10 +80,12 @@ export const Account: React.FC<{
   withBio?: boolean;
 }> = ({ id, size = 46, hidden, minimal, defaultAction, withBio }) => {
   const intl = useIntl();
+  const { signedIn } = useIdentity();
   const account = useAppSelector((state) => state.accounts.get(id));
   const relationship = useAppSelector((state) => state.relationships.get(id));
   const dispatch = useAppDispatch();
   const accountUrl = account?.url;
+  const isRemote = account?.acct !== account?.username;
 
   const handleBlock = useCallback(() => {
     if (relationship?.blocking) {
@@ -125,66 +128,74 @@ export const Account: React.FC<{
         },
       ];
     } else if (defaultAction !== 'block') {
-      const handleAddToLists = () => {
-        const openAddToListModal = () => {
-          dispatch(
-            openModal({
-              modalType: 'LIST_ADDER',
-              modalProps: {
-                accountId: id,
-              },
-            }),
-          );
-        };
-        if (relationship?.following || relationship?.requested || id === me) {
-          openAddToListModal();
-        } else {
-          dispatch(
-            openModal({
-              modalType: 'CONFIRM_FOLLOW_TO_LIST',
-              modalProps: {
-                accountId: id,
-                onConfirm: () => {
-                  apiFollowAccount(id)
-                    .then((relationship) => {
-                      dispatch(
-                        followAccountSuccess({
-                          relationship,
-                          alreadyFollowing: false,
-                        }),
-                      );
-                      openAddToListModal();
-                    })
-                    .catch((err: unknown) => {
-                      dispatch(showAlertForError(err));
-                    });
-                },
-              },
-            }),
-          );
-        }
-      };
+      arr = [];
 
-      arr = [
-        {
+      if (isRemote && accountUrl) {
+        arr.push({
+          text: intl.formatMessage(messages.openOriginalPage),
+          href: accountUrl,
+        });
+      }
+
+      if (signedIn) {
+        const handleAddToLists = () => {
+          const openAddToListModal = () => {
+            dispatch(
+              openModal({
+                modalType: 'LIST_ADDER',
+                modalProps: {
+                  accountId: id,
+                },
+              }),
+            );
+          };
+          if (relationship?.following || relationship?.requested || id === me) {
+            openAddToListModal();
+          } else {
+            dispatch(
+              openModal({
+                modalType: 'CONFIRM_FOLLOW_TO_LIST',
+                modalProps: {
+                  accountId: id,
+                  onConfirm: () => {
+                    apiFollowAccount(id)
+                      .then((relationship) => {
+                        dispatch(
+                          followAccountSuccess({
+                            relationship,
+                            alreadyFollowing: false,
+                          }),
+                        );
+                        openAddToListModal();
+                      })
+                      .catch((err: unknown) => {
+                        dispatch(showAlertForError(err));
+                      });
+                  },
+                },
+              }),
+            );
+          }
+        };
+
+        arr.push({
           text: intl.formatMessage(messages.addToLists),
           action: handleAddToLists,
-        },
-      ];
-
-      if (accountUrl) {
-        arr.unshift(
-          {
-            text: intl.formatMessage(messages.openOriginalPage),
-            href: accountUrl,
-          },
-          null,
-        );
+        });
       }
     }
 
     return arr;
-  }, [dispatch, intl, id, accountUrl, relationship, defaultAction]);
+  }, [
+    dispatch,
+    intl,
+    id,
+    accountUrl,
+    relationship,
+    defaultAction,
+    isRemote,
+    signedIn,
+  ]);
 
   if (hidden) {
     return (


### PR DESCRIPTION
Closes #857

Ported changes:
- 5d817a758d0d16924364489092f661b82451e1c9
- 24551375cf556dbf8ef86dd508413a1b449ebde9
- 6b066eac2c6fcf7b8073d0a0d27aa6a569a68f4a

Issues:
- [ ] dropdown is also shown on own account and I question the usefulness of that
- [x] dropdown also shows in compose (that's because "minimal" defaults to "true")
- [x] this makes it hard to tell whether an account is muted, because it replaces the mute button with follow
- [x] dropdown only shows unmute notification item in muted users