### PR TITLE
Fix display of mention placeholder in threads

### DIFF
--- a/app/javascript/flavours/polyam/styles/components/status/status.scss
+++ b/app/javascript/flavours/polyam/styles/components/status/status.scss
@@ -130,6 +130,7 @@
 
     // Polyam: .reactions-bar and .status__content__wrapper
     & > .status__content__wrapper,
+    & > .status__content,
     & > .status__action-bar,
     & > .reactions-bar,
     & > .media-gallery,


### PR DESCRIPTION
Re-add `.status__content` class to have mention placeholder and potentially other elements not wrapped having correct margin.