### PR TITLE
Remove custom message for hidden toots from web UI

### DIFF
--- a/app/javascript/flavours/polyam/actions/importer/normalizer.js
+++ b/app/javascript/flavours/polyam/actions/importer/normalizer.js
@@ -75,7 +75,6 @@ export function normalizeStatus(status, normalOldStatus, { settings, bogusQuoteP
     normalStatus.contentHtml = normalOldStatus.get('contentHtml');
     normalStatus.spoilerHtml = normalOldStatus.get('spoilerHtml');
     normalStatus.hidden = normalOldStatus.get('hidden');
-    normalStatus.hidden_by_moderators = normalOldStatus.get('hidden_by_moderators');
 
     if (normalOldStatus.get('translation')) {
       normalStatus.translation = normalOldStatus.get('translation');

--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -20,7 +20,7 @@ import Bundle from '../features/ui/components/bundle';
 import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
 import { SensitiveMediaContext } from '../features/ui/util/sensitive_media_context';
 import { identityContextPropShape, withIdentity } from '../identity_context';
-import { displayMedia, domain } from '../initial_state';
+import { displayMedia } from '../initial_state';
 
 import AttachmentList from './attachment_list';
 import { injectIntl } from './intl';
@@ -628,7 +628,6 @@ class Status extends ImmutablePureComponent {
     const connectToRoot = rootId && rootId === status.get('in_reply_to_id');
     const connectReply = nextInReplyToId && nextInReplyToId === status.get('id');
     const matchedFilters = status.get('matched_filters');
-    const hidden_by_moderators = status.get('hidden_by_moderators');
 
     const collapseEnabled = settings.getIn(['collapsed', 'enabled']);
     const showActionBar = settings.getIn(['collapsed', 'show_action_bar']);
@@ -645,18 +644,16 @@ class Status extends ImmutablePureComponent {
       );
     }
 
-    if (this.state.showDespiteFilter === undefined ? (hidden_by_moderators ? hidden_by_moderators : matchedFilters) : this.state.showDespiteFilter) {
+    if (this.state.showDespiteFilter === undefined ? matchedFilters : this.state.showDespiteFilter) {
       const minHandlers = this.props.muted ? {} : {
         moveUp: this.handleHotkeyMoveUp,
         moveDown: this.handleHotkeyMoveDown,
       };
 
-      const message = hidden_by_moderators ? <FormattedMessage id='status.hidden_by_moderators' defaultMessage='This toot has been hidden by the moderators of {domain}.' values={{ domain }} /> : <><FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {matchedFilters.join(', ')}.</>;
-
       return (
         <Hotkeys handlers={minHandlers} focusable={!unfocusable}>
           <div className='status__wrapper status__wrapper--filtered focusable' tabIndex={unfocusable ? null : 0} ref={this.handleRef}>
-            {message}
+            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {matchedFilters.join(', ')}.
             {' '}
             <button className='status__wrapper--filtered__button' onClick={this.handleUnfilterClick}>
               <FormattedMessage id='status.show_filter_reason' defaultMessage='Show anyway' />
@@ -919,7 +916,7 @@ class Status extends ImmutablePureComponent {
                 status={status}
                 account={status.get('account')}
                 showReplyCount={settings.get('show_reply_count')}
-                onFilter={matchedFilters || hidden_by_moderators ? this.handleFilterClick : null}
+                onFilter={matchedFilters ? this.handleFilterClick : null}
                 {...other}
               />
             )}

--- a/app/javascript/flavours/polyam/locales/en.json
+++ b/app/javascript/flavours/polyam/locales/en.json
@@ -41,7 +41,6 @@
   "settings.picker_opts": "Emoji picker categories",
   "settings.show_action_bar": "Show action buttons in collapsed toots",
   "status.collapse": "Collapse",
-  "status.hidden_by_moderators": "This toot has been hidden by the moderators of {domain}.",
   "status.is_thread": "This toot is part of a thread",
   "status.react": "React",
   "status.reactions.empty": "No one has reacted to this toot yet. When someone does, they will show up here.",


### PR DESCRIPTION
Ref #757

Removes the custom message for hidden toots.
Now they will display like a regular filter match.