### PR TITLE
Fix counters shown in account timeline

### DIFF
--- a/app/javascript/flavours/polyam/features/account_timeline/index.tsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/index.tsx
@@ -139,7 +139,7 @@ const InnerTimeline: FC<{ accountId: string; multiColumn: boolean }> = ({
         emptyMessage={<EmptyMessage accountId={accountId} />}
         bindToDocument={!multiColumn}
         timelineId='account'
-        withCounters
+        // Polyam: removed withCounters
         className={classNames(classes.statusWrapper)}
         statusProps={{ headerRenderFn: renderPinnedStatusHeader }}
       />


### PR DESCRIPTION
This removes like and boost count from toots in account timeline.
A local setting would make sense since there's already one for reply count