### PR TITLE
Collapsing: Fallback value for `autoCollapseHeight`

### DIFF
--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -263,7 +263,7 @@ class Status extends ImmutablePureComponent {
     // Polyam: Do not autocollapse quoted toots.
     if (isQuotedPost) return;
 
-    let autoCollapseHeight = parseInt(autoCollapseSettings.get('height'));
+    let autoCollapseHeight = parseInt(autoCollapseSettings.get('height')) || 400;
     if (status.get('media_attachments').size && !muted) {
       autoCollapseHeight += 210;
     }


### PR DESCRIPTION
Interim fix for #1239 

The autocollapse height setting allows empty string as value which results parseInt to return NaN breaking the height check. With the current code there is no good way to prevent a NaN in the setting, so this is the best interim solution. This should be properly fixed once the local settings components are refactored and converted to TS