### PR TITLE
Fix wrong PropType in Status component

### DIFF
--- a/app/javascript/flavours/polyam/features/status/index.jsx
+++ b/app/javascript/flavours/polyam/features/status/index.jsx
@@ -135,7 +135,7 @@ class Status extends ImmutablePureComponent {
     status: ImmutablePropTypes.map,
     isLoading: PropTypes.bool,
     settings: ImmutablePropTypes.map.isRequired,
-    ancestorsIds: PropTypes.arrayOf(PropTypes.string).list.isRequired,
+    ancestorsIds: PropTypes.arrayOf(PropTypes.string).isRequired,
     descendantsIds: PropTypes.arrayOf(PropTypes.string).isRequired,
     intl: PropTypes.object.isRequired,
     askReplyConfirmation: PropTypes.bool,


### PR DESCRIPTION
Follow-up to #865

I'm not sure whether this affects prod, but the wrong prop breaks detailed view in dev.