### PR TITLE
Fix missing status icons in account timeline

### DIFF
--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -842,7 +842,7 @@ class Status extends ImmutablePureComponent {
     );
 
     const header = this.props.headerRenderFn
-      ? this.props.headerRenderFn({ status, account, avatarSize, messages, onHeaderClick: this.handleHeaderClick, featured, contentBeforeDate: statusIcons })
+      ? this.props.headerRenderFn({ status, account, avatarSize, messages, onHeaderClick: this.handleHeaderClick, featured, contentBeforeDate: !isQuotedPost ? statusIcons : null })
       : (
         <StatusHeader
           status={status}

--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -830,24 +830,26 @@ class Status extends ImmutablePureComponent {
 
     const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
 
+    const statusIcons = (
+      <StatusIcons
+        status={status}
+        mediaIcons={mediaIcons}
+        settings={settings.get('status_icons')}
+        collapsible={!muted && collapseEnabled}
+        collapsed={isCollapsed}
+        setCollapsed={setCollapsed}
+      />
+    );
+
     const header = this.props.headerRenderFn
-      ? this.props.headerRenderFn({ status, account, avatarSize, messages, onHeaderClick: this.handleHeaderClick, featured })
+      ? this.props.headerRenderFn({ status, account, avatarSize, messages, onHeaderClick: this.handleHeaderClick, featured, contentBeforeDate: statusIcons })
       : (
         <StatusHeader
           status={status}
           account={account}
           avatarSize={avatarSize}
           onHeaderClick={this.handleHeaderClick}
-          contentBeforeDate={
-            <StatusIcons
-              status={status}
-              mediaIcons={mediaIcons}
-              settings={settings.get('status_icons')}
-              collapsible={!muted && collapseEnabled}
-              collapsed={isCollapsed}
-              setCollapsed={setCollapsed}
-            />
-          }
+          contentBeforeDate={statusIcons}
         />
       );
 

--- a/app/javascript/flavours/polyam/features/account_timeline/components/pinned_statuses.tsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/components/pinned_statuses.tsx
@@ -16,11 +16,10 @@ import classes from '../styles.module.scss';
 
 export const renderPinnedStatusHeader: StatusHeaderRenderFn = ({
   featured,
-  contentBeforeDate,
   ...args
 }) => {
   if (!featured) {
-    return <StatusHeader {...args} contentBeforeDate={contentBeforeDate} />;
+    return <StatusHeader {...args} />;
   }
   return (
     <StatusHeader

--- a/app/javascript/flavours/polyam/features/account_timeline/components/pinned_statuses.tsx
+++ b/app/javascript/flavours/polyam/features/account_timeline/components/pinned_statuses.tsx
@@ -16,10 +16,11 @@ import classes from '../styles.module.scss';
 
 export const renderPinnedStatusHeader: StatusHeaderRenderFn = ({
   featured,
+  contentBeforeDate,
   ...args
 }) => {
   if (!featured) {
-    return <StatusHeader {...args} />;
+    return <StatusHeader {...args} contentBeforeDate={contentBeforeDate} />;
   }
   return (
     <StatusHeader


### PR DESCRIPTION
Fixes #1206 

The account timeline sets a header function which prevented the status icons from being added to the header.
This fixes that by passing the status icons down to the header function used in the account timeline.