### PR TITLE
Add loading indicator to follow icon buttons

### DIFF
--- a/app/javascript/flavours/polyam/components/follow_icon_button.tsx
+++ b/app/javascript/flavours/polyam/components/follow_icon_button.tsx
@@ -13,6 +13,7 @@ import {
 } from 'flavours/polyam/actions/accounts';
 import { openModal } from 'flavours/polyam/actions/modal';
 import { IconButton } from 'flavours/polyam/components/icon_button';
+import { LoadingIndicator } from 'flavours/polyam/components/loading_indicator';
 import { me } from 'flavours/polyam/initial_state';
 import { useAppDispatch, useAppSelector } from 'flavours/polyam/store';
 
@@ -75,7 +76,7 @@ export const FollowIconButton: React.FC<{
     }
   }, [dispatch, accountId, relationship, account, signedIn]);
 
-  if (!relationship || accountId === me) return null;
+  if (accountId === me) return null;
 
   let label, icon, iconComponent;
 
@@ -83,6 +84,12 @@ export const FollowIconButton: React.FC<{
     label = intl.formatMessage(messages.follow);
     icon = 'user-add';
     iconComponent = FollowIcon;
+  } else if (!relationship) {
+    return (
+      <div className='icon-button'>
+        <LoadingIndicator />
+      </div>
+    );
   } else if (relationship.requested) {
     label = intl.formatMessage(messages.cancel_follow_request);
     icon = 'hourglass';
@@ -101,9 +108,9 @@ export const FollowIconButton: React.FC<{
     <IconButton
       onClick={handleClick}
       disabled={
-        relationship.blocked_by ||
-        relationship.blocking ||
-        (!(relationship.following || relationship.requested) &&
+        relationship?.blocked_by ||
+        relationship?.blocking ||
+        (!(relationship?.following || relationship?.requested) &&
           (account?.suspended || !!account?.moved))
       }
       active={following}

--- a/app/javascript/flavours/polyam/styles/components/loading.scss
+++ b/app/javascript/flavours/polyam/styles/components/loading.scss
@@ -56,6 +56,18 @@
   }
 }
 
+// Polyam: Loading indicator with icon-button
+.icon-button .loading-indicator {
+  position: static;
+  transform: none;
+
+  .circular-progress {
+    color: $primary-text-color;
+    width: 24px;
+    height: 24px;
+  }
+}
+
 .load-more .loading-indicator .circular-progress {
   color: lighten($ui-base-color, 26%);
 }


### PR DESCRIPTION
This adds a loading indicator to follow icons. This prevents items from "jumping" on load.

Not sure why this works now, but I'm not complaining.
(For context: I tried this initially and kept getting errors)