### PR TITLE
Add `Polyam` prefix to status reaction migrations

### DIFF
--- a/db/migrate/20221217125117_polyam_create_status_reactions.rb
+++ b/db/migrate/20221217125117_polyam_create_status_reactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateStatusReactions < ActiveRecord::Migration[6.1]
+class PolyamCreateStatusReactions < ActiveRecord::Migration[6.1]
   def change
     create_table :status_reactions do |t|
       t.references :account, null: false, foreign_key: true

--- a/db/migrate/20221218014608_polyam_change_status_reactions_table.rb
+++ b/db/migrate/20221218014608_polyam_change_status_reactions_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeStatusReactionsTable < ActiveRecord::Migration[6.1]
+class PolyamChangeStatusReactionsTable < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   # Thanks to kescherCode

--- a/db/migrate/20230222143034_polyam_add_reactions_count.rb
+++ b/db/migrate/20230222143034_polyam_add_reactions_count.rb
@@ -2,7 +2,7 @@
 
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddReactionsCount < ActiveRecord::Migration[6.1]
+class PolyamAddReactionsCount < ActiveRecord::Migration[6.1]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/post_migrate/20230222145758_polyam_backfill_reactions_count.rb
+++ b/db/post_migrate/20230222145758_polyam_backfill_reactions_count.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BackfillReactionsCount < ActiveRecord::Migration[6.1]
+class PolyamBackfillReactionsCount < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   class StatusReaction < ApplicationRecord; end


### PR DESCRIPTION
This should prevent name conflicts with upstream's PR, but does not solve the duplicate migration issue.