### PR TITLE
Collapsing: Fix autocollapsing for quotes

### DIFF
--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -260,6 +260,9 @@ class Status extends ImmutablePureComponent {
     // as it could cause surprising changes when receiving notifications
     if (settings.getIn(['content_warnings', 'shared_state']) && status.get('spoiler_text').length && !status.get('hidden')) return;
 
+    // Polyam: Do not autocollapse quoted toots.
+    if (isQuotedPost) return;
+
     let autoCollapseHeight = parseInt(autoCollapseSettings.get('height'));
     if (status.get('media_attachments').size && !muted) {
       autoCollapseHeight += 210;
@@ -272,7 +275,7 @@ class Status extends ImmutablePureComponent {
       (autoCollapseSettings.get('reblogs') && prepend === 'reblogged_by') ||
       (autoCollapseSettings.get('replies') && status.get('in_reply_to_id', null) !== null) ||
       (autoCollapseSettings.get('media') && !(status.get('spoiler_text').length) && status.get('media_attachments').size > 0) ||
-      (autoCollapseSettings.get('quotes') && !isQuotedPost && !!status.get('quote'))
+      (autoCollapseSettings.get('quotes') && !!status.get('quote'))
     ) {
       this.setCollapsed(true);
       // Hack to fix timeline jumps on second rendering when auto-collapsing

--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -272,7 +272,7 @@ class Status extends ImmutablePureComponent {
       (autoCollapseSettings.get('reblogs') && prepend === 'reblogged_by') ||
       (autoCollapseSettings.get('replies') && status.get('in_reply_to_id', null) !== null) ||
       (autoCollapseSettings.get('media') && !(status.get('spoiler_text').length) && status.get('media_attachments').size > 0) ||
-      (autoCollapseSettings.get('quotes') && isQuotedPost)
+      (autoCollapseSettings.get('quotes') && !isQuotedPost && !!status.get('quote'))
     ) {
       this.setCollapsed(true);
       // Hack to fix timeline jumps on second rendering when auto-collapsing


### PR DESCRIPTION
Fixes #1236 

A twofold fix:
- I misunderstood the `isQuotedPost` prop.
Instead of being `true` for quotes, it's actually `undefined` and only `true` for the quoted toot.
So the autocollapse setting actually applied to the quoted toot instead of the quote.
- Quoted toots should not be autocollapsed in general 

This needs to be backported.