### PR TITLE
Fix role color not applying to admin badge

### DIFF
--- a/app/javascript/flavours/polyam/features/account_timeline/components/badges.tsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/components/badges.tsx
@@ -55,6 +55,7 @@ export const AccountBadges: FC<{ accountId: string }> = ({ accountId }) => {
           label={role.name}
           className={className}
           roleId={role.id}
+          roleColor={role.color}
         />,
       );
     } else {


### PR DESCRIPTION
Fixes #1123

The issue wasn't role colors not applying at all but the new admin badge.
Adds missing `roleColor` prop.