### PR TITLE
Add collapsing to notification groups

### DIFF
--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -71,7 +71,23 @@ export const NotificationGroupWithStatus: React.FC<{
     (state) => state.local_settings.getIn(['collapsed', 'enabled']) as boolean,
   );
 
-  const [collapsed, setCollapsed] = useState(collapseEnabled && !unread);
+  const autoCollapse = useAppSelector((state) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const autoCollapseSettings = state.local_settings.getIn([
+      'collapsed',
+      'auto',
+    ]);
+    return (
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      (autoCollapseSettings.get('all') as boolean) ||
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      (autoCollapseSettings.get('notifications') as boolean)
+    );
+  });
+
+  const [collapsed, setCollapsed] = useState(
+    collapseEnabled && autoCollapse && !unread,
+  );
 
   const collapsibleType = ['favourite', 'reblog', 'reaction'].includes(type);
 
@@ -115,7 +131,7 @@ export const NotificationGroupWithStatus: React.FC<{
           {
             'notification-group--unread': unread,
             'notification-group--direct': isPrivateMention,
-            collapsed: collapseEnabled && collapsed,
+            collapsed: collapseEnabled && autoCollapse && collapsed,
           },
         )}
         tabIndex={0}

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -86,15 +86,11 @@ export const NotificationGroupWithStatus: React.FC<{
     );
   });
 
