### PR TITLE
Remove `anniversary` attribute from API

### DIFF
--- a/app/javascript/flavours/polyam/api_types/accounts.ts
+++ b/app/javascript/flavours/polyam/api_types/accounts.ts
@@ -44,7 +44,6 @@ export interface BaseApiAccountJSON {
   limited?: boolean;
   memorial?: boolean;
   hide_collections: boolean;
-  anniversary: boolean;
 }
 
 // See app/serializers/rest/muted_account_serializer.rb

--- a/app/javascript/flavours/polyam/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/components/account_header.tsx
@@ -1,5 +1,5 @@
 import type { RefCallback } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -60,6 +60,22 @@ export const AccountHeader: React.FC<{
     state.relationships.get(accountId),
   );
   const hidden = useAppSelector((state) => getAccountHidden(state, accountId));
+
+  const createdAtStr = account?.created_at;
+  const anniversary = useMemo(() => {
+    if (!createdAtStr) {
+      return null;
+    }
+    const now = new Date();
+    const createdAt = new Date(createdAtStr);
+    if (
+      now.getMonth() === createdAt.getMonth() &&
+      now.getDate() === createdAt.getDate()
+    ) {
+      return now.getFullYear() - createdAt.getFullYear();
+    }
+    return null;
+  }, [createdAtStr]);
 
   const handleOpenAvatar = useCallback(
     (e: React.MouseEvent) => {
@@ -133,8 +149,8 @@ export const AccountHeader: React.FC<{
       {!hidden && account.moved && (
         <MovedNote accountId={account.id} targetAccountId={account.moved} />
       )}
-      {!hidden && !account.memorial && account.anniversary && (
-        <AnniversaryNote account={account} />
+      {!hidden && !account.memorial && anniversary && (
+        <AnniversaryNote account={account} years={anniversary} />
       )}
 
       <AnimateEmojiProvider

--- a/app/javascript/flavours/polyam/features/account_timeline/components/anniversary-note.tsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/components/anniversary-note.tsx
@@ -12,8 +12,9 @@ const Fedimation: React.FC = () => (
   </div>
 );
 
-export const AnniversaryNote: React.FC<{ account: Account }> = ({
+export const AnniversaryNote: React.FC<{ account: Account; years: number }> = ({
   account,
+  years,
 }) => {
   return (
     <div className='account-anniversary-banner'>
@@ -26,9 +27,7 @@ export const AnniversaryNote: React.FC<{ account: Account }> = ({
           defaultMessage="It's {acct}'s {years, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} fediversary!"
           values={{
             acct: account.acct,
-            years:
-              new Date().getFullYear() -
-              new Date(account.created_at).getFullYear(),
+            years: years,
           }}
         />
       </div>

--- a/app/javascript/flavours/polyam/models/account.ts
+++ b/app/javascript/flavours/polyam/models/account.ts
@@ -93,7 +93,6 @@ export const accountDefaultValues: AccountShape = {
   limited: false,
   moved: null,
   hide_collections: false,
-  anniversary: false,
   // This comes from `ApiMutedAccountJSON`, but we should eventually
   // store that in a different object.
   mute_expires_at: null,

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -8,7 +8,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   attributes :id, :username, :acct, :display_name, :locked, :bot, :discoverable, :indexable, :group, :created_at,
              :note, :url, :uri, :avatar, :avatar_static, :avatar_description, :header, :header_static, :header_description,
-             :followers_count, :following_count, :statuses_count, :last_status_at, :hide_collections, :anniversary
+             :followers_count, :following_count, :statuses_count, :last_status_at, :hide_collections
 
   has_one :moved_to_account, key: :moved, serializer: REST::AccountSerializer, if: :moved_and_not_nested?
 
@@ -152,11 +152,6 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   def memorial
     object.memorial?
-  end
-
-  def anniversary
-    now = Time.now.utc
-    object.created_at.month == now.month && object.created_at.day == now.day && object.created_at.year != now.year
   end
 
   def roles


### PR DESCRIPTION
Removes `anniversary` from account serializer and uses JS for determining anniversary.

At the time of this feature's introduction `useMemo` wasn't available to use, which would've meant calculating the date at each visit of a profile. Now upstream has implemented a similiar feature which may or may not end up replacing this little banner, but for now it uses the same logic as upstream.