### PR TITLE
Remove `hidden_by_moderators` from API

### DIFF
--- a/app/javascript/flavours/polyam/api_types/statuses.ts
+++ b/app/javascript/flavours/polyam/api_types/statuses.ts
@@ -138,7 +138,6 @@ export interface ApiStatusJSON {
 
   // polyam-glitch additions
   reactions_count: number;
-  hidden_by_moderators: boolean;
   reactions: ApiReactionJSON[];
 }
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -283,10 +283,6 @@ class Status < ApplicationRecord
     @reported ||= account.targeted_reports.unresolved.exists?(['? = ANY(status_ids)', id]) || account.strikes.exists?(['? = ANY(status_ids)', id.to_s])
   end
 
-  def hidden_by_moderators?
-    CustomFilter.instance_filter.statuses.exists?(status_id: id)
-  end
-
   def emojis
     return @emojis if defined?(@emojis)
 

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -9,7 +9,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
              :sensitive, :spoiler_text, :visibility, :language,
              :uri, :url, :replies_count, :reblogs_count,
              :favourites_count, :quotes_count, :edited_at,
-             :reactions_count, :hidden_by_moderators
+             :reactions_count
 
   attribute :favourited, if: :current_user?
   attribute :reblogged, if: :current_user?
@@ -179,10 +179,6 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   def reactions
     relationships&.attributes_map&.dig(object.id, :reactions) || object.reactions(current_user&.account&.id)
-  end
-
-  def hidden_by_moderators
-    object.hidden_by_moderators?
   end
 
   def tagged_collections


### PR DESCRIPTION
Ref #757 

This should not have any impact.
This attribute was solely used to show a custom message.