### PR TITLE
Don't show alt-button in audio modal

### DIFF
--- a/app/javascript/flavours/polyam/features/audio/index.tsx
+++ b/app/javascript/flavours/polyam/features/audio/index.tsx
@@ -834,7 +834,7 @@ export const Audio: React.FC<{
           </div>
 
           <div className='video-player__buttons right'>
-            {alt && (
+            {alt && onOpenAltText && (
               <button
                 type='button'
                 title={intl.formatMessage(messages.alt)}


### PR DESCRIPTION
It's doing nothing in that context, so no point in showing it.

This also removes the button in reports, but that's in line with video attachments.