### PR TITLE
Restore navigation to request text filters

### DIFF
--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -68,6 +68,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :email_domain_blocks, safe_join([material_symbol('mail'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_path, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :ip_blocks, safe_join([material_symbol('hide_source'), t('admin.ip_blocks.title')]), admin_ip_blocks_path, highlights_on: %r{/admin/ip_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :action_logs, safe_join([material_symbol('list'), t('admin.action_logs.title')]), admin_action_logs_path, if: -> { current_user.can?(:view_audit_log) }
+      s.item :registration_filters, safe_join([material_symbol('filter_alt'), t('admin.registration_filters.title')]), admin_registration_filters_path, highlights_on: %r{/admin/registration_filters}, if: -> { current_user.can?(:manage_settings) }
     end
 
     n.item :admin, safe_join([material_symbol('manufacturing'), t('admin.title')]), nil, if: -> { current_user.can?(:view_dashboard, :manage_settings, :manage_rules, :manage_announcements, :manage_custom_emojis, :manage_webhooks, :manage_federation) && !self_destruct } do |s|


### PR DESCRIPTION
This probably got accidentally removed during a refactor.