### PR TITLE
Reduce differences with upstream again

### DIFF
--- a/app/javascript/flavours/polyam/actions/statuses.js
+++ b/app/javascript/flavours/polyam/actions/statuses.js
@@ -111,7 +111,7 @@ export function fetchStatusFail(id, error, skipLoading, parentQuotePostId) {
 
 export function redraft(status, raw_text, content_type, quoted_status_id = null) {
   return (dispatch, getState) => {
-    const maxOptions = getState().server.server.item?.configuration.polls.max_options;;
+    const maxOptions = getState().server.server.item?.configuration.polls.max_options;
 
     dispatch({
       type: REDRAFT,

--- a/app/javascript/flavours/polyam/components/admin/Trends.jsx
+++ b/app/javascript/flavours/polyam/components/admin/Trends.jsx
@@ -53,7 +53,7 @@ export default class Trends extends PureComponent {
             <Hashtag
               key={hashtag.name}
               name={hashtag.name}
-              href={hashtag.id ? `/admin/tags/${hashtag.id}` : undefined}
+              href={hashtag.id === undefined ? undefined : `/admin/tags/${hashtag.id}`}
               people={hashtag.history[0].accounts * 1 + hashtag.history[1].accounts * 1}
               uses={hashtag.history[0].uses * 1 + hashtag.history[1].uses * 1}
               history={hashtag.history.reverse().map(day => day.uses)}

--- a/app/javascript/flavours/polyam/components/badge/index.tsx
+++ b/app/javascript/flavours/polyam/components/badge/index.tsx
@@ -71,7 +71,7 @@ export const Badge: FC<BadgeProps> = ({
     {icon}
     <span className={classes.content}>
       {label}
-      {domain && <span className={classes.domain}>{domain}</span>}
+      {domain && <span className={classes.domain}> {domain}</span>}
     </span>
   </div>
 );

--- a/app/javascript/flavours/polyam/components/follow_button.tsx
+++ b/app/javascript/flavours/polyam/components/follow_button.tsx
@@ -33,7 +33,7 @@ const longMessages = defineMessages({
     id: 'account.follow_request_cancel',
     defaultMessage: 'Cancel request',
   },
-  editProfile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
+  edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
 });
 
 const shortMessages = {
@@ -114,10 +114,7 @@ export const FollowButton: React.FC<{
       dispatch(unmuteAccount(accountId));
     } else if (account && relationship.following) {
       dispatch(
-        openModal({
-          modalType: 'CONFIRM_UNFOLLOW',
-          modalProps: { account },
-        }),
+        openModal({ modalType: 'CONFIRM_UNFOLLOW', modalProps: { account } }),
       );
     } else if (account && relationship.requested) {
       dispatch(
@@ -147,7 +144,7 @@ export const FollowButton: React.FC<{
   if (!signedIn) {
     label = intl.formatMessage(followMessage);
   } else if (accountId === me) {
-    label = intl.formatMessage(messages.editProfile);
+    label = intl.formatMessage(messages.edit_profile);
   } else if (!relationship) {
     label = <LoadingIndicator />;
   } else if (relationship.muting && withUnmute) {

--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -574,7 +574,7 @@ class Status extends ImmutablePureComponent {
       rootId,
       skipPrepend,
       avatarSize = 46,
-      children
+      children,
     } = this.props;
 
     // glitch-soc-specific
@@ -601,7 +601,7 @@ class Status extends ImmutablePureComponent {
     //  contents (affected by CW) while other will be displayed outside of the
     //  CW.
     let media = [];
-    let mediaIcons= [];
+    let mediaIcons = [];
 
     if (status === null) {
       return null;
@@ -639,7 +639,7 @@ class Status extends ImmutablePureComponent {
 
     if (hidden) {
       return (
-        <Hotkeys handlers={handlers} focusables={!unfocusable}>
+        <Hotkeys handlers={handlers} focusable={!unfocusable}>
           <div ref={this.handleRef} className='status focusable' tabIndex={unfocusable ? null : 0}>
             <span>{status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}</span>
             {status.get('spoiler_text').length > 0 && (<span>{status.get('spoiler_text')}</span>)}
@@ -788,7 +788,7 @@ class Status extends ImmutablePureComponent {
         );
       }
       mediaIcons.push('link');
-    } else if (status.get('tagged_collections').size && !status.get('quote')) {
+    } else if (status.get('tagged_collections').size && !status.get('quote') && settings.get('inline_preview_cards') && !this.props.muted) {
       const firstLinkedCollection = status.get('tagged_collections').first();
       if (firstLinkedCollection) {
         media = (

--- a/app/javascript/flavours/polyam/components/status_prepend.jsx
+++ b/app/javascript/flavours/polyam/components/status_prepend.jsx
@@ -6,14 +6,14 @@ import { FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-import PollIcon from '@/awesome-icons/solid/bars-progress.svg?react';
+import InsertChartIcon from '@/awesome-icons/solid/bars-progress.svg?react';
 import NotificationsIcon from '@/awesome-icons/solid/bell.svg?react';
 import ReactIcon from '@/awesome-icons/solid/face-grin-wide.svg?react';
 import EditIcon from '@/awesome-icons/solid/pencil.svg?react';
 import FormatQuoteIcon from '@/awesome-icons/solid/quote-right.svg?react';
 import StarIcon from '@/awesome-icons/solid/star.svg?react';
-import PinIcon from '@/awesome-icons/solid/thumbtack.svg?react';
-import BoostIcon from '@/svg-icons/boost.svg?react';
+import PushPinIcon from '@/awesome-icons/solid/thumbtack.svg?react';
+import RepeatIcon from '@/svg-icons/boost.svg?react';
 import { Icon } from 'flavours/polyam/components/icon';
 import { me } from 'flavours/polyam/initial_state';
 
@@ -140,16 +140,16 @@ export default class StatusPrepend extends PureComponent {
       break;
     case 'featured':
       iconId = 'thumb-tack';
-      iconComponent = PinIcon;
+      iconComponent = PushPinIcon;
       break;
     case 'poll':
       iconId = 'tasks';
-      iconComponent = PollIcon;
+      iconComponent = InsertChartIcon;
       break;
     case 'reblog':
     case 'reblogged_by':
       iconId = 'retweet';
-      iconComponent = BoostIcon;
+      iconComponent = RepeatIcon;
       break;
     case 'status':
       iconId = 'bell';

--- a/app/javascript/flavours/polyam/components/visibility_icon.tsx
+++ b/app/javascript/flavours/polyam/components/visibility_icon.tsx
@@ -1,9 +1,9 @@
 import { defineMessages, useIntl } from 'react-intl';
 
-import EnvelopeIcon from '@/awesome-icons/solid/envelope.svg?react';
+import MailIcon from '@/awesome-icons/solid/envelope.svg?react';
 import PublicIcon from '@/awesome-icons/solid/globe.svg?react';
 import LockIcon from '@/awesome-icons/solid/lock.svg?react';
-import UnlistedIcon from '@/awesome-icons/solid/unlock.svg?react';
+import QuietTimeIcon from '@/awesome-icons/solid/unlock.svg?react';
 import type { StatusVisibility } from 'flavours/polyam/models/status';
 
 import { Icon } from './icon';
@@ -37,7 +37,7 @@ export const VisibilityIcon: React.FC<{ visibility: StatusVisibility }> = ({
     },
     unlisted: {
       icon: 'unlock',
-      iconComponent: UnlistedIcon,
+      iconComponent: QuietTimeIcon,
       text: intl.formatMessage(messages.unlisted_short),
     },
     private: {
@@ -47,14 +47,14 @@ export const VisibilityIcon: React.FC<{ visibility: StatusVisibility }> = ({
     },
     direct: {
       icon: 'envelope',
-      iconComponent: EnvelopeIcon,
+      iconComponent: MailIcon,
       text: intl.formatMessage(messages.direct_short),
     },
   };
 
   const visibilityIcon = visibilityIconInfo[visibility];
 
-  // Additional attributes compared to upstream: className, aria-hidden and fixedWidth
+  // Additional attributes compared to upstream: aria-hidden
   return (
     <Icon
       className='status__visibility-icon'

--- a/app/javascript/flavours/polyam/features/account_edit/components/tag_search.tsx
+++ b/app/javascript/flavours/polyam/features/account_edit/components/tag_search.tsx
@@ -34,6 +34,7 @@ export const AccountEditTagSearch: FC = () => {
     // Remove existing featured tags from suggestions
     filterResults: (tag) => !tag.featuring,
   });
+
   const handleSearchChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e) => {
       setQuery(e.target.value);

--- a/app/javascript/flavours/polyam/features/account_gallery/index.tsx
+++ b/app/javascript/flavours/polyam/features/account_gallery/index.tsx
@@ -73,6 +73,7 @@ const selectGalleryTimeline = createAppSelector(
       `account:${accountId}:media${withReplies ? ':with_replies' : ''}`,
     );
     const statusIds = timeline?.get('items');
+
     if (isList(statusIds)) {
       for (const statusId of statusIds) {
         const status = statuses.get(statusId);
@@ -105,6 +106,7 @@ export const AccountGallery: React.FC<{
     hasMore,
     withReplies,
   } = useAppSelector((state) => selectGalleryTimeline(state, accountId));
+
   const { suspended, blockedBy, hidden } = useAccountVisibility(accountId);
 
   const maxId = attachments.last()?.getIn(['status', 'id']) as

--- a/app/javascript/flavours/polyam/features/alt_text_modal/index.tsx
+++ b/app/javascript/flavours/polyam/features/alt_text_modal/index.tsx
@@ -491,6 +491,7 @@ export const AltTextModal = forwardRef<ModalRef, Props & Partial<RestoreProps>>(
                 />
 
                 <div className='spacer' />
+
                 <button
                   className='link-button'
                   onClick={handleDetectClick}

--- a/app/javascript/flavours/polyam/features/blocks/index.jsx
+++ b/app/javascript/flavours/polyam/features/blocks/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import BanIcon from '@/awesome-icons/solid/ban.svg?react';
+import BlockIcon from '@/awesome-icons/solid/ban.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { Account } from 'flavours/polyam/components/account';
 
@@ -61,7 +61,7 @@ class Blocks extends ImmutablePureComponent {
     const emptyMessage = <FormattedMessage id='empty_column.blocks' defaultMessage="You haven't blocked any users yet." />;
 
     return (
-      <Column name='blocks' bindToDocument={!multiColumn} icon='ban' iconComponent={BanIcon} heading={intl.formatMessage(messages.heading)} alwaysShowBackButton>
+      <Column bindToDocument={!multiColumn} icon='ban' iconComponent={BlockIcon} heading={intl.formatMessage(messages.heading)} alwaysShowBackButton>
         <ScrollableList
           scrollKey='blocks'
           onLoadMore={this.handleLoadMore}

--- a/app/javascript/flavours/polyam/features/bookmarked_statuses/index.tsx
+++ b/app/javascript/flavours/polyam/features/bookmarked_statuses/index.tsx
@@ -94,6 +94,7 @@ const Bookmarks: React.FC<{
         onClick={handleHeaderClick}
         pinned={pinned}
         multiColumn={multiColumn}
+        showBackButton
       />
 
       <StatusList

--- a/app/javascript/flavours/polyam/features/community_timeline/index.jsx
+++ b/app/javascript/flavours/polyam/features/community_timeline/index.jsx
@@ -141,7 +141,7 @@ class CommunityTimeline extends PureComponent {
     );
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)} name='local'>
+      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
         <ColumnHeader
           icon='users'
           iconComponent={PeopleIcon}

--- a/app/javascript/flavours/polyam/features/compose/components/content_type_button.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/content_type_button.jsx
@@ -4,7 +4,7 @@ import { useIntl, defineMessages } from 'react-intl';
 
 import MarkdownIcon from '@/awesome-icons/brands/markdown.svg?react';
 import CodeIcon from '@/awesome-icons/solid/code.svg?react';
-import TextFileIcon from '@/awesome-icons/solid/file-lines.svg?react';
+import DescriptionIcon from '@/awesome-icons/solid/file-lines.svg?react';
 import { changeComposeContentType } from 'flavours/polyam/actions/compose';
 import { useAppSelector, useAppDispatch } from 'flavours/polyam/store';
 
@@ -36,7 +36,7 @@ export const ContentTypeButton = () => {
   }
 
   const options = [
-    { icon: 'file-text', iconComponent: TextFileIcon, value: 'text/plain', text: intl.formatMessage(messages.plain_text_label), meta: intl.formatMessage(messages.plain_text_meta) },
+    { icon: 'file-text', iconComponent: DescriptionIcon, value: 'text/plain', text: intl.formatMessage(messages.plain_text_label), meta: intl.formatMessage(messages.plain_text_meta) },
     { icon: 'arrow-circle-down', iconComponent: MarkdownIcon, value: 'text/markdown', text: intl.formatMessage(messages.markdown_label), meta: intl.formatMessage(messages.markdown_meta) },
     { icon: 'code', iconComponent: CodeIcon,  value: 'text/html', text: intl.formatMessage(messages.html_label), meta: intl.formatMessage(messages.html_meta) },
   ];
@@ -48,7 +48,7 @@ export const ContentTypeButton = () => {
   }[contentType];
 
   const iconComponent = {
-    'text/plain': TextFileIcon,
+    'text/plain': DescriptionIcon,
     'text/markdown': MarkdownIcon,
     'text/html': CodeIcon,
   }[contentType];

--- a/app/javascript/flavours/polyam/features/compose/components/edit_indicator.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/edit_indicator.jsx
@@ -4,8 +4,8 @@ import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import ImageIcon from '@/awesome-icons/regular/image.svg?react';
-import PollIcon from '@/awesome-icons/solid/bars-progress.svg?react';
+import PhotoLibraryIcon from '@/awesome-icons/regular/image.svg?react';
+import BarChart4BarsIcon from '@/awesome-icons/solid/bars-progress.svg?react';
 import CloseIcon from '@/awesome-icons/solid/xmark.svg?react';
 import { cancelReplyCompose } from 'flavours/polyam/actions/compose';
 import { Icon } from 'flavours/polyam/components/icon';
@@ -54,8 +54,8 @@ export const EditIndicator = () => {
 
       {(status.get('poll') || status.get('media_attachments').size > 0) && (
         <div className='edit-indicator__attachments'>
-          {status.get('poll') && <><Icon icon={PollIcon} /><FormattedMessage id='reply_indicator.poll' defaultMessage='Poll' /></>}
-          {status.get('media_attachments').size > 0 && <><Icon icon={ImageIcon} /><FormattedMessage id='reply_indicator.attachments' defaultMessage='{count, plural, one {# attachment} other {# attachments}}' values={{ count: status.get('media_attachments').size }} /></>}
+          {status.get('poll') && <><Icon icon={BarChart4BarsIcon} /><FormattedMessage id='reply_indicator.poll' defaultMessage='Poll' /></>}
+          {status.get('media_attachments').size > 0 && <><Icon icon={PhotoLibraryIcon} /><FormattedMessage id='reply_indicator.attachments' defaultMessage='{count, plural, one {# attachment} other {# attachments}}' values={{ count: status.get('media_attachments').size }} /></>}
         </div>
       )}
     </div>

--- a/app/javascript/flavours/polyam/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/emoji_picker_dropdown.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 
 import { supportsPassiveEvents } from 'detect-passive-events';
 
-import ReactIcon from '@/awesome-icons/solid/face-grin-wide.svg?react';
+import MoodIcon from '@/awesome-icons/solid/face-grin-wide.svg?react';
 import { IconButton } from '@/flavours/polyam/components/icon_button';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { Popover } from '@/flavours/polyam/components/popover';
@@ -349,7 +349,7 @@ class EmojiPickerDropdown extends PureComponent {
           title={title}
           aria-expanded={active}
           active={active}
-          iconComponent={ReactIcon}
+          iconComponent={MoodIcon}
           onClick={this.onToggle}
           disabled={disabled}
           id="emoji"

--- a/app/javascript/flavours/polyam/features/compose/components/federation_button.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/federation_button.jsx
@@ -2,8 +2,8 @@ import { useCallback } from 'react';
 
 import { useIntl, defineMessages } from 'react-intl';
 
-import LocalOnlyIcon from '@/awesome-icons/solid/house.svg?react';
-import FederatedIcon from '@/awesome-icons/solid/tower-broadcast.svg?react';
+import ShareOffIcon from '@/awesome-icons/solid/house.svg?react';
+import ShareIcon from '@/awesome-icons/solid/tower-broadcast.svg?react';
 import { changeComposeAdvancedOption } from 'flavours/polyam/actions/compose';
 import { useAppSelector, useAppDispatch } from 'flavours/polyam/store';
 
@@ -29,15 +29,15 @@ export const FederationButton = () => {
   }, [dispatch]);
 
   const options = [
-    { icon: 'link', iconComponent: FederatedIcon, value: 'federated', text: intl.formatMessage(messages.federated_label), meta: intl.formatMessage(messages.federated_meta) },
-    { icon: 'link-slash', iconComponent: LocalOnlyIcon, value: 'local-only', text: intl.formatMessage(messages.local_only_label), meta: intl.formatMessage(messages.local_only_meta) },
+    { icon: 'link', iconComponent: ShareIcon, value: 'federated', text: intl.formatMessage(messages.federated_label), meta: intl.formatMessage(messages.federated_meta) },
+    { icon: 'link-slash', iconComponent: ShareOffIcon, value: 'local-only', text: intl.formatMessage(messages.local_only_label), meta: intl.formatMessage(messages.local_only_meta) },
   ];
 
   return (
     <DropdownIconButton
       disabled={isEditing}
       icon={do_not_federate ? 'link-slash' : 'link'}
-      iconComponent={do_not_federate ? LocalOnlyIcon : FederatedIcon}
+      iconComponent={do_not_federate ? ShareOffIcon : ShareIcon}
       onChange={handleChange}
       options={options}
       title={intl.formatMessage(messages.change_federation_settings)}

--- a/app/javascript/flavours/polyam/features/compose/components/poll_button.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/poll_button.jsx
@@ -3,7 +3,7 @@ import { PureComponent } from 'react';
 
 import { defineMessages } from 'react-intl';
 
-import PollIcon from '@/awesome-icons/solid/bars-progress.svg?react';
+import BarChart4BarsIcon from '@/awesome-icons/solid/bars-progress.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 
 import { IconButton } from '../../../components/icon_button';
@@ -38,7 +38,7 @@ class PollButton extends PureComponent {
       <div className='compose-form__poll-button'>
         <IconButton
           icon='tasks'
-          iconComponent={PollIcon}
+          iconComponent={BarChart4BarsIcon}
           title={intl.formatMessage(active ? messages.remove_poll : messages.add_poll)}
           disabled={disabled}
           onClick={this.handleClick}

--- a/app/javascript/flavours/polyam/features/compose/components/reply_indicator.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/reply_indicator.jsx
@@ -2,8 +2,8 @@ import { FormattedMessage } from 'react-intl';
 
 import { useSelector } from 'react-redux';
 
-import ImageIcon from '@/awesome-icons/regular/image.svg?react';
-import PollIcon from '@/awesome-icons/solid/bars-progress.svg?react';
+import PhotoLibraryIcon from '@/awesome-icons/regular/image.svg?react';
+import BarChart4BarsIcon from '@/awesome-icons/solid/bars-progress.svg?react';
 import { Avatar } from 'flavours/polyam/components/avatar';
 import { DisplayName } from 'flavours/polyam/components/display_name';
 import { Icon } from 'flavours/polyam/components/icon';
@@ -39,8 +39,8 @@ export const ReplyIndicator = () => {
 
         {(status.get('poll') || status.get('media_attachments').size > 0) && (
           <div className='reply-indicator__attachments'>
-            {status.get('poll') && <><Icon icon={PollIcon} /><FormattedMessage id='reply_indicator.poll' defaultMessage='Poll' /></>}
-            {status.get('media_attachments').size > 0 && <><Icon icon={ImageIcon} /><FormattedMessage id='reply_indicator.attachments' defaultMessage='{count, plural, one {# attachment} other {# attachments}}' values={{ count: status.get('media_attachments').size }} /></>}
+            {status.get('poll') && <><Icon icon={BarChart4BarsIcon} /><FormattedMessage id='reply_indicator.poll' defaultMessage='Poll' /></>}
+            {status.get('media_attachments').size > 0 && <><Icon icon={PhotoLibraryIcon} /><FormattedMessage id='reply_indicator.attachments' defaultMessage='{count, plural, one {# attachment} other {# attachments}}' values={{ count: status.get('media_attachments').size }} /></>}
           </div>
         )}
       </div>

--- a/app/javascript/flavours/polyam/features/compose/components/secondary_privacy_button.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/secondary_privacy_button.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 
 import { useIntl, defineMessages } from 'react-intl';
 
-import EnvelopeIcon from '@/awesome-icons/solid/envelope.svg?react';
+import MailIcon from '@/awesome-icons/solid/envelope.svg?react';
 import PublicIcon from '@/awesome-icons/solid/globe.svg?react';
 import LockIcon from '@/awesome-icons/solid/lock.svg?react';
-import UnlistedIcon from '@/awesome-icons/solid/unlock.svg?react';
+import QuietTimeIcon from '@/awesome-icons/solid/unlock.svg?react';
 import { Button } from 'flavours/polyam/components/button';
 import { Icon } from 'flavours/polyam/components/icon';
 
@@ -24,10 +24,10 @@ export const SecondaryPrivacyButton = ({ disabled, privacy, isEditing, onClick }
   }
 
   const privacyProps = {
-    direct: { icon: 'envelope', iconComponent: EnvelopeIcon, title: messages.direct },
+    direct: { icon: 'envelope', iconComponent: MailIcon, title: messages.direct },
     private: { icon: 'lock', iconComponent: LockIcon, title: messages.private },
     public: { icon: 'globe', iconComponent: PublicIcon, title: messages.public },
-    unlisted: { icon: 'unlock', iconComponent: UnlistedIcon, title: messages.unlisted },
+    unlisted: { icon: 'unlock', iconComponent: QuietTimeIcon, title: messages.unlisted },
   };
 
   return (

--- a/app/javascript/flavours/polyam/features/compose/components/thread_mode_button.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/thread_mode_button.jsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { useIntl, defineMessages } from 'react-intl';
 
-import CommentsIcon from '@/awesome-icons/solid/comments.svg?react';
+import QuickreplyIcon from '@/awesome-icons/solid/comments.svg?react';
 import { changeComposeAdvancedOption } from 'flavours/polyam/actions/compose';
 import { IconButton } from 'flavours/polyam/components/icon_button';
 import { useAppSelector, useAppDispatch } from 'flavours/polyam/store';
@@ -31,7 +31,7 @@ export const ThreadModeButton = () => {
       disabled={isEditing}
       icon=''
       onClick={handleClick}
-      iconComponent={CommentsIcon}
+      iconComponent={QuickreplyIcon}
       title={title}
       active={active}
       size={18}

--- a/app/javascript/flavours/polyam/features/compose/components/upload_button.jsx
+++ b/app/javascript/flavours/polyam/features/compose/components/upload_button.jsx
@@ -6,9 +6,9 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-import FileArrowUpIcon from '@/awesome-icons/solid/file-arrow-up.svg?react';
-import PaintBrushIcon from '@/awesome-icons/solid/paintbrush.svg?react';
-import PaperClipIcon from '@/awesome-icons/solid/paperclip.svg?react';
+import UploadFileIcon from '@/awesome-icons/solid/file-arrow-up.svg?react';
+import BrushIcon from '@/awesome-icons/solid/paintbrush.svg?react';
+import PhotoLibraryIcon from '@/awesome-icons/solid/paperclip.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 
 import { DropdownIconButton } from './dropdown_icon_button';
@@ -64,13 +64,13 @@ class UploadButton extends ImmutablePureComponent {
     const options = [
       {
         icon: 'file-arrow-up',
-        iconComponent: FileArrowUpIcon,
+        iconComponent: UploadFileIcon,
         value: 'upload',
         text: intl.formatMessage(messages.upload),
       },
       {
         icon: 'paint-brush',
-        iconComponent: PaintBrushIcon,
+        iconComponent: BrushIcon,
         value: 'doodle',
         text: intl.formatMessage(messages.doodle),
       },
@@ -80,7 +80,7 @@ class UploadButton extends ImmutablePureComponent {
       <div className='compose-form__upload-button'>
         <DropdownIconButton
           icon='paperclip'
-          iconComponent={PaperClipIcon}
+          iconComponent={PhotoLibraryIcon}
           title={message}
           disabled={disabled}
           onChange={this.handleSelect}

--- a/app/javascript/flavours/polyam/features/direct_timeline/components/conversation.jsx
+++ b/app/javascript/flavours/polyam/features/direct_timeline/components/conversation.jsx
@@ -78,7 +78,7 @@ export const Conversation = ({ conversation, scrollKey }) => {
       let state = getState();
 
       if (state.getIn(['compose', 'text']).trim().length !== 0) {
-        dispatch(openModal({ modalType: 'CONFIRM_REPLY', modalProps: { status: lastStatus }}));
+        dispatch(openModal({ modalType: 'CONFIRM_REPLY', modalProps: { status: lastStatus } }));
       } else {
         dispatch(replyCompose(lastStatus));
       }

--- a/app/javascript/flavours/polyam/features/direct_timeline/index.jsx
+++ b/app/javascript/flavours/polyam/features/direct_timeline/index.jsx
@@ -7,7 +7,7 @@ import { Helmet } from '@unhead/react/helmet';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import EnvelopeIcon from '@/awesome-icons/solid/envelope.svg?react';
+import MailIcon from '@/awesome-icons/solid/envelope.svg?react';
 import { addColumn, removeColumn, moveColumn } from 'flavours/polyam/actions/columns';
 import { mountConversations, unmountConversations, expandConversations } from 'flavours/polyam/actions/conversations';
 import { connectDirectStream } from 'flavours/polyam/actions/streaming';
@@ -74,7 +74,7 @@ const DirectTimeline = ({ columnId, multiColumn }) => {
     <Column bindToDocument={!multiColumn} ref={columnRef} label={intl.formatMessage(messages.title)}>
       <ColumnHeader
         icon='envelope'
-        iconComponent={EnvelopeIcon}
+        iconComponent={MailIcon}
         active={hasUnread}
         title={intl.formatMessage(messages.title)}
         onPin={handlePin}

--- a/app/javascript/flavours/polyam/features/favourited_statuses/index.tsx
+++ b/app/javascript/flavours/polyam/features/favourited_statuses/index.tsx
@@ -94,6 +94,7 @@ const Favourites: React.FC<{ columnId: string; multiColumn: boolean }> = ({
         onClick={handleHeaderClick}
         pinned={pinned}
         multiColumn={multiColumn}
+        showBackButton
       />
 
       <StatusList

--- a/app/javascript/flavours/polyam/features/follow_requests/index.jsx
+++ b/app/javascript/flavours/polyam/features/follow_requests/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import FollowIcon from '@/awesome-icons/solid/user-plus.svg?react';
+import PersonAddIcon from '@/awesome-icons/solid/user-plus.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 
 import { fetchFollowRequests, expandFollowRequests } from '../../actions/accounts';
@@ -69,7 +69,7 @@ class FollowRequests extends ImmutablePureComponent {
     );
 
     return (
-      <Column bindToDocument={!multiColumn} name='follow-requests' icon='user-plus' iconComponent={FollowIcon} heading={intl.formatMessage(messages.heading)} alwaysShowBackButton>
+      <Column bindToDocument={!multiColumn} icon='user-plus' iconComponent={PersonAddIcon} heading={intl.formatMessage(messages.heading)} alwaysShowBackButton>
         <ScrollableList
           scrollKey='follow_requests'
           onLoadMore={this.handleLoadMore}

--- a/app/javascript/flavours/polyam/features/hashtag_timeline/index.jsx
+++ b/app/javascript/flavours/polyam/features/hashtag_timeline/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 
 import { isEqual } from 'lodash';
 
-import HashtagIcon from '@/awesome-icons/solid/hashtag.svg?react';
+import TagIcon from '@/awesome-icons/solid/hashtag.svg?react';
 import { addColumn, removeColumn, moveColumn } from 'flavours/polyam/actions/columns';
 import { connectHashtagStream } from 'flavours/polyam/actions/streaming';
 import { expandHashtagTimeline, clearTimeline } from 'flavours/polyam/actions/timelines';
@@ -176,7 +176,7 @@ class HashtagTimeline extends PureComponent {
       <Column bindToDocument={!multiColumn} ref={this.setRef} label={`#${id}`}>
         <ColumnHeader
           icon='hashtag'
-          iconComponent={HashtagIcon}
+          iconComponent={TagIcon}
           active={hasUnread}
           title={this.title()}
           onPin={this.handlePin}

--- a/app/javascript/flavours/polyam/features/home_timeline/index.jsx
+++ b/app/javascript/flavours/polyam/features/home_timeline/index.jsx
@@ -8,7 +8,7 @@ import { Helmet } from '@unhead/react/helmet';
 
 import { connect } from 'react-redux';
 
-import AnnouncementIcon from '@/awesome-icons/solid/bullhorn.svg?react';
+import CampaignIcon from '@/awesome-icons/solid/bullhorn.svg?react';
 import HomeIcon from '@/awesome-icons/solid/house.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { SymbolLogo } from 'flavours/polyam/components/logo';
@@ -146,13 +146,13 @@ class HomeTimeline extends PureComponent {
           aria-label={intl.formatMessage(showAnnouncements ? messages.hide_announcements : messages.show_announcements)}
           onClick={this.handleToggleAnnouncementsClick}
         >
-          <IconWithBadge id='bullhorn' icon={AnnouncementIcon} count={unreadAnnouncements} />
+          <IconWithBadge id='bullhorn' icon={CampaignIcon} count={unreadAnnouncements} />
         </button>
       );
     }
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} name='home' label={intl.formatMessage(messages.title)}>
+      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
         <ColumnHeader
           icon='home'
           iconComponent={matchesBreakpoint ? SymbolLogo : HomeIcon}

--- a/app/javascript/flavours/polyam/features/keyboard_shortcuts/index.jsx
+++ b/app/javascript/flavours/polyam/features/keyboard_shortcuts/index.jsx
@@ -7,7 +7,7 @@ import { Helmet } from '@unhead/react/helmet';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-import QuestionIcon from '@/awesome-icons/solid/question.svg?react';
+import InfoIcon from '@/awesome-icons/solid/question.svg?react';
 import Column from 'flavours/polyam/components/column';
 import ColumnHeader from 'flavours/polyam/components/column_header';
 import { injectIntl } from '@/flavours/polyam/components/intl';
@@ -36,7 +36,7 @@ class KeyboardShortcuts extends ImmutablePureComponent {
         <ColumnHeader
           title={intl.formatMessage(messages.heading)}
           icon='question'
-          iconComponent={QuestionIcon}
+          iconComponent={InfoIcon}
           multiColumn={multiColumn}
         />
 

--- a/app/javascript/flavours/polyam/features/list_timeline/index.jsx
+++ b/app/javascript/flavours/polyam/features/list_timeline/index.jsx
@@ -9,9 +9,9 @@ import { Link, withRouter } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-import ListIcon from '@/awesome-icons/solid/list-ul.svg?react';
+import ListAltIcon from '@/awesome-icons/solid/list-ul.svg?react';
 import EditIcon from '@/awesome-icons/solid/pencil.svg?react';
-import TrashIcon from '@/awesome-icons/solid/trash.svg?react';
+import DeleteIcon from '@/awesome-icons/solid/trash.svg?react';
 import { addColumn, removeColumn, moveColumn } from 'flavours/polyam/actions/columns';
 import { fetchList } from 'flavours/polyam/actions/lists';
 import { openModal } from 'flavours/polyam/actions/modal';
@@ -136,7 +136,7 @@ class ListTimeline extends PureComponent {
       <Column bindToDocument={!multiColumn} ref={this.setRef} label={title}>
         <ColumnHeader
           icon='list-ul'
-          iconComponent={ListIcon}
+          iconComponent={ListAltIcon}
           active={hasUnread}
           title={title}
           onPin={this.handlePin}
@@ -152,7 +152,7 @@ class ListTimeline extends PureComponent {
               </Link>
 
               <button type='button' className='text-btn column-header__setting-btn' tabIndex={0} onClick={this.handleDeleteClick}>
-                <Icon id='trash' icon={TrashIcon} /> <FormattedMessage id='lists.delete' defaultMessage='Delete list' />
+                <Icon id='trash' icon={DeleteIcon} /> <FormattedMessage id='lists.delete' defaultMessage='Delete list' />
               </button>
             </section>
           </div>

--- a/app/javascript/flavours/polyam/features/local_settings/navigation/index.jsx
+++ b/app/javascript/flavours/polyam/features/local_settings/navigation/index.jsx
@@ -6,7 +6,7 @@ import { defineMessages } from 'react-intl';
 import ImageIcon from '@/awesome-icons/regular/image.svg?react';
 import CollapseIcon from '@/awesome-icons/solid/angles-up.svg?react';
 import SettingsIcon from '@/awesome-icons/solid/gear.svg?react';
-import AppSettingsIcon from '@/awesome-icons/solid/gears.svg?react';
+import ManufacturingIcon from '@/awesome-icons/solid/gears.svg?react';
 import EditIcon from '@/awesome-icons/solid/pencil.svg?react';
 import WarningIcon from '@/awesome-icons/solid/triangle-exclamation.svg?react';
 import CloseIcon from '@/awesome-icons/solid/xmark.svg?react';
@@ -45,7 +45,7 @@ class LocalSettingsNavigation extends PureComponent {
           index={0}
           onNavigate={onNavigate}
           icon='cogs'
-          iconComponent={AppSettingsIcon}
+          iconComponent={ManufacturingIcon}
           title={intl.formatMessage(messages.general)}
         />
         <LocalSettingsNavigationItem

--- a/app/javascript/flavours/polyam/features/local_settings/navigation/item/index.jsx
+++ b/app/javascript/flavours/polyam/features/local_settings/navigation/item/index.jsx
@@ -6,8 +6,6 @@ import classNames from 'classnames';
 
 import { Icon } from 'flavours/polyam/components/icon';
 
-//  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
 export default class LocalSettingsPage extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/flavours/polyam/features/mutes/index.jsx
+++ b/app/javascript/flavours/polyam/features/mutes/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import MuteIcon from '@/awesome-icons/solid/volume-xmark.svg?react';
+import VolumeOffIcon from '@/awesome-icons/solid/volume-xmark.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { Account } from 'flavours/polyam/components/account';
 
@@ -63,7 +63,7 @@ class Mutes extends ImmutablePureComponent {
     const emptyMessage = <FormattedMessage id='empty_column.mutes' defaultMessage="You haven't muted any users yet." />;
 
     return (
-      <Column bindToDocument={!multiColumn} name='mutes' icon='volume-off' iconComponent={MuteIcon} heading={intl.formatMessage(messages.heading)} alwaysShowBackButton>
+      <Column bindToDocument={!multiColumn} icon='volume-off' iconComponent={VolumeOffIcon} heading={intl.formatMessage(messages.heading)} alwaysShowBackButton>
         <ScrollableList
           scrollKey='mutes'
           onLoadMore={this.handleLoadMore}

--- a/app/javascript/flavours/polyam/features/notifications/components/clear_column_button.jsx
+++ b/app/javascript/flavours/polyam/features/notifications/components/clear_column_button.jsx
@@ -3,7 +3,7 @@ import { PureComponent } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import EraserIcon from '@/awesome-icons/solid/eraser.svg?react';
+import DeleteForeverIcon from '@/awesome-icons/solid/eraser.svg?react';
 import { Icon }  from 'flavours/polyam/components/icon';
 
 export default class ClearColumnButton extends PureComponent {
@@ -14,7 +14,7 @@ export default class ClearColumnButton extends PureComponent {
 
   render () {
     return (
-      <button className='text-btn column-header__setting-btn' tabIndex={0} onClick={this.props.onClick}><Icon id='eraser' icon={EraserIcon} /> <FormattedMessage id='notifications.clear' defaultMessage='Clear notifications' /></button>
+      <button className='text-btn column-header__setting-btn' tabIndex={0} onClick={this.props.onClick}><Icon id='eraser' icon={DeleteForeverIcon} /> <FormattedMessage id='notifications.clear' defaultMessage='Clear notifications' /></button>
     );
   }
 

--- a/app/javascript/flavours/polyam/features/notifications/components/notification.jsx
+++ b/app/javascript/flavours/polyam/features/notifications/components/notification.jsx
@@ -9,8 +9,8 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import FlagIcon from '@/awesome-icons/solid/flag.svg?react';
-import FollowIcon from '@/awesome-icons/solid/user-plus.svg?react';
-import UserIcon from '@/awesome-icons/solid/user.svg?react';
+import PersonAddIcon from '@/awesome-icons/solid/user-plus.svg?react';
+import PersonIcon from '@/awesome-icons/solid/user.svg?react';
 import { Account } from 'flavours/polyam/components/account';
 import { LinkedDisplayName } from '@/flavours/polyam/components/display_name';
 import { Icon }  from 'flavours/polyam/components/icon';
@@ -112,7 +112,7 @@ class Notification extends ImmutablePureComponent {
       <Hotkeys handlers={this.getHandlers()}>
         <div className={classNames('notification notification-follow focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.follow, { name: account.get('acct') }), notification.get('created_at'))}>
           <div className='notification__message'>
-            <Icon id='user-plus' icon={FollowIcon} />
+            <Icon id='user-plus' icon={PersonAddIcon} />
 
             <span title={notification.get('created_at')}>
               <FormattedMessage id='notification.follow' defaultMessage='{name} followed you' values={{ name: link }} />
@@ -132,7 +132,7 @@ class Notification extends ImmutablePureComponent {
       <Hotkeys handlers={this.getHandlers()}>
         <div className={classNames('notification notification-follow-request focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage({ id: 'notification.follow_request', defaultMessage: '{name} has requested to follow you' }, { name: account.get('acct') }), notification.get('created_at'))}>
           <div className='notification__message'>
-            <Icon id='user' icon={UserIcon} />
+            <Icon id='user' icon={PersonIcon} />
 
             <span title={notification.get('created_at')}>
               <FormattedMessage id='notification.follow_request' defaultMessage='{name} has requested to follow you' values={{ name: link }} />
@@ -415,7 +415,7 @@ class Notification extends ImmutablePureComponent {
       <Hotkeys handlers={this.getHandlers()}>
         <div className={classNames('notification notification-admin-sign-up focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.adminSignUp, { name: account.get('acct') }), notification.get('created_at'))}>
           <div className='notification__message'>
-            <Icon id='user-plus' icon={FollowIcon} />
+            <Icon id='user-plus' icon={PersonAddIcon} />
 
             <span title={notification.get('created_at')}>
               <FormattedMessage id='notification.admin.sign_up' defaultMessage='{name} signed up' values={{ name: link }} />

--- a/app/javascript/flavours/polyam/features/notifications/request.jsx
+++ b/app/javascript/flavours/polyam/features/notifications/request.jsx
@@ -7,8 +7,8 @@ import { Helmet } from '@unhead/react/helmet';
 
 import { useSelector, useDispatch } from 'react-redux';
 
-import ArchiveIcon from '@/awesome-icons/solid/box-archive.svg?react';
-import CheckIcon from '@/awesome-icons/solid/check.svg?react';
+import InventoryIcon from '@/awesome-icons/solid/box-archive.svg?react';
+import DoneIcon from '@/awesome-icons/solid/check.svg?react';
 import DeleteIcon from '@/awesome-icons/solid/trash.svg?react';
 import {
   fetchNotificationRequest,
@@ -92,7 +92,7 @@ export const NotificationRequest = ({ multiColumn, params: { id } }) => {
     <Column bindToDocument={!multiColumn} ref={columnRef} label={columnTitle}>
       <ColumnHeader
         icon='archive'
-        iconComponent={ArchiveIcon}
+        iconComponent={InventoryIcon}
         title={columnTitle}
         onClick={handleHeaderClick}
         multiColumn={multiColumn}
@@ -100,7 +100,7 @@ export const NotificationRequest = ({ multiColumn, params: { id } }) => {
         extraButton={!removed && (
           <>
             <IconButton className='column-header__button' iconComponent={DeleteIcon} onClick={handleDismiss} title={intl.formatMessage(messages.dismiss)} />
-            <IconButton className='column-header__button' iconComponent={CheckIcon} onClick={handleAccept} title={intl.formatMessage(messages.accept)} />
+            <IconButton className='column-header__button' iconComponent={DoneIcon} onClick={handleAccept} title={intl.formatMessage(messages.accept)} />
           </>
         )}
       />

--- a/app/javascript/flavours/polyam/features/pinned_statuses/index.jsx
+++ b/app/javascript/flavours/polyam/features/pinned_statuses/index.jsx
@@ -8,7 +8,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-import PinIcon from '@/awesome-icons/solid/thumbtack.svg?react';
+import PushPinIcon from '@/awesome-icons/solid/thumbtack.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { getStatusList } from 'flavours/polyam/selectors';
 
@@ -51,7 +51,7 @@ class PinnedStatuses extends ImmutablePureComponent {
     const { intl, statusIds, hasMore, multiColumn } = this.props;
 
     return (
-      <Column bindToDocument={!multiColumn} icon='thumb-tack' iconComponent={PinIcon} heading={intl.formatMessage(messages.heading)} ref={this.setRef} alwaysShowBackButton>
+      <Column bindToDocument={!multiColumn} icon='thumb-tack' iconComponent={PushPinIcon} heading={intl.formatMessage(messages.heading)} ref={this.setRef} alwaysShowBackButton>
         <StatusList
           statusIds={statusIds}
           scrollKey='pinned_statuses'

--- a/app/javascript/flavours/polyam/features/public_timeline/index.jsx
+++ b/app/javascript/flavours/polyam/features/public_timeline/index.jsx
@@ -146,7 +146,7 @@ class PublicTimeline extends PureComponent {
     );
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} name='federated' label={intl.formatMessage(messages.title)}>
+      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
         <ColumnHeader
           icon='globe'
           iconComponent={PublicIcon}

--- a/app/javascript/flavours/polyam/features/reblogs/index.jsx
+++ b/app/javascript/flavours/polyam/features/reblogs/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import { debounce } from 'lodash';
 
 import RefreshIcon from '@/awesome-icons/solid/arrows-rotate.svg?react';
-import BoostIcon from '@/svg-icons/boost.svg?react';
+import RepeatIcon from '@/svg-icons/boost.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { Account } from 'flavours/polyam/components/account';
 import { Icon }  from 'flavours/polyam/components/icon';
@@ -84,7 +84,7 @@ class Reblogs extends ImmutablePureComponent {
       <Column ref={this.setRef}>
         <ColumnHeader
           icon='retweet'
-          iconComponent={BoostIcon}
+          iconComponent={RepeatIcon}
           title={intl.formatMessage(messages.heading)}
           onClick={this.handleHeaderClick}
           showBackButton

--- a/app/javascript/flavours/polyam/features/status/index.jsx
+++ b/app/javascript/flavours/polyam/features/status/index.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 
 import VisibilityOffIcon from '@/awesome-icons/regular/eye-slash.svg?react';
 import VisibilityIcon from '@/awesome-icons/regular/eye.svg?react';
-import CommentIcon from '@/awesome-icons/solid/comment.svg?react';
+import ChatIcon from '@/awesome-icons/solid/comment.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { Hotkeys } from 'flavours/polyam/components/hotkeys';
 import { Icon }  from 'flavours/polyam/components/icon';
@@ -637,7 +637,7 @@ class Status extends ImmutablePureComponent {
       <Column bindToDocument={!multiColumn} ref={this.setColumnRef} label={intl.formatMessage(messages.detailedStatus)}>
         <ColumnHeader
           icon='comment'
-          iconComponent={CommentIcon}
+          iconComponent={ChatIcon}
           title={intl.formatMessage(messages.tootHeading)}
           onClick={this.handleHeaderClick}
           showBackButton

--- a/app/javascript/flavours/polyam/features/ui/components/block_modal.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/block_modal.jsx
@@ -8,9 +8,9 @@ import classNames from 'classnames';
 import { useDispatch } from 'react-redux';
 
 import VisibilityOffIcon from '@/awesome-icons/regular/eye-slash.svg?react';
-import AtIcon from '@/awesome-icons/solid/at.svg?react';
-import BanIcon from '@/awesome-icons/solid/ban.svg?react';
-import AnnouncementIcon from '@/awesome-icons/solid/bullhorn.svg?react';
+import AlternateEmailIcon from '@/awesome-icons/solid/at.svg?react';
+import BlockIcon from '@/awesome-icons/solid/ban.svg?react';
+import CampaignIcon from '@/awesome-icons/solid/bullhorn.svg?react';
 import CollectionsIcon from '@/awesome-icons/solid/shapes.svg?react';
 import ReplyIcon from '@/awesome-icons/solid/reply.svg?react';
 import { blockAccount } from 'flavours/polyam/actions/accounts';
@@ -43,7 +43,7 @@ export const BlockModal = ({ accountId, acct }) => {
       <div className='safety-action-modal__top'>
         <div className='safety-action-modal__header'>
           <div className='safety-action-modal__header__icon'>
-            <Icon icon={BanIcon} />
+            <Icon icon={BlockIcon} />
           </div>
 
           <div>
@@ -56,7 +56,7 @@ export const BlockModal = ({ accountId, acct }) => {
 
         <ul className='safety-action-modal__bullet-points'>
           <li>
-            <div className='safety-action-modal__bullet-points__icon'><Icon icon={AnnouncementIcon} /></div>
+            <div className='safety-action-modal__bullet-points__icon'><Icon icon={CampaignIcon} /></div>
             <div><FormattedMessage id='block_modal.they_will_know' defaultMessage="They can see that they're blocked." /></div>
           </li>
 
@@ -66,7 +66,7 @@ export const BlockModal = ({ accountId, acct }) => {
           </li>
 
           <li>
-            <div className='safety-action-modal__bullet-points__icon'><Icon icon={AtIcon} /></div>
+            <div className='safety-action-modal__bullet-points__icon'><Icon icon={AlternateEmailIcon} /></div>
             <div><FormattedMessage id='block_modal.you_wont_see_mentions' defaultMessage="You won't see posts from others that mention them." /></div>
           </li>
 

--- a/app/javascript/flavours/polyam/features/ui/components/compare_history_modal.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/compare_history_modal.jsx
@@ -67,7 +67,7 @@ class CompareHistoryModal extends PureComponent {
             {label}
           </div>
 
-        <div className='compare-history-modal__container'>
+          <div className='compare-history-modal__container'>
             <div className='status__content'>
               {currentVersion.get('spoiler_text').length > 0 && (
                 <>

--- a/app/javascript/flavours/polyam/features/ui/components/deprecated_settings_modal.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/deprecated_settings_modal.jsx
@@ -6,7 +6,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import SettingsIcon from '@/awesome-icons/solid/gear.svg?react';
-import AppSettingsIcon from '@/awesome-icons/solid/gears.svg?react';
+import ManufacturingIcon from '@/awesome-icons/solid/gears.svg?react';
 import { injectIntl } from '@/flavours/polyam/components/intl';
 import { Button } from 'flavours/polyam/components/button';
 import { Icon } from 'flavours/polyam/components/icon';
@@ -48,7 +48,7 @@ class DeprecatedSettingsModal extends PureComponent {
             values={{
               app_settings: (
                 <strong className='deprecated-settings-label'>
-                  <Icon id='cogs' icon={AppSettingsIcon} /> <FormattedMessage id='navigation_bar.app_settings' defaultMessage='App settings' />
+                  <Icon id='cogs' icon={ManufacturingIcon} /> <FormattedMessage id='navigation_bar.app_settings' defaultMessage='App settings' />
                 </strong>
               ),
               preferences: (

--- a/app/javascript/flavours/polyam/features/ui/components/doodle_modal.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/doodle_modal.jsx
@@ -9,10 +9,10 @@ import { connect } from 'react-redux';
 import Atrament from 'atrament'; // the doodling library
 import { debounce, mapValues } from 'lodash';
 
-import BathIcon from '@/awesome-icons/solid/bath.svg?react';
+import ColorsIcon from '@/awesome-icons/solid/bath.svg?react';
 import EditIcon from '@/awesome-icons/solid/pencil.svg?react';
 import UndoIcon from '@/awesome-icons/solid/rotate-left.svg?react';
-import TrashIcon from '@/awesome-icons/solid/trash.svg?react';
+import DeleteIcon from '@/awesome-icons/solid/trash.svg?react';
 import { doodleSet, uploadCompose } from 'flavours/polyam/actions/compose';
 import { Button } from 'flavours/polyam/components/button';
 import { IconButton } from 'flavours/polyam/components/icon_button';
@@ -589,9 +589,9 @@ class DoodleModal extends ImmutablePureComponent {
           </div>
           <div className='doodle-toolbar'>
             <IconButton icon='pencil' iconComponent={EditIcon} title='Draw' label='Draw' onClick={this.setModeDraw} size={18} active={this.mode === 'draw'} inverted />
-            <IconButton icon='bath' iconComponent={BathIcon} title='Fill' label='Fill' onClick={this.setModeFill} size={18} active={this.mode === 'fill'} inverted />
+            <IconButton icon='bath' iconComponent={ColorsIcon} title='Fill' label='Fill' onClick={this.setModeFill} size={18} active={this.mode === 'fill'} inverted />
             <IconButton icon='undo' iconComponent={UndoIcon} title='Undo' label='Undo' onClick={this.undo} size={18} inverted />
-            <IconButton icon='trash' iconComponent={TrashIcon} title='Clear' label='Clear' onClick={this.handleClearBtn} size={18} inverted />
+            <IconButton icon='trash' iconComponent={DeleteIcon} title='Clear' label='Clear' onClick={this.handleClearBtn} size={18} inverted />
           </div>
           <div className='doodle-palette'>
             {

--- a/app/javascript/flavours/polyam/features/ui/components/media_modal.tsx
+++ b/app/javascript/flavours/polyam/features/ui/components/media_modal.tsx
@@ -45,6 +45,7 @@ interface MediaModalProps {
   autoPlay?: boolean;
   volume?: number;
 }
+
 const MIN_SWIPE_DISTANCE = 400;
 const isLtrDir = getComputedStyle(document.body).direction !== 'rtl';
 

--- a/app/javascript/flavours/polyam/features/ui/components/mute_modal.jsx
+++ b/app/javascript/flavours/polyam/features/ui/components/mute_modal.jsx
@@ -8,10 +8,10 @@ import classNames from 'classnames';
 import { useDispatch } from 'react-redux';
 
 import VisibilityOffIcon from '@/awesome-icons/regular/eye-slash.svg?react';
-import AtIcon from '@/awesome-icons/solid/at.svg?react';
-import AnnouncementIcon from '@/awesome-icons/solid/bullhorn.svg?react';
+import AlternateEmailIcon from '@/awesome-icons/solid/at.svg?react';
+import CampaignIcon from '@/awesome-icons/solid/bullhorn.svg?react';
 import ReplyIcon from '@/awesome-icons/solid/reply.svg?react';
-import MuteIcon from '@/awesome-icons/solid/volume-xmark.svg?react';
+import VolumeOffIcon from '@/awesome-icons/solid/volume-xmark.svg?react';
 import { muteAccount } from 'flavours/polyam/actions/accounts';
 import { closeModal } from 'flavours/polyam/actions/modal';
 import { Button } from 'flavours/polyam/components/button';
@@ -80,7 +80,7 @@ export const MuteModal = ({ accountId, acct }) => {
       <div className='safety-action-modal__top'>
         <div className='safety-action-modal__header'>
           <div className='safety-action-modal__header__icon'>
-            <Icon icon={MuteIcon} />
+            <Icon icon={VolumeOffIcon} />
           </div>
 
           <div>
@@ -93,7 +93,7 @@ export const MuteModal = ({ accountId, acct }) => {
 
         <ul className='safety-action-modal__bullet-points'>
           <li>
-            <div className='safety-action-modal__bullet-points__icon'><Icon icon={AnnouncementIcon} /></div>
+            <div className='safety-action-modal__bullet-points__icon'><Icon icon={CampaignIcon} /></div>
             <div><FormattedMessage id='mute_modal.they_wont_know' defaultMessage="They won't know they've been muted." /></div>
           </li>
 
@@ -103,7 +103,7 @@ export const MuteModal = ({ accountId, acct }) => {
           </li>
 
           <li>
-            <div className='safety-action-modal__bullet-points__icon'><Icon icon={AtIcon} /></div>
+            <div className='safety-action-modal__bullet-points__icon'><Icon icon={AlternateEmailIcon} /></div>
             <div><FormattedMessage id='mute_modal.you_wont_see_mentions' defaultMessage="You won't see posts that mention them." /></div>
           </li>
 

--- a/app/javascript/flavours/polyam/features/ui/containers/status_list_container.js
+++ b/app/javascript/flavours/polyam/features/ui/containers/status_list_container.js
@@ -106,7 +106,7 @@ const makeMapStateToProps = () => {
   const getPendingStatusIds = makeGetStatusIds(true);
 
   /**
-   * @param {import('mastodon/store').RootState} state
+   * @param {import('flavours/polyam/store').RootState} state
    * @param {Object} props
    * @param {string} props.timelineId
    * @param {boolean} [props.initialLoadingState]

--- a/app/javascript/flavours/polyam/features/ui/util/async-components.js
+++ b/app/javascript/flavours/polyam/features/ui/util/async-components.js
@@ -180,7 +180,7 @@ export function IgnoreNotificationsModal () {
 }
 
 export function MediaGallery () {
-  return import('flavours/polyam/components/media_gallery');
+  return import('../../../components/media_gallery');
 }
 
 export function Video () {


### PR DESCRIPTION
Most differences are random extra new lines or whitespace which were ignored.

Replaces icon names to match upstream since earlier ports tried to copy upstream's naming convention but it's not worth it.

Removed some extra attributes left for column headers.