### PR TITLE
Replace `person_icon` with `material_symbol` call

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,13 +138,6 @@ module ApplicationHelper
     inline_svg_tag 'check.svg'
   end
 
-  # Polyam: Used in app/views/admin/roles/_form.html.haml for role badge preview
-  # TODO: Replace with material_symbol call?
-  def person_icon
-    content_tag(:svg,
-                tag.path(d: 'M479.885-488.348q-72.333 0-118.174-45.842-45.842-45.842-45.842-118.174 0-72.333 45.842-118.29 45.841-45.957 118.174-45.957t118.572 45.957q46.239 45.957 46.239 118.29 0 72.332-46.239 118.174-46.239 45.842-118.572 45.842ZM145.869-138.521v-109.145q0-41.678 21.164-72.191 21.164-30.512 54.749-46.361 68.131-30.565 131.303-45.848 63.173-15.282 126.763-15.282 64.674 0 127.239 15.782 62.565 15.783 130.051 45.542 35.038 15.234 56.298 45.759 21.26 30.526 21.26 72.452v109.292H145.869Zm79.218-79.218h509.826v-27.782q0-15.635-9.5-29.835-9.5-14.201-23.5-21.035-61.739-29.304-113.324-40.239-51.584-10.935-108.869-10.935-56.155 0-109.307 10.935t-113.084 40.151q-14.242 6.839-23.242 21.065-9 14.227-9 29.893v27.782Zm254.798-349.828q36.854 0 60.941-23.999 24.087-24 24.087-60.893 0-37.127-23.972-61.03t-60.826-23.903q-36.854 0-60.941 23.929-24.087 23.929-24.087 60.723 0 37.028 23.972 61.101 23.972 24.072 60.826 24.072Zm.115-84.912Zm0 434.74Z'), xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 -960 960 960', fill: 'currentColor') # rubocop:disable Layout/LineLength
-  end
-
   def interrelationships_icon(relationships, account_id)
     if relationships.following[account_id] && relationships.followed_by[account_id]
       material_symbol('sync_alt', title: I18n.t('relationships.mutual'), class: 'active passive')

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -26,20 +26,20 @@
         .user-role__preview{ id: 'user_role_preview' }
           .item.dark
             .account-role{ class: "user-role-#{form.object.id}", id: 'user-role-preview-1' }
-              = person_icon
+              = material_symbol 'person'
               %span= form.object.name
               - unless current_user.setting_flavour == 'polyam'
                 %span.account-role__domain= current_user.account.local_username_and_domain.split('@')[1]
           .item.light
             .account-role{ class: "user-role-#{form.object.id}", id: 'user-role-preview-2' }
-              = person_icon
+              = material_symbol 'person'
               %span= form.object.name
               - unless current_user.setting_flavour == 'polyam'
                 %span.account-role__domain= current_user.account.local_username_and_domain.split('@')[1]
           - if current_user.setting_skin != 'default' && current_user.setting_skin != 'mastodon-light'
             .item.account__header.account_header_badges
               .account-role{ class: "user-role-#{form.object.id}", id: 'user-role-preview-3' }
-                = person_icon
+                = material_symbol 'person'
                 %span= form.object.name
                 - unless current_user.setting_flavour == 'polyam'
                   %span.account-role__domain= current_user.account.local_username_and_domain.split('@')[1]


### PR DESCRIPTION
Backport of #932 

That method has been removed by upstream a while ago, but was still used for the role badge preview.