### PR TITLE
Cherry-pick context extension from upstream's reactions PR

### DIFF
--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -14,6 +14,7 @@ module ContextHelper
     moved_to: { 'movedTo' => { '@id' => 'as:movedTo', '@type' => '@id' } },
     also_known_as: { 'alsoKnownAs' => { '@id' => 'as:alsoKnownAs', '@type' => '@id' } },
     emoji: { 'toot' => 'http://joinmastodon.org/ns#', 'Emoji' => 'toot:Emoji' },
+    emoji_react: { 'litepub' => 'http://litepub.social/ns#', 'EmojiReact' => 'litepub:EmojiReact' },
     featured: { 'toot' => 'http://joinmastodon.org/ns#', 'featured' => { '@id' => 'toot:featured', '@type' => '@id' }, 'featuredTags' => { '@id' => 'toot:featuredTags', '@type' => '@id' } },
     property_value: { 'schema' => 'http://schema.org#', 'PropertyValue' => 'schema:PropertyValue', 'value' => 'schema:value' },
     atom_uri: { 'ostatus' => 'http://ostatus.org#', 'atomUri' => 'ostatus:atomUri' },

--- a/app/serializers/activitypub/emoji_reaction_serializer.rb
+++ b/app/serializers/activitypub/emoji_reaction_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ActivityPub::EmojiReactionSerializer < ActivityPub::Serializer
+  context_extensions :emoji, :emoji_react
+
   attributes :id, :type, :actor, :content
   attribute :virtual_object, key: :object
   attribute :custom_emoji, key: :tag, unless: -> { object.custom_emoji.nil? }


### PR DESCRIPTION
As far as I understand, some ActivityPub implementations cannot reliably handle emoji reactions without this context.