### PR TITLE
Rename foreign key migration for reactions

### DIFF
--- a/db/migrate/20221218014608_polyam_fix_status_reactions_foreign_keys.rb
+++ b/db/migrate/20221218014608_polyam_fix_status_reactions_foreign_keys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PolyamChangeStatusReactionsTable < ActiveRecord::Migration[6.1]
+class PolyamFixStatusReactionsForeignKeys < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   # Thanks to kescherCode


### PR DESCRIPTION
Not necessary, but clearer on what the migration does.

Also I tested whether this migration runs if the correct keys already exist and turns out: yes.
That's not necessary, but it also does cause no harm.
(I was working on whether the migration can be skipped)