### PR TITLE
Fix light skin variables used when using custom skins

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,7 +189,7 @@ module ApplicationHelper
       'data-system-light': system_skins[1],
     }
 
-    base[:'data-system-theme'] = 'true' if page_color_scheme == 'auto'
+    base[:'data-system-theme'] = 'true' if page_color_scheme == 'auto' && current_skin == 'system'
 
     base
   end

--- a/app/javascript/flavours/polyam/styles/mastodon/theme/index.scss
+++ b/app/javascript/flavours/polyam/styles/mastodon/theme/index.scss
@@ -7,6 +7,8 @@ html {
   @include base.palette;
 }
 
+// Polyam: Wrapped as otherwise light style is unconditionally set
+// when prefers-color-scheme is light
 [data-color-scheme='dark'],
 html:not([data-color-scheme]) {
   color-scheme: dark;
@@ -14,12 +16,14 @@ html:not([data-color-scheme]) {
   @include utils.invert-on-dark;
 
   // Polyam Wrapped in data-system-dark to not override user-set dark skin
-  &[data-system-dark='default'] {
-    @include dark.tokens;
+  &[data-system-theme='true'] {
+    &[data-system-dark='default'] {
+      @include dark.tokens;
 
-    &[data-contrast='high'],
-    [data-contrast='high'] & {
-      @include dark.contrast-overrides;
+      &[data-contrast='high'],
+      [data-contrast='high'] & {
+        @include dark.contrast-overrides;
+      }
     }
   }
 }
@@ -30,12 +34,14 @@ html:not([data-color-scheme]) {
   @include utils.invert-on-light;
 
   // Polyam: Wrapped in data-system-light to not override user-set light skin
-  &[data-system-light='mastodon-light'] {
-    @include light.tokens;
+  &[data-system-theme='true'] {
+    &[data-system-light='mastodon-light'] {
+      @include light.tokens;
 
-    &[data-contrast='high'],
-    [data-contrast='high'] & {
-      @include light.contrast-overrides;
+      &[data-contrast='high'],
+      [data-contrast='high'] & {
+        @include light.contrast-overrides;
+      }
     }
   }
 }


### PR DESCRIPTION
When setting the skin to a third-party skin while `prefers-color-scheme` is set to `light`, the custom skin is overridden by light style.

This fixes that by using the `data-system-theme` attribute to conditionally use system styles. Currently that data attribute is always "true", so it was made to also rely on the skin setting.

This does break `default` and `mastodon-light` when selected as skin, but upstream's idea is to merge them into the system skin.