### PR TITLE
Skip old exclusive lists migrations when running new code

### DIFF
--- a/db/migrate/20230517195218_polyam_set_exclusive_not_null.rb
+++ b/db/migrate/20230517195218_polyam_set_exclusive_not_null.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+# This migration is only needed when Polyam-glitch was run before upstream implemented exclusive lists.
+# The prior code allowed the `exclusive` column to be null.
 class PolyamSetExclusiveNotNull < ActiveRecord::Migration[6.1]
   def change
+    return if column_exists?(:lists, :exclusive, null: false)
+
     add_check_constraint :lists, 'exclusive IS NOT NULL', name: 'lists_exclusive_null', validate: false
   end
 end

--- a/db/migrate/20230517195554_polyam_validate_exclusive_not_null.rb
+++ b/db/migrate/20230517195554_polyam_validate_exclusive_not_null.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+# This migration is only needed when Polyam-glitch was run before upstream implemented exclusive lists.
+# The prior code allowed the `exclusive` column to be null.
 class PolyamValidateExclusiveNotNull < ActiveRecord::Migration[6.1]
   def change
+    return unless check_constraint_exists?(:lists, name: 'lists_exclusive_null')
+
     validate_check_constraint :lists, name: 'lists_exclusive_null'
 
     # The following lines are fine for Postgres 12+ environments, which every reasonable admin should run anyway


### PR DESCRIPTION
Backport of #900 