### PR TITLE
Increase collapse icon size

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/status/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status/status.scss
@@ -303,8 +303,7 @@
   color: $action-button-color;
   gap: 4px;
 
-  // Polyam: Different class as otherwise doesn't apply to collapse icon
-  .icon {
+  & > .icon {
     width: 16px;
     height: 16px;
   }


### PR DESCRIPTION
This doesn't look as out-of-place as it used to and also matches the size in upcoming collapsed notifications.