-  const [collapsed, setCollapsed] = useState(
-    collapseEnabled && autoCollapse && !unread,
-  );
-
-  const collapsibleType = ['favourite', 'reblog', 'reaction'].includes(type);
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
-    setCollapsed(collapsibleType && collapseEnabled && autoCollapse && !unread);
-  }, [autoCollapse, collapseEnabled, collapsibleType, unread]);
+    setCollapsed(collapseEnabled && autoCollapse && !unread);
+  }, [autoCollapse, collapseEnabled, unread]);
 
   const handleCollapseClick = useCallback(() => {
     setCollapsed(!collapsed);
@@ -125,14 +121,14 @@ export const NotificationGroupWithStatus: React.FC<{
       },
 
       toggleCollapse: () => {
-        if (!collapseEnabled || !collapsibleType) {
+        if (!collapseEnabled) {
           return;
         }
 
         setCollapsed(!collapsed);
       },
     }),
-    [dispatch, statusId, collapseEnabled, collapsibleType, collapsed],
+    [dispatch, statusId, collapseEnabled, collapsed],
   );
 
   return (
@@ -166,7 +162,7 @@ export const NotificationGroupWithStatus: React.FC<{
               {actions && (
                 <div className='notification-group__actions'>{actions}</div>
               )}
-              {collapseEnabled && collapsibleType && (
+              {collapseEnabled && statusId && (
                 <CollapseButton
                   collapsed={collapsed}
                   setCollapsed={handleCollapseClick}

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -3,6 +3,8 @@ import type { JSX } from 'react';
 
 import classNames from 'classnames';
 
+import type { Map as ImmutableMap } from 'immutable';
+
 import { HotKeys } from 'react-hotkeys';
 
 import { replyComposeById } from 'flavours/polyam/actions/compose';
@@ -67,20 +69,19 @@ export const NotificationGroupWithStatus: React.FC<{
   // Polyam: collapsing
 
   const collapseEnabled = useAppSelector(
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    (state) => state.local_settings.getIn(['collapsed', 'enabled']) as boolean,
+    (state) =>
+      (state.local_settings as ImmutableMap<string, unknown>).getIn([
+        'collapsed',
+        'enabled',
+      ]) as boolean,
   );
 
   const autoCollapse = useAppSelector((state) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    const autoCollapseSettings = state.local_settings.getIn([
-      'collapsed',
-      'auto',
-    ]);
+    const autoCollapseSettings = (
+      state.local_settings as ImmutableMap<string, unknown>
+    ).getIn(['collapsed', 'auto']) as ImmutableMap<string, unknown>;
     return (
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       (autoCollapseSettings.get('all') as boolean) ||
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       (autoCollapseSettings.get('notifications') as boolean)
     );
   });

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -118,8 +118,16 @@ export const NotificationGroupWithStatus: React.FC<{
       reply: () => {
         dispatch(replyComposeById(statusId));
       },
+
+      toggleCollapse: () => {
+        if (!collapseEnabled || !collapsibleType) {
+          return;
+        }
+
+        setCollapsed(!collapsed);
+      },
     }),
-    [dispatch, statusId],
+    [dispatch, statusId, collapseEnabled, collapsibleType, collapsed],
   );
 
   return (

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useEffect } from 'react';
 import type { JSX } from 'react';
 
 import classNames from 'classnames';
@@ -92,6 +92,10 @@ export const NotificationGroupWithStatus: React.FC<{
 
   const collapsibleType = ['favourite', 'reblog', 'reaction'].includes(type);
 
+  useEffect(() => {
+    setCollapsed(collapsibleType && collapseEnabled && autoCollapse && !unread);
+  }, [autoCollapse, collapseEnabled, collapsibleType, unread]);
+
   const handleCollapseClick = useCallback(() => {
     setCollapsed(!collapsed);
   }, [collapsed, setCollapsed]);
@@ -140,7 +144,6 @@ export const NotificationGroupWithStatus: React.FC<{
           {
             'notification-group--unread': unread,
             'notification-group--direct': isPrivateMention,
-            collapsed: collapseEnabled && autoCollapse && collapsed,
           },
         )}
         tabIndex={0}
@@ -184,7 +187,7 @@ export const NotificationGroupWithStatus: React.FC<{
             </div>
           </div>
 
-          {statusId && (
+          {!collapsed && statusId && (
             <div className='notification-group__main__status'>
               <EmbeddedStatus statusId={statusId} />
             </div>

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import type { JSX } from 'react';
 
 import classNames from 'classnames';
@@ -9,6 +9,7 @@ import { replyComposeById } from 'flavours/polyam/actions/compose';
 import { navigateToStatus } from 'flavours/polyam/actions/statuses';
 import { Avatar } from 'flavours/polyam/components/avatar';
 import { AvatarGroup } from 'flavours/polyam/components/avatar_group';
+import { CollapseButton } from 'flavours/polyam/components/collapse_button';
 import type { IconProp } from 'flavours/polyam/components/icon';
 import { Icon } from 'flavours/polyam/components/icon';
 import { RelativeTimestamp } from 'flavours/polyam/components/relative_timestamp';
@@ -63,6 +64,15 @@ export const NotificationGroupWithStatus: React.FC<{
 }) => {
   const dispatch = useAppDispatch();
 
+  // Polyam: collapsing
+  const [collapsed, setCollapsed] = useState(!unread);
+
+  const collapsibleType = ['favourite', 'reblog', 'reaction'].includes(type);
+
+  const handleCollapseClick = useCallback(() => {
+    setCollapsed(!collapsed);
+  }, [collapsed, setCollapsed]);
+
   const label = useMemo(
     () =>
       labelRenderer(
@@ -99,6 +109,7 @@ export const NotificationGroupWithStatus: React.FC<{
           {
             'notification-group--unread': unread,
             'notification-group--direct': isPrivateMention,
+            collapsed: collapsed,
           },
         )}
         tabIndex={0}
@@ -120,6 +131,12 @@ export const NotificationGroupWithStatus: React.FC<{
 
               {actions && (
                 <div className='notification-group__actions'>{actions}</div>
+              )}
+              {collapsibleType && (
+                <CollapseButton
+                  collapsed={collapsed}
+                  setCollapsed={handleCollapseClick}
+                />
               )}
             </div>
 

--- a/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/flavours/polyam/features/notifications_v2/components/notification_group_with_status.tsx
@@ -65,7 +65,13 @@ export const NotificationGroupWithStatus: React.FC<{
   const dispatch = useAppDispatch();
 
   // Polyam: collapsing
-  const [collapsed, setCollapsed] = useState(!unread);
+
+  const collapseEnabled = useAppSelector(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    (state) => state.local_settings.getIn(['collapsed', 'enabled']) as boolean,
+  );
+
+  const [collapsed, setCollapsed] = useState(collapseEnabled && !unread);
 
   const collapsibleType = ['favourite', 'reblog', 'reaction'].includes(type);
 
@@ -109,7 +115,7 @@ export const NotificationGroupWithStatus: React.FC<{
           {
             'notification-group--unread': unread,
             'notification-group--direct': isPrivateMention,
-            collapsed: collapsed,
+            collapsed: collapseEnabled && collapsed,
           },
         )}
         tabIndex={0}
@@ -132,7 +138,7 @@ export const NotificationGroupWithStatus: React.FC<{
               {actions && (
                 <div className='notification-group__actions'>{actions}</div>
               )}
-              {collapsibleType && (
+              {collapseEnabled && collapsibleType && (
                 <CollapseButton
                   collapsed={collapsed}
                   setCollapsed={handleCollapseClick}

--- a/app/javascript/flavours/polyam/styles/components/collapsing.scss
+++ b/app/javascript/flavours/polyam/styles/components/collapsing.scss
@@ -64,9 +64,3 @@
     height: 16px;
   }
 }
-
-.notification-group.collapsed {
-  .notification-group__main__status {
-    display: none;
-  }
-}

--- a/app/javascript/flavours/polyam/styles/components/collapsing.scss
+++ b/app/javascript/flavours/polyam/styles/components/collapsing.scss
@@ -64,3 +64,9 @@
     height: 16px;
   }
 }
+
+.notification-group.collapsed {
+  .notification-group__main__status {
+    display: none;
+  }
+}


### PR DESCRIPTION
Considerations:
- Unread notifications should not be collapsed
- Hiding embedded status element is the most straightforward thing design-wise (I don't think gradients make sense here)
- Follow and other non-status notifications don't need collapsing

Unclear:
- Collapsing of notifications with CWs (As in, should they uncollapsed by default?). Not sure that's really possible as there is no way to know whether there is a CW at the time of collapsing.

TODO:
- [x] Fix follow notifications (For some reason they do use the WithStatus component)
- [x] Respect collapse setting
- [x] Respect auto-collapse setting
- [x] Hotkey support
- [x] Make code a bit less messy