### PR TITLE
Add icon variant detection from name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,12 +119,12 @@ module ApplicationHelper
   end
 
   def awesome_icon(icon, attributes = {})
-    variant = "#{attributes[:variant] || 'solid'}/" unless attributes[:variant] == 'custom'
+    variant = "#{attributes[:variant] || fa_variant(icon)}/"
 
     safe_join(
       [
         inline_svg_tag(
-          "#{variant}#{icon}.svg",
+          "#{variant if variant != 'custom/'}#{icon}.svg",
           class: ['icon', "fa-#{icon}"].concat(attributes[:class].to_s.split),
           role: :img,
           data: attributes[:data]

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -95,7 +95,25 @@ module IconHelper
     warning: 'triangle-exclamation',
   }.freeze
 
+  FA_VARIANT = {
+    bell: 'regular',
+    boost: 'custom',
+    eye: 'regular',
+    'eye-slash': 'regular',
+    'face-smile': 'regular',
+    gem: 'regular',
+    'id-badge': 'regular',
+    image: 'regular',
+    markdown: 'brands',
+    newspaper: 'regular',
+    square: 'regular',
+  }.freeze
+
   def fa_icon(icon)
     MATERIAL_TO_FA[icon.to_sym]
+  end
+
+  def fa_variant(icon)
+    FA_VARIANT[icon.to_sym] || 'solid'
   end
 end

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -58,9 +58,9 @@
         - if params[:local] == '1'
           = f.button safe_join([material_symbol('save'), t('generic.save_changes')]), name: :update, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([material_symbol('visibility', variant: 'regular'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([material_symbol('visibility'), t('admin.custom_emojis.list')]), name: :list, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-          = f.button safe_join([material_symbol('visibility_off', variant: 'regular'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([material_symbol('visibility_off'), t('admin.custom_emojis.unlist')]), name: :unlist, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
         = f.button safe_join([material_symbol('radio_button_checked'), t('admin.custom_emojis.enable')]), name: :enable, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -5,7 +5,7 @@
     .status__card
       - if status.reblog?
         .status__prepend
-          = material_symbol('repeat', variant: 'custom')
+          = material_symbol('repeat')
           = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(status.proper.account, path: admin_account_status_path(status.proper.account.id, status.proper.id)))
       - elsif status.reply? && status.in_reply_to_id.present?
         .status__prepend
@@ -49,5 +49,5 @@
 
         - if status.proper.sensitive?
           ·
-          = material_symbol('visibility_off', variant: 'regular')
+          = material_symbol('visibility_off')
           = t('stream_entries.sensitive_content')

--- a/app/views/admin/status_edits/_status_edit.html.haml
+++ b/app/views/admin/status_edits/_status_edit.html.haml
@@ -26,5 +26,5 @@
 
         - if status_edit.sensitive?
           ·
-          = material_symbol('visibility_off', variant: 'regular')
+          = material_symbol('visibility_off')
           = t('stream_entries.sensitive_content')

--- a/app/views/admin/statuses/show.html.haml
+++ b/app/views/admin/statuses/show.html.haml
@@ -59,7 +59,7 @@
 .status__card
   - if @status.reblog?
     .status__prepend
-      = material_symbol('repeat', variant: 'custom')
+      = material_symbol('repeat')
       = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(@status.proper.account, path: admin_account_status_path(@status.proper.account.id, @status.proper.id)))
   - elsif @status.reply? && @status.in_reply_to_id.present?
     .status__prepend
@@ -96,7 +96,7 @@
         = t("statuses.visibilities.#{@status.visibility}")
       - if @status.proper.sensitive?
         ·
-        = material_symbol('visibility_off', variant: 'regular')
+        = material_symbol('visibility_off')
         = t('stream_entries.sensitive_content')
 
 %hr.spacer/

--- a/app/views/filters/statuses/_status_filter.html.haml
+++ b/app/views/filters/statuses/_status_filter.html.haml
@@ -33,5 +33,5 @@
       = t("statuses.visibilities.#{status.visibility}")
       - if status.sensitive?
         ·
-        = material_symbol 'visibility_off', variant: 'regular'
+        = material_symbol 'visibility_off'
         = t('stream_entries.sensitive_content')

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -52,7 +52,7 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :trends, safe_join([material_symbol('trending_up'), t('admin.trends.title')]), admin_trends_statuses_path, if: -> { current_user.can?(:manage_taxonomies) && !self_destruct } do |s|
       s.item :statuses, safe_join([material_symbol('chat_bubble'), t('admin.trends.statuses.title')]), admin_trends_statuses_path, highlights_on: %r{/admin/trends/statuses}
       s.item :tags, safe_join([material_symbol('tag'), t('admin.trends.tags.title')]), admin_trends_tags_path, highlights_on: %r{/admin/trends/tags}
-      s.item :links, safe_join([material_symbol('breaking_news', variant: 'regular'), t('admin.trends.links.title')]), admin_trends_links_path, highlights_on: %r{/admin/trends/links}
+      s.item :links, safe_join([material_symbol('breaking_news'), t('admin.trends.links.title')]), admin_trends_links_path, highlights_on: %r{/admin/trends/links}
       s.item :follow_recommendations, safe_join([material_symbol('person_add'), t('admin.follow_recommendations.title')]), admin_follow_recommendations_path, highlights_on: %r{/admin/follow_recommendations}
     end
 
@@ -79,13 +79,13 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :warning_presets, safe_join([material_symbol('warning'), t('admin.warning_presets.title')]), admin_warning_presets_path, highlights_on: %r{/admin/warning_presets}, if: -> { current_user.can?(:manage_settings) }
       s.item :roles, safe_join([material_symbol('contact_mail'), t('admin.roles.title')]), admin_roles_path, highlights_on: %r{/admin/roles}, if: -> { current_user.can?(:manage_roles) }
       s.item :announcements, safe_join([material_symbol('campaign'), t('admin.announcements.title')]), admin_announcements_path, highlights_on: %r{/admin/announcements}, if: -> { current_user.can?(:manage_announcements) }
-      s.item :custom_emojis, safe_join([material_symbol('mood', variant: 'regular'), t('admin.custom_emojis.title')]), admin_custom_emojis_path, highlights_on: %r{/admin/custom_emojis}, if: -> { current_user.can?(:manage_custom_emojis) }
+      s.item :custom_emojis, safe_join([material_symbol('mood'), t('admin.custom_emojis.title')]), admin_custom_emojis_path, highlights_on: %r{/admin/custom_emojis}, if: -> { current_user.can?(:manage_custom_emojis) }
       s.item :webhooks, safe_join([material_symbol('inbox'), t('admin.webhooks.title')]), admin_webhooks_path, highlights_on: %r{/admin/webhooks}, if: -> { current_user.can?(:manage_webhooks) }
       s.item :fasp, safe_join([material_symbol('extension'), t('admin.fasp.title')]), admin_fasp_providers_path, highlights_on: %r{/admin/fasp}, if: -> { current_user.can?(:manage_federation) } if Mastodon::Feature.fasp_enabled?
       s.item :relays, safe_join([material_symbol('captive_portal'), t('admin.relays.title')]), admin_relays_path, highlights_on: %r{/admin/relays}, if: -> { !limited_federation_mode? && current_user.can?(:manage_federation) }
     end
 
-    n.item :sidekiq, safe_join([material_symbol('diamond', variant: 'regular'), 'Sidekiq']), sidekiq_path, link_html: { target: 'sidekiq' }, if: -> { current_user.can?(:view_devops) }
+    n.item :sidekiq, safe_join([material_symbol('diamond'), 'Sidekiq']), sidekiq_path, link_html: { target: 'sidekiq' }, if: -> { current_user.can?(:view_devops) }
     n.item :pghero, safe_join([material_symbol('database'), 'PgHero']), pghero_path, link_html: { target: 'pghero' }, if: -> { current_user.can?(:view_devops) }
     n.item :logout, safe_join([material_symbol('logout'), t('auth.logout')]), destroy_user_session_path, link_html: { 'data-method' => 'delete' }
   end

--- a/lib/tasks/icons.rake
+++ b/lib/tasks/icons.rake
@@ -103,12 +103,12 @@ def find_used_backend_icons(material: false, convert: true)
           icons[400][24] ||= Set.new
           icons[400][24] << match['icon']
         else
-          variant = match['variant'].present? ? match['variant'].to_s : 'solid'
+          fa_icon = fa_icon(match['icon'])
+          variant = match['variant'].present? ? match['variant'].to_s : fa_variant(fa_icon)
 
           icons[variant] ||= Set.new
 
           if convert
-            fa_icon = IconHelper::MATERIAL_TO_FA[match['icon'].to_sym]
             icons[variant] << fa_icon unless fa_icon.nil?
           else
             icons[variant] << match['icon']
@@ -136,6 +136,8 @@ namespace :icons do
 
   desc 'Download used FA icons'
   task download_awesome: :environment do
+    include IconHelper
+
     find_used_awesome_icons(with_backend: true).each do |variant, icons|
       # Skip custom icons as they can't be downloaded
       next if variant == 'custom'
@@ -148,6 +150,8 @@ namespace :icons do
 
   desc 'Check used icons'
   task check: :environment do
+    include IconHelper
+
     pastel = Pastel.new
 
     missing_icons = []
@@ -155,7 +159,7 @@ namespace :icons do
 
     find_used_backend_icons(convert: false).each do |variant, icons|
       icons.each do |icon|
-        fa_icon = IconHelper::MATERIAL_TO_FA[icon.to_sym]
+        fa_icon = fa_icon(icon)
         if fa_icon.nil?
           missing_icons << icon.to_s
         elsif variant == 'custom'


### PR DESCRIPTION
Creates a new method to get the icon variant from its name.
The original idea was to pass `variant` to `material_symbol` call to allow the same icon in different variants, but there isn't a practical use for that and it doesn't work when the call is wrapped like in `table_link_to`.

It's still possible to pass `variant`, but the default is now to get it by name.
This also reduces merge conflicts due to setting `variant`

Long term IconHelper should return a variant icon-name pair, but that's too involved to get into the 4.4 release.