### PR TITLE
Fix crash when `nil` is passed to `fa_variant`

### DIFF
--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -114,6 +114,8 @@ module IconHelper
   end
 
   def fa_variant(icon)
+    return 'solid' if icon.nil?
+
     FA_VARIANT[icon.to_sym] || 'solid'
   end
 end


### PR DESCRIPTION
Follow-up to #948 

In cases where `fa_icon` returns nil, because there is no default value for non-existing icons, that nil is passed to `fa_variant` which causes an error because `nil.to_sym` is undefined.