### PR TITLE
Change version string

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -9,15 +9,15 @@ module Mastodon
     end
 
     def minor
-      7
+      6
     end
 
     def patch
-      0
+      3
     end
 
     def default_prerelease
-      'alpha.1'
+      ''
     end
 
     def prerelease


### PR DESCRIPTION
I have not fully decided on the version string, so this is early work.
However no 4.7 release is planned so 4.6.3 is more accurate.
Ultimately I also want to ditch the '+glitch' once apps stop using it for feature detection, since it's not particularly accurate.
Technically more accurate would be '4.6.4-alpha.1+glitch.polyam' but that probably causes confusion as it points to a non-existent upstream release.

The biggest issue is how to communicate that this is a patched version. I thought about adding 'LTS' or 'patch.x' as pre-release which would look like '4.6.x-LTS+polyam' or '4.6.x-patch.y+polyam' but I think that's quite a stretch of definition.
Another option is to add a patch/build number at the end to signal support, which would look like '4.6.x+polyam.y' where the number increases with every security patch.
Yet another option is to add a patch date, which is more obvious than a number: `4.6.3+polyam.YYYY-MM-DD'