### PR TITLE
Remove obsolete check constraint for exclusive column

### DIFF
--- a/db/migrate/20250606113926_polyam_remove_exclusive_check_constraint.rb
+++ b/db/migrate/20250606113926_polyam_remove_exclusive_check_constraint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PolyamRemoveExclusiveCheckConstraint < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :lists, :exclusive, false if column_exists?(:lists, :exclusive, null: true)
+
+    return unless check_constraint_exists?(:lists, name: 'lists_exclusive_null')
+
+    remove_check_constraint :lists, name: 'lists_exclusive_null'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_20_204643) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_06_113926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -623,7 +623,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_20_204643) do
     t.integer "replies_policy", default: 0, null: false
     t.boolean "exclusive", default: false, null: false
     t.index ["account_id"], name: "index_lists_on_account_id"
-    t.check_constraint "exclusive IS NOT NULL", name: "lists_exclusive_null"
   end
 
   create_table "login_activities", force: :cascade do |t|


### PR DESCRIPTION
:warning: Includes DB migration

This constraint was only for compatibility with Postgres 10, but that version is no longer supported.