### PR TITLE
Re-add missing hotkey for toggling collapsing

### DIFF
--- a/app/javascript/flavours/polyam/features/ui/index.jsx
+++ b/app/javascript/flavours/polyam/features/ui/index.jsx
@@ -141,7 +141,9 @@ const keyMap = {
   bookmark: 'd',
   toggleSensitive: 'h',
   openMedia: 'e',
-  onTranslate: 't'
+  onTranslate: 't',
+  // Polyam
+  toggleCollapse: 'shift+x',
 };
 
 class SwitchingColumnsArea extends PureComponent {


### PR DESCRIPTION
This re-adds the key combination for collapsing.

Not sure why this was removed.
Maybe accidentally while porting a change.