### PR TITLE
Make alt-badge clickable behind sensitive overlay

### DIFF
--- a/app/javascript/flavours/polyam/styles/mastodon/components.scss
+++ b/app/javascript/flavours/polyam/styles/mastodon/components.scss
@@ -7442,7 +7442,7 @@ img.modal-warning {
   border-radius: 4px;
   font-size: 12px;
   font-weight: 700;
-  z-index: 1;
+  z-index: 101; // Polyam: Needs to be higher than .spoiler-button
   line-height: 20px;
   cursor: pointer;
   pointer-events: auto;
@@ -7680,7 +7680,8 @@ img.modal-warning {
   overflow: hidden;
   outline: 1px solid var(--color-border-media);
   outline-offset: -1px;
-  z-index: 1;
+
+  // Polyam: z-index: 1; removed as it prevents clickable alt-badge behind overlay
 
   &--tall {
     grid-row: span 2;
@@ -7738,7 +7739,7 @@ img.modal-warning {
   text-decoration: none;
   color: var(--color-text-primary);
   position: relative;
-  z-index: -1;
+  z-index: 1; // Polyam: Kept 1 instead of -1
   border-radius: inherit;
 
   &,
@@ -7778,7 +7779,7 @@ img.modal-warning {
   position: absolute;
   top: 0;
   inset-inline-start: 0;
-  z-index: -2;
+  z-index: 0; // Polyam: Kept at 0 instead of -1
   background: var(--color-bg-overlay);
 
   &--hidden {


### PR DESCRIPTION
Re-implementation of #201 
Revert of #232

This reverts some of upstream's pointless z-index changes and changes the z-index of the alt-badge to be rendered above the overlay, making it clickable.

See: https://github.com/polyamspace/mastodon/pull/1144#issuecomment-4470613165

Preview:
<img width="392" height="356" alt="A toot with 4 hidden media attachments. The alt overlay displays the alt-text of the bottom right image" src="https://github.com/user-attachments/assets/1f7980b5-24ad-451c-98ea-5a2624cfc907" />
