### PR TITLE
Fix missing background in audio modal

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/media.scss
+++ b/app/javascript/flavours/polyam/styles/components/media.scss
@@ -380,7 +380,7 @@
   overflow: hidden;
   box-sizing: border-box;
   position: relative;
-  background: var(--player-background-color), var(--background-color);
+  background: var(--player-background-color, var(--background-color));
   color: var(--player-foreground-color);
   border-radius: 8px;
   padding-bottom: 44px;


### PR DESCRIPTION
Follow-up to #867 

I mistyped the background value, which prevented the background color from applying.