### PR TITLE
Add media icon for quotes

### DIFF
--- a/app/javascript/flavours/polyam/components/media_icon.tsx
+++ b/app/javascript/flavours/polyam/components/media_icon.tsx
@@ -4,6 +4,7 @@ import ImageIcon from '@/awesome-icons/regular/image.svg?react';
 import InsertChartIcon from '@/awesome-icons/solid/bars-progress.svg?react';
 import LinkIcon from '@/awesome-icons/solid/link.svg?react';
 import MusicNoteIcon from '@/awesome-icons/solid/music.svg?react';
+import FormatQuoteIcon from '@/awesome-icons/solid/quote-right.svg?react';
 import MovieIcon from '@/awesome-icons/solid/video.svg?react';
 import { Icon } from 'flavours/polyam/components/icon';
 
@@ -25,6 +26,10 @@ const messages = defineMessages({
     id: 'status.has_audio',
     defaultMessage: 'Features attached audio files',
   },
+  quote: {
+    id: 'status.has_quote',
+    defaultMessage: 'Features an attached quote',
+  },
 });
 
 const iconComponents = {
@@ -33,6 +38,7 @@ const iconComponents = {
   tasks: InsertChartIcon,
   'video-camera': MovieIcon,
   music: MusicNoteIcon,
+  quote: FormatQuoteIcon,
 };
 
 export type IconName = keyof typeof iconComponents;

--- a/app/javascript/flavours/polyam/components/status.jsx
+++ b/app/javascript/flavours/polyam/components/status.jsx
@@ -801,6 +801,10 @@ class Status extends ImmutablePureComponent {
       mediaIcons.push('tasks');
     }
 
+    if (status.get('quote')) {
+      mediaIcons.push('quote');
+    }
+
     //  Here we prepare extra data-* attributes for CSS selectors.
     //  Users can use those for theming, hiding avatars etc via UserStyle
     const selectorAttribs = {

--- a/app/javascript/flavours/polyam/features/status/components/detailed_status.tsx
+++ b/app/javascript/flavours/polyam/features/status/components/detailed_status.tsx
@@ -346,6 +346,10 @@ export const DetailedStatus: React.FC<{
     mediaIcons.push('tasks');
   }
 
+  if (status.get('quote')) {
+    mediaIcons.push('quote');
+  }
+
   if (status.get('application')) {
     applicationLink = (
       <>

--- a/app/javascript/flavours/polyam/locales/en.json
+++ b/app/javascript/flavours/polyam/locales/en.json
@@ -40,6 +40,7 @@
   "settings.picker_opts": "Emoji picker categories",
   "settings.show_action_bar": "Show action buttons in collapsed toots",
   "status.collapse": "Collapse",
+  "status.has_quote": "Features an attached quote",
   "status.is_thread": "This toot is part of a thread",
   "status.react": "React",
   "status.reactions.empty": "No one has reacted to this toot yet. When someone does, they will show up here.",


### PR DESCRIPTION
Fixes #1245

I'm not sure it's particularly useful to add this while the Status component is being refactored but this can be backported as is.