### PR TITLE
Change position of alt-badge in multimedia layout

### DIFF
--- a/app/javascript/flavours/polyam/components/alt_text_badge/index.tsx
+++ b/app/javascript/flavours/polyam/components/alt_text_badge/index.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import type {
   OffsetValue,
   UsePopperOptions,
+  Placement,
 } from 'react-overlays/esm/usePopper';
 import Overlay from 'react-overlays/Overlay';
 
@@ -18,8 +19,9 @@ import classes from './styles.module.scss';
 const offset = [0, 4] as OffsetValue;
 const popperConfig = { strategy: 'fixed' } as UsePopperOptions;
 
-export const AltTextBadge: React.FC<{ description: string }> = ({
+export const AltTextBadge: React.FC<{ description: string; placement?: Placement }> = ({
   description,
+  placement = 'top-end',
 }) => {
   const intl = useIntl();
   const uniqueId = useId();
@@ -62,7 +64,7 @@ export const AltTextBadge: React.FC<{ description: string }> = ({
         onHide={handleClose}
         show={open}
         target={buttonRef}
-        placement='top-end'
+        placement={placement}
         flip
         offset={offset}
         popperConfig={popperConfig}

--- a/app/javascript/flavours/polyam/components/alt_text_badge/index.tsx
+++ b/app/javascript/flavours/polyam/components/alt_text_badge/index.tsx
@@ -19,10 +19,10 @@ import classes from './styles.module.scss';
 const offset = [0, 4] as OffsetValue;
 const popperConfig = { strategy: 'fixed' } as UsePopperOptions;
 
-export const AltTextBadge: React.FC<{ description: string; placement?: Placement }> = ({
-  description,
-  placement = 'top-end',
-}) => {
+export const AltTextBadge: React.FC<{
+  description: string;
+  placement?: Placement;
+}> = ({ description, placement = 'top-end' }) => {
   const intl = useIntl();
   const uniqueId = useId();
   const popoverId = `${uniqueId}-popover`;

--- a/app/javascript/flavours/polyam/components/media_gallery.jsx
+++ b/app/javascript/flavours/polyam/components/media_gallery.jsx
@@ -105,9 +105,11 @@ class Item extends PureComponent {
     }
 
     const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
+    // Polyam: Whether to show badge on left side instead of right
+    const invertedBadge = (size === 4 && index % 2 === 0)
 
     if (description?.length > 0) {
-      badges.push(<AltTextBadge key='alt' description={description} />);
+      badges.push(<AltTextBadge key='alt' description={description} placement={invertedBadge ? 'top-start' : undefined} />);
     }
 
     if (attachment.get('type') === 'unknown') {
@@ -204,7 +206,7 @@ class Item extends PureComponent {
         {visible && thumbnail}
 
         {badges && (
-          <div className='media-gallery__item__badges'>
+          <div className={classNames('media-gallery__item__badges', { 'media-gallery__item__badges--inverted': invertedBadge })}>
             {badges}
           </div>
         )}

--- a/app/javascript/flavours/polyam/components/media_gallery.jsx
+++ b/app/javascript/flavours/polyam/components/media_gallery.jsx
@@ -106,7 +106,7 @@ class Item extends PureComponent {
 
     const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
     // Polyam: Whether to show badge on left side instead of right
-    const invertedBadge = (size === 4 && index % 2 === 0)
+    const invertedBadge = (size === 3 && index === 0) || (size % 2 === 0 && index % 2 === 0)
 
     if (description?.length > 0) {
       badges.push(<AltTextBadge key='alt' description={description} placement={invertedBadge ? 'top-start' : undefined} />);

--- a/app/javascript/flavours/polyam/styles/mastodon/components.scss
+++ b/app/javascript/flavours/polyam/styles/mastodon/components.scss
@@ -7422,6 +7422,12 @@ img.modal-warning {
   display: flex;
   gap: 2px;
   pointer-events: none;
+
+  // Polyam: Different badge position per layout
+  &--inverted {
+    inset-inline-end: unset;
+    inset-inline-start: 8px;
+  }
 }
 
 .media-gallery__alt__label,


### PR DESCRIPTION
Proper fix for #230

In toots with 4 attachments the top-left alt-badge is hidden behind the "Click to show" overlay. This moves the alt-badge to the left side and changes the alt-overlay accordingly.

This does not make the badge clickable again.
With the old design it was as simple as changing the z-index, but that does not work anymore.

| Before | After |
| -- | -- |
|<img width="395" height="357" alt="Top-left alt-badge hidden behin text" src="https://github.com/user-attachments/assets/2f2766f1-ef00-4d41-8008-e32343977a7c" />|<img width="393" height="362" alt="Alt-badge is displayed on the left on left-aligned images" src="https://github.com/user-attachments/assets/062d0cb3-95ce-4f5f-99e3-20caa82e7d86" />|
|<img width="394" height="355" alt="3 attachments. All badges are aligned right" src="https://github.com/user-attachments/assets/f19d8070-ecc0-48b7-802a-758e548b44ae" />|<img width="396" height="360" alt="3 attachments. First one is aligned left." src="https://github.com/user-attachments/assets/35a3a31c-8b55-4f8b-9f66-b36f6bb95d66" />|
|<img width="395" height="362" alt="2 attachments. All badges are aligned right" src="https://github.com/user-attachments/assets/0ebbefe9-f9e2-4fa8-af9d-01d9f026ff0c" />|<img width="388" height="353" alt="2 attachments. First badge is aligned left" src="https://github.com/user-attachments/assets/bc281e65-0ef5-4c87-8b8b-d756c010a018" />|
|<img width="388" height="360" alt="Overlay overflows to the left" src="https://github.com/user-attachments/assets/59204ebf-846b-4bf5-a645-246dd607e16c" />|<img width="387" height="355" alt="Overlay is within column" src="https://github.com/user-attachments/assets/2c36ea2f-b5fe-46b2-b8af-9de4e718b4c1" />|


