### PR TITLE
Allow scrolling to top in profile redesign

### DIFF
--- a/app/javascript/flavours/polyam/features/account_timeline/v2/index.tsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/v2/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { FC } from 'react';
 
 import { FormattedMessage } from 'react-intl';
@@ -12,11 +12,12 @@ import {
   expandTimelineByKey,
   timelineKey,
 } from '@/flavours/polyam/actions/timelines_typed';
+import type { ColumnRef } from '@/flavours/polyam/components/column';
 import { Column } from '@/flavours/polyam/components/column';
-import { ColumnBackButton } from '@/flavours/polyam/components/column_back_button';
 import { LoadingIndicator } from '@/flavours/polyam/components/loading_indicator';
 import { RemoteHint } from '@/flavours/polyam/components/remote_hint';
 import StatusList from '@/flavours/polyam/components/status_list';
+import { ProfileColumnHeader } from '@/flavours/polyam/features/account/components/profile_column_header';
 import BundleColumnError from '@/flavours/polyam/features/ui/components/bundle_column_error';
 import {
   useAccountId,
@@ -82,6 +83,7 @@ const InnerTimeline: FC<{ accountId: string; multiColumn: boolean }> = ({
     boosts,
     replies,
   });
+  const columnRef = useRef<ColumnRef>(null);
 
   const timeline = useAppSelector((state) => selectTimelineByKey(state, key));
   const { blockedBy, hidden, suspended } = useAccountVisibility(accountId);
@@ -103,14 +105,22 @@ const InnerTimeline: FC<{ accountId: string; multiColumn: boolean }> = ({
     [accountId, dispatch, key],
   );
 
+  const handleHeaderClick = useCallback(() => {
+    columnRef.current?.scrollTop();
+  }, [columnRef]);
+
   const { isLoading: isPinnedLoading, statusIds: pinnedStatusIds } =
     usePinnedStatusIds({ accountId, tagged, forceEmptyState });
 
   const isLoading = !!timeline?.isLoading || isPinnedLoading;
 
   return (
-    <Column bindToDocument={!multiColumn}>
-      <ColumnBackButton />
+    <Column ref={columnRef} bindToDocument={!multiColumn}>
+      {/* Polyam: Use profile header to allow scrolling to top */}
+      <ProfileColumnHeader
+        onClick={handleHeaderClick}
+        multiColumn={multiColumn}
+      />
 
       <StatusList
         alwaysPrepend


### PR DESCRIPTION
Fixes #1138 

Replaces the back button with the profile header.

I'm holding off on merging this until the design is final and give upstream a chance to fix it.