### PR TITLE
Fix missing status icons due to missed change

### DIFF
--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -837,16 +837,17 @@ class Status extends ImmutablePureComponent {
           account={account}
           avatarSize={avatarSize}
           onHeaderClick={this.handleHeaderClick}
-        >
-          <StatusIcons
-            status={status}
-            mediaIcons={mediaIcons}
-            settings={settings.get('status_icons')}
-            collapsible={!muted && collapseEnabled}
-            collapsed={isCollapsed}
-            setCollapsed={setCollapsed}
-          />
-        </StatusHeader>
+          contentBeforeDate={
+            <StatusIcons
+              status={status}
+              mediaIcons={mediaIcons}
+              settings={settings.get('status_icons')}
+              collapsible={!muted && collapseEnabled}
+              collapsed={isCollapsed}
+              setCollapsed={setCollapsed}
+            />
+          }
+        />
       );
 
     return (


### PR DESCRIPTION
I put as much care into the merges as upstream does to code changes and now I'm paying the price.

This was a glitch-soc change I missed while porting d20d04922672ed016029c40ed64798f341ebca91