### PR TITLE
Remove code tag style from vanilla

### DIFF
--- a/app/javascript/styles/mastodon/rich_text.scss
+++ b/app/javascript/styles/mastodon/rich_text.scss
@@ -113,21 +113,4 @@
   ol {
     list-style-type: decimal;
   }
-
-  code {
-    background: darken($ui-base-color, 4%);
-    border-radius: 3px;
-    padding: 0 0.3em;
-  }
-
-  pre {
-    background: darken($ui-base-color, 4%);
-    border-radius: 3px;
-    padding: 0.5em;
-  }
-
-  pre code {
-    // prevent padding of code tags inside pre
-    padding: 0;
-  }
 }


### PR DESCRIPTION
Vanilla changed the style for code tags a while ago, so this isn't necessary and shouldn't have been added to vanilla in the first place. Also this made the vanilla flavour error due to undefined var caused by missing imports.