### PR TITLE
Change variant from empty string to 'custom' for custom icons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,7 +119,7 @@ module ApplicationHelper
   end
 
   def awesome_icon(icon, attributes = {})
-    variant = "#{attributes[:variant] || 'solid'}/" unless attributes[:variant] == ''
+    variant = "#{attributes[:variant] || 'solid'}/" unless attributes[:variant] == 'custom'
 
     safe_join(
       [

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -5,7 +5,7 @@
     .status__card
       - if status.reblog?
         .status__prepend
-          = material_symbol('repeat', variant: '')
+          = material_symbol('repeat', variant: 'custom')
           = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(status.proper.account, path: admin_account_status_path(status.proper.account.id, status.proper.id)))
       - elsif status.reply? && status.in_reply_to_id.present?
         .status__prepend

--- a/app/views/admin/statuses/show.html.haml
+++ b/app/views/admin/statuses/show.html.haml
@@ -59,7 +59,7 @@
 .status__card
   - if @status.reblog?
     .status__prepend
-      = material_symbol('repeat', variant: '')
+      = material_symbol('repeat', variant: 'custom')
       = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(@status.proper.account, path: admin_account_status_path(@status.proper.account.id, @status.proper.id)))
   - elsif @status.reply? && @status.in_reply_to_id.present?
     .status__prepend


### PR DESCRIPTION
Not sure what my reasoning was to set it to empty string instead, but I think 'custom' is clearer.

Sidenote:
Some FASP pages use the boost icon and I'm not sure why and how to best address that. It's on the bottom of my to-do list though.