### PR TITLE
Fix path in registration filter spec

### DIFF
--- a/spec/requests/admin/registration_filters_spec.rb
+++ b/spec/requests/admin/registration_filters_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Admin Registration Filters' do
     before { sign_in Fabricate(:admin_user) }
 
     it 'gracefully handles invalid nested params' do
-      post admin_email_domain_blocks_path(phrase: 'invalid')
+      post admin_registration_filters_path(phrase: 'invalid')
 
       expect(response)
         .to have_http_status(400)


### PR DESCRIPTION
Follow-up to #908 

Oops, wrote the path out, looked what the other specs did, noticed not much, and copy and pasted one, so I don't have to type that out, but that of course overwrote the path.